### PR TITLE
TS-39579: Prevent system prompts from being leaked in debug logs

### DIFF
--- a/src/contrast_api.py
+++ b/src/contrast_api.py
@@ -90,8 +90,15 @@ def get_vulnerability_with_prompts(contrast_host, contrast_org_id, contrast_app_
             return None
         elif response.status_code == 200:
             response_json = response.json()
-            debug_print(f"Full response_json: {json.dumps(response_json, indent=2)}")
             
+            # Create a redacted copy of the response for debug logging
+            redacted_response = response_json.copy()
+            # Redact sensitive prompt data
+            for key in ['fixSystemPrompt', 'fixUserPrompt', 'qaSystemPrompt', 'qaUserPrompt']:
+                if key in redacted_response:
+                    redacted_response[key] = f"[REDACTED - {len(redacted_response[key])} chars]"
+            
+            debug_print(f"Response with redacted prompts: {json.dumps(redacted_response, indent=2)}")
             debug_print("Successfully received vulnerability and prompts from API")
             debug_print(f"Response keys: {list(response_json.keys())}")
             


### PR DESCRIPTION
## Summary
- Modified contrast_api.py to redact sensitive prompt information in debug logs
- Creates a redacted copy of the API response that shows prompt lengths but not content
- Ensures system prompts aren't leaked when debug mode is enabled

## Security Impact
This change prevents sensitive system prompts from being logged, which could potentially contain:
- Security information about vulnerability detection
- Information about code structure that shouldn't be exposed
- Algorithmic details about the remediation process

## Test Plan
- Manually verified debug logging with DEBUG_MODE=true
- Confirmed API responses are properly redacted in logs
- Verified application functionality is unaffected