### PR TITLE
TS-39583: Add API call to mark remediation as failed

### DIFF
--- a/src/contrast_api.py
+++ b/src/contrast_api.py
@@ -303,3 +303,66 @@ def notify_remediation_pr_closed(remediation_id: str, contrast_host: str, contra
     except json.JSONDecodeError:
         print(f"Error decoding JSON response when notifying Remediation service about closed PR for remediation {remediation_id}.", file=sys.stderr)
         return False
+        
+def notify_remediation_failed(remediation_id: str, failure_category: str, contrast_host: str, contrast_org_id: str, contrast_app_id: str, contrast_auth_key: str, contrast_api_key: str) -> bool:
+    """Notifies the Remediation backend service that a remediation has failed.
+
+    Args:
+        remediation_id: The ID of the remediation.
+        failure_category: The category of failure (e.g., "INITIAL_BUILD_FAILURE").
+        contrast_host: The Contrast Security host URL.
+        contrast_org_id: The organization ID.
+        contrast_app_id: The application ID.
+        contrast_auth_key: The Contrast authorization key.
+        contrast_api_key: The Contrast API key.
+
+    Returns:
+        bool: True if the notification was successful, False otherwise.
+    """
+    debug_print(f"--- Notifying Remediation service about failed remediation {remediation_id} with category {failure_category} ---")
+    api_url = f"https://{normalize_host(contrast_host)}/api/v4/aiml-remediation/organizations/{contrast_org_id}/applications/{contrast_app_id}/remediations/{remediation_id}/failed"
+
+    headers = {
+        "Authorization": contrast_auth_key,
+        "API-Key": contrast_api_key,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": config.USER_AGENT
+    }
+    
+    payload = {
+        "failureCategory": failure_category
+    }
+
+    try:
+        debug_print(f"Making PUT request to: {api_url}")
+        debug_print(f"Payload: {json.dumps(payload)}") 
+        response = requests.put(api_url, headers=headers, json=payload)
+        response.raise_for_status()  # Raises an HTTPError for bad responses (4xx or 5xx)
+
+        debug_print(f"Remediation failed notification API response status code: {response.status_code}")
+        
+        if response.status_code == 204:
+            debug_print(f"Successfully notified Remediation service API about failed remediation {remediation_id}")
+            return True
+        else:
+            error_message = "Unknown error"
+            try:
+                response_json = response.json()
+                if "messages" in response_json and response_json["messages"]:
+                    error_message = response_json["messages"][0]
+            except:
+                error_message = response.text
+                
+            print(f"Failed to notify Remediation service about failed remediation {remediation_id}. Error: {error_message}", file=sys.stderr)
+            return False
+
+    except requests.exceptions.HTTPError as e:
+        print(f"HTTP error notifying Remediation service about failed remediation {remediation_id}: {e.response.status_code} - {e.response.text}", file=sys.stderr)
+        return False
+    except requests.exceptions.RequestException as e:
+        print(f"Request error notifying Remediation service about failed remediation {remediation_id}: {e}", file=sys.stderr)
+        return False
+    except json.JSONDecodeError:
+        print(f"Error decoding JSON response when notifying Remediation service about failed remediation {remediation_id}.", file=sys.stderr)
+        return False


### PR DESCRIPTION
## Summary
- Added new `notify_remediation_failed` function to `contrast_api.py` to call the backend service
- Updated initial build failure handling to notify backend with `INITIAL_BUILD_FAILURE` category
- Added QA agent failure handling to notify backend with `EXCEEDED_QA_ATTEMPTS` category when max retries exhausted

## Problem Solved
When the SmartFix Action encounters errors before creating a PR (especially during initial build), the remediation record is currently locked in FIX_REQUESTED status for a week. This PR adds the ability to mark remediation records as FAILED with a specific failure category, so these vulnerabilities can be retried sooner.

## Test plan
- Verify API call is made with correct payload when initial build fails
- Verify API call is made with correct payload when QA agent fails after max retries
- Verify error handling around API call failures

🤖 Generated with [Claude Code](https://claude.ai/code)