### PR TITLE
TS-39689 Update icon to a wrench

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Automatically generate fixes for vulnerabilities detected by Contr
 author: 'Contrast Security'
 
 branding:
-  icon: 'shield'
+  icon: 'tool'
   color: 'green'
 
 inputs:


### PR DESCRIPTION
**Ticket**
https://contrast.atlassian.net/browse/TS-39689

**Overview**
Update the icon that SmartFix uses in the Github Marketplace (https://github.com/marketplace?query=contrast) to be a wrench.  I dug into the branding guidelines some more and think the correct name of the wrench icon is "tool".  Per [Metadata syntax for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#brandingicon)  and [Feather – Simply beautiful open source icons](https://feathericons.com/?query=terminal) , the wrench icon is named “tool”.

**Testing**
Make sure build checks pass.

I'll verify the icon is completely valid after merging.