### PR TITLE
TS-39689 Revert to shield icon

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Automatically generate fixes for vulnerabilities detected by Contr
 author: 'Contrast Security'
 
 branding:
-  icon: 'tool'
+  icon: 'shield'
   color: 'green'
 
 inputs:


### PR DESCRIPTION
**Ticket**
https://contrast.atlassian.net/browse/TS-39689

**Overview**
The previous PR's change to a tool icon, was shown to not work when github automation checked the action.yml file.  Since no tool-like icon is currently supported, I am reverting to the shield icon.

**Evidence**
<img width="1334" alt="Screenshot 2025-06-23 at 1 35 49 PM" src="https://github.com/user-attachments/assets/714548a5-ce6b-4d94-9a4b-4c655ad7f849" />
