### PR TITLE
TS-39904 Fix GitHub infinite loop bug

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -240,7 +240,7 @@ def main():
     # Construct GitHub repository URL (used for each API call)
     github_repo_url = f"https://github.com/{config.GITHUB_REPOSITORY}"
     debug_log(f"GitHub repository URL: {github_repo_url}")
-
+    skipped_vulns = set()  # TS-39904
     remediation_id = "unknown"
 
     while True:
@@ -308,8 +308,12 @@ def main():
 
         # Changed this logic to check only for OPEN PRs for dev purposes
         if pr_status == "OPEN":
-            log(f"Skipping vulnerability {vuln_uuid} as an OPEN or MERGED PR with label '{label_name}' already exists.")
+            log(f"Skipping vulnerability {vuln_uuid} as an OPEN PR with label '{label_name}' already exists.")
             log("\n::endgroup::")
+            if vuln_uuid in skipped_vulns:
+                log(f"Already skipped {vuln_uuid} before, breaking loop to avoid infinite loop.")
+                break
+            skipped_vulns.add(vuln_uuid)
             continue
         else:
             log(f"No existing OPEN or MERGED PR found for vulnerability {vuln_uuid}. Proceeding with fix attempt.")


### PR DESCRIPTION
**Ticket**
https://contrast.atlassian.net/browse/TS-39084

**Overview**
There were a few minutes this afternoon when GitHub correctly reported that there were no open PRs, but SmartFix wouldn’t work on the received vuln because GitHub incorrectly (maybe because of a cache?) reported that there was still an open PR for that vulnId.  This led SmartFix to enter an infinite loop because the backend kept giving it the same vuln that it thought there was an open PR for.