### PR TITLE
TS-39917 Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ For the Early Access release, SmartFix uses a "Bring Your Own LLM" (BYOLLM) mode
 
 Refer to the `action.yml` file within the SmartFix GitHub Action repository and LiteLLM documentation for specific `agent_model` strings and required credentials for other models/providers.  The LiteLLM documentation can be found at https://docs.litellm.ai/docs/providers/.
 
-## Agent Model values
+### Agent Model values
 
 Here are several recommended `agent_model` values:
 


### PR DESCRIPTION
**Ticket**
https://contrast.atlassian.net/browse/TS-39917

**Overview**
The "Agent Model Values" heading is at the wrong heading level.  This PR fixes that.