### PR TITLE
Aiml 48 query api for vuln details and format for issue body

### DIFF
--- a/src/closed_handler.py
+++ b/src/closed_handler.py
@@ -78,7 +78,7 @@ def handle_closed_pr():
         # Extract GitHub issue number from branch name
         issue_number = extract_issue_number_from_branch(branch_name)
         if issue_number:
-            telemetry_handler.update_telemetry("additionalAttributes.githubIssueNumber", issue_number)
+            telemetry_handler.update_telemetry("additionalAttributes.externalIssueNumber", issue_number)
             debug_log(f"Extracted GitHub issue number from branch name: {issue_number}")
         else:
             debug_log(f"Could not extract issue number from branch name: {branch_name}")

--- a/src/external_coding_agent.py
+++ b/src/external_coding_agent.py
@@ -54,7 +54,7 @@ class ExternalCodingAgent:
         
         log(f"\n::group::--- Using External Coding Agent ({self.config.CODING_AGENT}) ---")
         telemetry_handler.update_telemetry("additionalAttributes.codingAgent", "EXTERNAL-COPILOT")
-        
+
         # Hard-coded vulnerability label for now, will be passed as argument later
         vulnerability_label = f"contrast-vuln-id:VULN-{vuln_uuid}"
         remediation_label = f"smartfix-id:{remediation_id}"
@@ -76,7 +76,7 @@ class ExternalCodingAgent:
                 log(f"Failed to create issue with labels {vulnerability_label}, {remediation_label}", is_error=True)
                 error_exit(remediation_id, FailureCategory.AGENT_FAILURE.value)
         
-        telemetry_handler.update_telemetry("additionalAttributes.githubIssueNumber", issue_number)
+        telemetry_handler.update_telemetry("additionalAttributes.externalIssueNumber", issue_number)
 
         # Poll for PR creation by the external agent
         log(f"Waiting for external agent to create a PR for issue #{issue_number}")

--- a/src/external_coding_agent.py
+++ b/src/external_coding_agent.py
@@ -53,6 +53,7 @@ class ExternalCodingAgent:
             return False
         
         log(f"\n::group::--- Using External Coding Agent ({self.config.CODING_AGENT}) ---")
+        telemetry_handler.update_telemetry("additionalAttributes.codingAgent", "EXTERNAL-COPILOT")
         
         # Hard-coded vulnerability label for now, will be passed as argument later
         vulnerability_label = f"contrast-vuln-id:VULN-{vuln_uuid}"
@@ -79,7 +80,6 @@ class ExternalCodingAgent:
 
         # Poll for PR creation by the external agent
         log(f"Waiting for external agent to create a PR for issue #{issue_number}")
-        telemetry_handler.update_telemetry("additionalAttributes.codingAgent", "EXTERNAL")
         
         # Poll for a PR to be created by the external agent (100 attempts, 5 seconds apart = ~8.3 minutes max)
         pr_info = self._poll_for_pr(issue_number, remediation_id, vulnerability_label, remediation_label, max_attempts=100, sleep_seconds=5)

--- a/src/git_handler.py
+++ b/src/git_handler.py
@@ -20,7 +20,7 @@
 import os
 import json
 import subprocess
-from typing import List
+from typing import List, Optional
 from src.utils import run_command, debug_log, log, error_exit
 from src.contrast_api import FailureCategory
 from src.config import get_config
@@ -650,6 +650,25 @@ def find_open_pr_for_issue(issue_number: int) -> dict:
         return None
     except Exception as e:
         log(f"Error searching for PRs related to issue #{issue_number}: {e}", is_error=True)
+        return None
+
+def extract_issue_number_from_branch(branch_name: str) -> Optional[int]:
+    """
+    Extracts the GitHub issue number from a branch name with format 'copilot/fix-<issue_number>'.
+    
+    Args:
+        branch_name: The branch name to extract the issue number from
+        
+    Returns:
+        Optional[int]: The issue number if found and valid, None otherwise
+    """
+    if not branch_name.startswith("copilot/fix-"):
+        return None
+        
+    try:
+        issue_number = int(branch_name.split("copilot/fix-")[1])
+        return issue_number
+    except (IndexError, ValueError):
         return None
 
 def add_labels_to_pr(pr_number: int, labels: List[str]) -> bool:

--- a/src/main.py
+++ b/src/main.py
@@ -351,6 +351,8 @@ def main():
                 contrast_api.send_telemetry_data()
             continue  # Skip the built-in SmartFix code and PR creation
 
+        telemetry_handler.update_telemetry("additionalAttributes.codingAgent", "INTERNAL-SMARTFIX")
+
         # --- Run AI Fix Agent (SmartFix) ---
         ai_fix_summary_full = agent_handler.run_ai_fix_agent(
             config.REPO_ROOT, fix_system_prompt, fix_user_prompt, remediation_id

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -24,7 +24,8 @@ import sys
 # Import from src package to ensure correct module resolution
 from src import contrast_api
 from src.config import get_config  # Using get_config function instead of direct import
-from src.utils import debug_log, extract_remediation_id_from_branch, log
+from src.utils import debug_log, extract_remediation_id_from_branch, extract_remediation_id_from_labels, log
+from src.git_handler import extract_issue_number_from_branch
 import src.telemetry_handler as telemetry_handler
 
 def handle_merged_pr():
@@ -65,18 +66,27 @@ def handle_merged_pr():
     
     debug_log(f"Branch name: {branch_name}")
 
+    labels = pull_request.get("labels", [])
+
     # Extract remediation ID from branch name or PR labels
     remediation_id = None
     
     # Check if this is a branch created by external agent (e.g., GitHub Copilot)
     if branch_name.startswith("copilot/fix"):
         debug_log("Branch appears to be created by external agent. Extracting remediation ID from PR labels.")
-        # Get labels from the PR
-        labels = pull_request.get("labels", [])
         remediation_id = extract_remediation_id_from_labels(labels)
+        # Extract GitHub issue number from branch name
+        issue_number = extract_issue_number_from_branch(branch_name)
+        if issue_number:
+            telemetry_handler.update_telemetry("additionalAttributes.githubIssueNumber", issue_number)
+            debug_log(f"Extracted GitHub issue number from branch name: {issue_number}")
+        else:
+            debug_log(f"Could not extract issue number from branch name: {branch_name}")
+        telemetry_handler.update_telemetry("additionalAttributes.codingAgent", "EXTERNAL-COPILOT")
     else:
         # Use original method for branches created by SmartFix
         remediation_id = extract_remediation_id_from_branch(branch_name)
+        telemetry_handler.update_telemetry("additionalAttributes.codingAgent", "INTERNAL-SMARTFIX")
     
     if not remediation_id:
         if branch_name.startswith("copilot/fix"):
@@ -90,7 +100,6 @@ def handle_merged_pr():
     telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)
     
     # Try to extract vulnerability UUID from PR labels
-    labels = pull_request.get("labels", [])
     vuln_uuid = "unknown"
     
     for label in labels:

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -78,7 +78,7 @@ def handle_merged_pr():
         # Extract GitHub issue number from branch name
         issue_number = extract_issue_number_from_branch(branch_name)
         if issue_number:
-            telemetry_handler.update_telemetry("additionalAttributes.githubIssueNumber", issue_number)
+            telemetry_handler.update_telemetry("additionalAttributes.externalIssueNumber", issue_number)
             debug_log(f"Extracted GitHub issue number from branch name: {issue_number}")
         else:
             debug_log(f"Could not extract issue number from branch name: {branch_name}")

--- a/test/test_external_coding_agent.py
+++ b/test/test_external_coding_agent.py
@@ -83,7 +83,7 @@ class TestExternalCodingAgent(unittest.TestCase):
         agent = ExternalCodingAgent(self.config)
         
         # Call generate_fixes
-        result = agent.generate_fixes("1234-FAKE-ABCD", "1REM-FAKE-ABCD", "Fake Vulnerability Title")
+        result = agent.generate_fixes("1234-FAKE-ABCD", "1REM-FAKE-ABCD", "Fake Vulnerability Title", "Fake issue body.")
         
         # Assert that result is False
         self.assertFalse(result)
@@ -125,7 +125,7 @@ class TestExternalCodingAgent(unittest.TestCase):
         agent = ExternalCodingAgent(self.config)
         
         # Call generate_fixes
-        result = agent.generate_fixes("1234-FAKE-ABCD", "1REM-FAKE-ABCD", "Fake Vulnerability Title")
+        result = agent.generate_fixes("1234-FAKE-ABCD", "1REM-FAKE-ABCD", "Fake Vulnerability Title", "Fake issue body.")
 
         # Assert that result is True
         self.assertTrue(result)
@@ -171,7 +171,7 @@ class TestExternalCodingAgent(unittest.TestCase):
         
         try:
             # Call generate_fixes
-            result = agent.generate_fixes("1234-FAKE-ABCD", "1REM-FAKE-ABCD", "Fake Vulnerability Title")
+            result = agent.generate_fixes("1234-FAKE-ABCD", "1REM-FAKE-ABCD", "Fake Vulnerability Title", "Fake issue body.")
 
             # Assert that result is False when PR is not created
             self.assertFalse(result)
@@ -229,7 +229,7 @@ class TestExternalCodingAgent(unittest.TestCase):
         
         try:
             # Call generate_fixes
-            result = agent.generate_fixes("1234-FAKE-ABCD", "1REM-FAKE-ABCD", "Fake Vulnerability Title")
+            result = agent.generate_fixes("1234-FAKE-ABCD", "1REM-FAKE-ABCD", "Fake Vulnerability Title", "Fake issue body.")
 
             # Assert that result is True
             self.assertTrue(result)

--- a/test/test_external_coding_agent.py
+++ b/test/test_external_coding_agent.py
@@ -135,7 +135,7 @@ class TestExternalCodingAgent(unittest.TestCase):
         mock_log.assert_any_call(f"External agent created PR #123 at https://github.com/owner/repo/pull/123")
         
         # Verify telemetry updates
-        mock_update_telemetry.assert_any_call("additionalAttributes.codingAgent", "EXTERNAL")
+        mock_update_telemetry.assert_any_call("additionalAttributes.codingAgent", "EXTERNAL-COPILOT")
         mock_update_telemetry.assert_any_call("resultInfo.prCreated", True)
         mock_update_telemetry.assert_any_call("additionalAttributes.prStatus", "OPEN")
         mock_update_telemetry.assert_any_call("additionalAttributes.prNumber", 123)
@@ -187,7 +187,7 @@ class TestExternalCodingAgent(unittest.TestCase):
         mock_log.assert_any_call("External agent failed to create a PR within the timeout period", is_error=True)
         
         # Verify telemetry updates
-        mock_update_telemetry.assert_any_call("additionalAttributes.codingAgent", "EXTERNAL")
+        mock_update_telemetry.assert_any_call("additionalAttributes.codingAgent", "EXTERNAL-COPILOT")
         mock_update_telemetry.assert_any_call("resultInfo.prCreated", False)
         mock_update_telemetry.assert_any_call("resultInfo.failureReason", "PR creation timeout")
         mock_update_telemetry.assert_any_call("resultInfo.failureCategory", "AGENT_FAILURE")

--- a/test/test_git_handler.py
+++ b/test/test_git_handler.py
@@ -415,23 +415,17 @@ class TestGitHandler(unittest.TestCase):
             "copilot/fix-123-extra",         # Extra parts
             "smartfix/remediation-123",      # Different prefix
             "",                              # Empty string
-            "copilot/fix-0",                 # Zero (technically valid but edge case)
         ]
         
         for branch_name in invalid_branches:
             with self.subTest(branch_name=branch_name):
                 result = git_handler.extract_issue_number_from_branch(branch_name)
-                if branch_name == "copilot/fix-0":
-                    # Zero is technically a valid issue number
-                    self.assertEqual(result, 0)
-                else:
-                    self.assertIsNone(result)
+                self.assertIsNone(result)
 
     def test_extract_issue_number_from_branch_edge_cases(self):
         """Test edge cases for extracting issue number from branch name"""
         # Test edge cases
         edge_cases = [
-            ("copilot/fix-0", 0),            # Zero issue number
             ("copilot/fix-2147483647", 2147483647),  # Large number (max 32-bit int)
         ]
         

--- a/test/test_git_handler.py
+++ b/test/test_git_handler.py
@@ -388,6 +388,58 @@ class TestGitHandler(unittest.TestCase):
         mock_log.assert_any_call("Adding labels to PR #123: ['contrast-vuln-id:VULN-12345', 'smartfix-id:remediation-67890']")
         mock_log.assert_any_call("Successfully added labels to PR #123: ['contrast-vuln-id:VULN-12345', 'smartfix-id:remediation-67890']")
 
+    def test_extract_issue_number_from_branch_success(self):
+        """Test extracting issue number from valid copilot branch name"""
+        # Test cases with valid branch names
+        test_cases = [
+            ("copilot/fix-123", 123),
+            ("copilot/fix-1", 1),
+            ("copilot/fix-999999", 999999),
+            ("copilot/fix-42", 42),
+        ]
+        
+        for branch_name, expected_issue_number in test_cases:
+            with self.subTest(branch_name=branch_name):
+                result = git_handler.extract_issue_number_from_branch(branch_name)
+                self.assertEqual(result, expected_issue_number)
+
+    def test_extract_issue_number_from_branch_invalid(self):
+        """Test extracting issue number from invalid branch names"""
+        # Test cases with invalid branch names
+        invalid_branches = [
+            "main",                           # Wrong branch name
+            "feature/new-feature",           # Wrong branch name
+            "copilot/fix-",                  # Missing issue number
+            "copilot/fix-abc",               # Non-numeric issue number
+            "copilot/fix-123abc",            # Invalid format
+            "copilot/fix-123-extra",         # Extra parts
+            "smartfix/remediation-123",      # Different prefix
+            "",                              # Empty string
+            "copilot/fix-0",                 # Zero (technically valid but edge case)
+        ]
+        
+        for branch_name in invalid_branches:
+            with self.subTest(branch_name=branch_name):
+                result = git_handler.extract_issue_number_from_branch(branch_name)
+                if branch_name == "copilot/fix-0":
+                    # Zero is technically a valid issue number
+                    self.assertEqual(result, 0)
+                else:
+                    self.assertIsNone(result)
+
+    def test_extract_issue_number_from_branch_edge_cases(self):
+        """Test edge cases for extracting issue number from branch name"""
+        # Test edge cases
+        edge_cases = [
+            ("copilot/fix-0", 0),            # Zero issue number
+            ("copilot/fix-2147483647", 2147483647),  # Large number (max 32-bit int)
+        ]
+        
+        for branch_name, expected_issue_number in edge_cases:
+            with self.subTest(branch_name=branch_name):
+                result = git_handler.extract_issue_number_from_branch(branch_name)
+                self.assertEqual(result, expected_issue_number)
+
     @patch('src.git_handler.ensure_label')
     @patch('src.git_handler.run_command')
     @patch('src.git_handler.log')


### PR DESCRIPTION
**Ticket**
https://contrast.atlassian.net/browse/AIML-48

**Overview**
This change calls the Remediation backend API for vuln details, formats it into an Issue description body, and then uses that body text when opening the GitHub Issue.

**Testing**
- Build checks should pass
- Tests can now be run locally with ./test/run_tests.sh to get uv to install all the necessary dependencies.

**Evidence**
Issue with vulnerability details:
<img width="1387" height="902" alt="Screenshot 2025-07-28 at 8 10 40 PM" src="https://github.com/user-attachments/assets/6b4124fc-a23c-49fd-a7db-7562548f5e21" />

PR in progress:
<img width="1483" height="901" alt="Screenshot 2025-07-28 at 8 13 37 PM" src="https://github.com/user-attachments/assets/acd60876-9d19-481e-9f1a-21baf43ce9bd" />

Finished PR:
<img width="1370" height="889" alt="Screenshot 2025-07-28 at 8 21 46 PM" src="https://github.com/user-attachments/assets/41ecd03d-d488-4323-9f68-62cf6ef1d5e0" />
