### PR TITLE
AIML-84 Extend Google ADK's LiteLlm classes for prompt caching

### DIFF
--- a/src/agent_handler.py
+++ b/src/agent_handler.py
@@ -52,8 +52,8 @@ ADK_AVAILABLE = False
 try:
     from google.adk.agents import Agent
     from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService
-    from src.extensions.extended_litellm import ExtendedLiteLlm
-    from src.extensions.extended_llm_agent import ExtendedLlmAgent
+    from src.extensions.smartfix_litellm import SmartFixLiteLlm
+    from src.extensions.smartfix_llm_agent import SmartFixLlmAgent
     from google.adk.runners import Runner
     from google.adk.sessions import InMemorySessionService
     from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters, StdioConnectionParams
@@ -80,10 +80,10 @@ library_logger.setLevel(logging.ERROR)
 async def _create_mcp_toolset(target_folder_str: str) -> MCPToolset:
     """Create MCP toolset with platform-specific configuration."""
     if platform.system() == 'Windows':
-        connection_timeout = 300
+        connection_timeout = 180
         debug_log("Using Windows-specific MCP connection settings")
     else:
-        connection_timeout = 180
+        connection_timeout = 120
 
     return MCPToolset(
         connection_params=StdioConnectionParams(
@@ -208,13 +208,13 @@ async def create_agent(target_folder: Path, remediation_id: str, agent_type: str
     agent_name = f"contrast_{agent_type}_agent"
 
     try:
-        model_instance = ExtendedLiteLlm(
+        model_instance = SmartFixLiteLlm(
             model=config.AGENT_MODEL,
             temperature=0.2,  # Set low temperature for more deterministic output
             # seed=42, # The random seed for reproducibility (not supported by bedrock/anthropic atm call throws error)
             stream_options={"include_usage": True}
         )
-        root_agent = ExtendedLlmAgent(
+        root_agent = SmartFixLlmAgent(
             model=model_instance,
             name=agent_name,
             instruction=agent_instruction,

--- a/src/extensions/smartfix_litellm.py
+++ b/src/extensions/smartfix_litellm.py
@@ -1,6 +1,6 @@
 # -
 # #%L
-# Extended LiteLLM with Prompt Caching
+# SmartFix LiteLLM with Prompt Caching
 # %%
 # Copyright (C) 2025 Contrast Security, Inc.
 # %%
@@ -58,7 +58,7 @@ class TokenCostAccumulator:
 
     def add_usage(self, input_tokens: int, output_tokens: int, cache_read_tokens: int,
                   cache_write_tokens: int, new_input_cost: float, cache_read_cost: float,
-                  cache_write_cost: float, output_cost: float):
+                  cache_write_cost: float, output_cost: float) -> None:
         """Add usage statistics from a single LLM call."""
         # Accumulate tokens
         self.total_new_input_tokens += input_tokens
@@ -114,8 +114,8 @@ class TokenCostAccumulator:
         return 0.0
 
 
-class ExtendedLiteLlm(LiteLlm):
-    """Extended LiteLlm with automatic prompt caching and comprehensive cost analysis.
+class SmartFixLiteLlm(LiteLlm):
+    """SmartFix LiteLlm with automatic prompt caching and comprehensive cost analysis.
 
     This class extends the base LiteLlm to automatically apply prompt caching
     and provide detailed cost analysis for all LLM interactions:
@@ -131,16 +131,16 @@ class ExtendedLiteLlm(LiteLlm):
     Example usage:
     ```python
     # Bedrock Claude - Works with all features and cost tracking
-    model = ExtendedLiteLlm(model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+    model = SmartFixLiteLlm(model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0")
 
     # Direct Anthropic - Works with all features and cost tracking
-    model = ExtendedLiteLlm(model="anthropic/claude-3-7-sonnet-20250219")
+    model = SmartFixLiteLlm(model="anthropic/claude-3-7-sonnet-20250219")
 
     # OpenAI - works with cost tracking (no caching applied)
-    model = ExtendedLiteLlm(model="openai/gpt-4o")
+    model = SmartFixLiteLlm(model="openai/gpt-4o")
 
     # Other models - work normally with cost tracking
-    model = ExtendedLiteLlm(model="gemini/gemini-1.5-pro")
+    model = SmartFixLiteLlm(model="gemini/gemini-1.5-pro")
     ```
     """
 

--- a/src/extensions/smartfix_llm_agent.py
+++ b/src/extensions/smartfix_llm_agent.py
@@ -1,6 +1,6 @@
 # -
 # #%L
-# Extended LLM Agent
+# SmartFix LLM Agent
 # %%
 # Copyright (C) 2025 Contrast Security, Inc.
 # %%
@@ -31,32 +31,32 @@ from pydantic import Field, model_validator
 from google.adk.agents import LlmAgent
 from src.utils import debug_log
 
-# Import ExtendedLiteLlm at module level so it's available for model_rebuild()
-ExtendedLiteLlm = None
+# Import SmartFixLiteLlm at module level so it's available for model_rebuild()
+SmartFixLiteLlm = None
 try:
-    from .extended_litellm import ExtendedLiteLlm
+    from .smartfix_litellm import SmartFixLiteLlm
 except ImportError:
     pass
 
 
-class ExtendedLlmAgent(LlmAgent):
-    """Extended LLM Agent that preserves ExtendedLiteLlm statistics across calls.
+class SmartFixLlmAgent(LlmAgent):
+    """SmartFix LLM Agent that preserves SmartFixLiteLlm statistics across calls.
 
-    This class solves the issue where ExtendedLiteLlm accumulated statistics
+    This class solves the issue where SmartFixLiteLlm accumulated statistics
     aren't preserved when using the model within a Google ADK Agent. It ensures
-    that the same ExtendedLiteLlm instance is used for all LLM calls and provides
+    that the same SmartFixLiteLlm instance is used for all LLM calls and provides
     convenient methods to access accumulated statistics.
 
     Example usage:
     ```python
-    from src.extensions.extended_litellm import ExtendedLiteLlm
-    from src.extensions.extended_llm_agent import ExtendedLlmAgent
+    from src.extensions.smartfix_litellm import SmartFixLiteLlm
+    from src.extensions.smartfix_llm_agent import SmartFixLlmAgent
 
     # Create the extended model
-    model = ExtendedLiteLlm(model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+    model = SmartFixLiteLlm(model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0")
 
     # Create the extended agent
-    agent = ExtendedLlmAgent(
+    agent = SmartFixLlmAgent(
         name="my-agent",
         model=model,
         instruction="You are a helpful assistant."
@@ -77,23 +77,23 @@ class ExtendedLlmAgent(LlmAgent):
     original_extended_model: Optional[Any] = Field(
         default=None,
         exclude=True,
-        description="Reference to the original ExtendedLiteLlm instance for stats access"
+        description="Reference to the original SmartFixLiteLlm instance for stats access"
     )
 
     @model_validator(mode='after')
     def _preserve_extended_model_reference(self):
-        """Preserve a reference to the ExtendedLiteLlm instance if provided."""
+        """Preserve a reference to the SmartFixLiteLlm instance if provided."""
         # Import here to avoid circular imports
         try:
-            from .extended_litellm import ExtendedLiteLlm
+            from .smartfix_litellm import SmartFixLiteLlm
 
-            if isinstance(self.model, ExtendedLiteLlm):
+            if isinstance(self.model, SmartFixLiteLlm):
                 # Store reference to the original instance
                 self.original_extended_model = self.model
-                debug_log(f"[EXTENDED_AGENT] Preserved reference to ExtendedLiteLlm instance for agent: {self.name}")
+                debug_log(f"[SMARTFIX_AGENT] Preserved reference to SmartFixLiteLlm instance for agent: {self.name}")
 
         except ImportError:
-            # ExtendedLiteLlm not available, ignore
+            # SmartFixLiteLlm not available, ignore
             pass
 
         return self
@@ -101,8 +101,8 @@ class ExtendedLlmAgent(LlmAgent):
     @override
     @property
     def canonical_model(self):
-        """Override to ensure we return the original ExtendedLiteLlm instance."""
-        # If we have a preserved ExtendedLiteLlm instance, return it
+        """Override to ensure we return the original SmartFixLiteLlm instance."""
+        # If we have a preserved SmartFixLiteLlm instance, return it
         if self.original_extended_model is not None:
             return self.original_extended_model
 
@@ -110,15 +110,15 @@ class ExtendedLlmAgent(LlmAgent):
         return super().canonical_model
 
     def has_extended_model(self) -> bool:
-        """Check if this agent is using an ExtendedLiteLlm model."""
+        """Check if this agent is using an SmartFixLiteLlm model."""
         try:
-            from .extended_litellm import ExtendedLiteLlm
-            return isinstance(self.canonical_model, ExtendedLiteLlm)
+            from .smartfix_litellm import SmartFixLiteLlm
+            return isinstance(self.canonical_model, SmartFixLiteLlm)
         except ImportError:
             return False
 
     def get_extended_model(self) -> Optional[Any]:
-        """Get the ExtendedLiteLlm instance if available."""
+        """Get the SmartFixLiteLlm instance if available."""
         if self.has_extended_model():
             return self.canonical_model
         return None
@@ -127,18 +127,18 @@ class ExtendedLlmAgent(LlmAgent):
         """Get accumulated token usage and cost statistics as dictionary.
 
         This method provides programmatic access to the accumulated statistics
-        from the ExtendedLiteLlm instance being used by this agent.
+        from the SmartFixLiteLlm instance being used by this agent.
 
         Returns:
             dict: Dictionary containing accumulated statistics
 
         Raises:
-            ValueError: If the agent is not using an ExtendedLiteLlm model.
+            ValueError: If the agent is not using an SmartFixLiteLlm model.
         """
         extended_model = self.get_extended_model()
         if extended_model is None:
             raise ValueError(
-                f"Agent '{self.name}' is not using an ExtendedLiteLlm model. "
+                f"Agent '{self.name}' is not using an SmartFixLiteLlm model. "
                 "Cannot access accumulated statistics. "
                 f"Current model type: {type(self.canonical_model).__name__}"
             )
@@ -149,18 +149,18 @@ class ExtendedLlmAgent(LlmAgent):
         """Get accumulated token usage and cost statistics as JSON string.
 
         This method provides programmatic access to the accumulated statistics
-        from the ExtendedLiteLlm instance being used by this agent.
+        from the SmartFixLiteLlm instance being used by this agent.
 
         Returns:
             str: JSON formatted string containing accumulated statistics
 
         Raises:
-            ValueError: If the agent is not using an ExtendedLiteLlm model.
+            ValueError: If the agent is not using an SmartFixLiteLlm model.
         """
         extended_model = self.get_extended_model()
         if extended_model is None:
             raise ValueError(
-                f"Agent '{self.name}' is not using an ExtendedLiteLlm model. "
+                f"Agent '{self.name}' is not using an SmartFixLiteLlm model. "
                 "Cannot access accumulated statistics. "
                 f"Current model type: {type(self.canonical_model).__name__}"
             )
@@ -171,12 +171,12 @@ class ExtendedLlmAgent(LlmAgent):
         """Reset accumulated statistics to start fresh.
 
         Raises:
-            ValueError: If the agent is not using an ExtendedLiteLlm model.
+            ValueError: If the agent is not using an SmartFixLiteLlm model.
         """
         extended_model = self.get_extended_model()
         if extended_model is None:
             raise ValueError(
-                f"Agent '{self.name}' is not using an ExtendedLiteLlm model. "
+                f"Agent '{self.name}' is not using an SmartFixLiteLlm model. "
                 "Cannot reset accumulated statistics. "
                 f"Current model type: {type(self.canonical_model).__name__}"
             )
@@ -197,12 +197,12 @@ class ExtendedLlmAgent(LlmAgent):
                 - And more detailed breakdowns
 
         Raises:
-            ValueError: If the agent is not using an ExtendedLiteLlm model.
+            ValueError: If the agent is not using an SmartFixLiteLlm model.
         """
         extended_model = self.get_extended_model()
         if extended_model is None:
             raise ValueError(
-                f"Agent '{self.name}' is not using an ExtendedLiteLlm model. "
+                f"Agent '{self.name}' is not using an SmartFixLiteLlm model. "
                 "Cannot access accumulated statistics. "
                 f"Current model type: {type(self.canonical_model).__name__}"
             )
@@ -236,7 +236,7 @@ class ExtendedLlmAgent(LlmAgent):
             dict: Dictionary containing model information including:
                 - model_name: The model name/identifier
                 - model_type: The class name of the model
-                - is_extended: Whether it's an ExtendedLiteLlm instance
+                - is_extended: Whether it's an SmartFixLiteLlm instance
                 - has_stats: Whether accumulated statistics are available
         """
         model = self.canonical_model
@@ -251,11 +251,11 @@ class ExtendedLlmAgent(LlmAgent):
         }
 
 
-# Rebuild the model schema after ExtendedLiteLlm is available
+# Rebuild the model schema after SmartFixLiteLlm is available
 # This resolves forward references and ensures Pydantic can fully validate the model
-if ExtendedLiteLlm is not None:
+if SmartFixLiteLlm is not None:
     try:
-        ExtendedLlmAgent.model_rebuild()
+        SmartFixLlmAgent.model_rebuild()
     except Exception:
         # If rebuild fails for any reason, just continue
         # The class will still work, just without perfect type validation

--- a/test/test_smartfix_litellm.py
+++ b/test/test_smartfix_litellm.py
@@ -19,7 +19,7 @@
 #
 
 """
-Unit tests for ExtendedLiteLlm and TokenCostAccumulator classes.
+Unit tests for SmartFixLiteLlm and TokenCostAccumulator classes.
 
 This module tests the extended LiteLLM functionality including:
 - Token cost accumulation and statistics gathering
@@ -44,7 +44,7 @@ from src.config import get_config  # noqa: E402
 _ = get_config(testing=True)
 
 # Import the classes under test AFTER config initialization
-from src.extensions.extended_litellm import ExtendedLiteLlm, TokenCostAccumulator  # noqa: E402
+from src.extensions.smartfix_litellm import SmartFixLiteLlm, TokenCostAccumulator  # noqa: E402
 
 
 class TestTokenCostAccumulator(unittest.TestCase):
@@ -262,21 +262,21 @@ class TestTokenCostAccumulator(unittest.TestCase):
         self.assertEqual(self.accumulator.call_count, 0)
 
 
-class TestExtendedLiteLlm(unittest.TestCase):
-    """Test cases for ExtendedLiteLlm class."""
+class TestSmartFixLiteLlm(unittest.TestCase):
+    """Test cases for SmartFixLiteLlm class."""
 
     def setUp(self):
         """Set up test fixtures before each test method."""
         # Mock LiteLlm initialization to avoid dependencies
         with patch('litellm.completion'):
-            self.extended_model = ExtendedLiteLlm(model="test-model")
+            self.extended_model = SmartFixLiteLlm(model="test-model")
 
     def test_initialization(self):
-        """Test that ExtendedLiteLlm initializes correctly."""
+        """Test that SmartFixLiteLlm initializes correctly."""
         self.assertEqual(self.extended_model.model, "test-model")
         self.assertIsInstance(self.extended_model.cost_accumulator, TokenCostAccumulator)
 
-    @patch('src.extensions.extended_litellm.debug_log')
+    @patch('src.extensions.smartfix_litellm.debug_log')
     def test_gather_accumulated_stats_dict(self, mock_debug_log):
         """Test statistics dictionary generation."""
         # Add some usage to the accumulator
@@ -299,7 +299,7 @@ class TestExtendedLiteLlm(unittest.TestCase):
         self.assertIn('cost_analysis', stats)
         self.assertIn('averages', stats)
 
-    @patch('src.extensions.extended_litellm.debug_log')
+    @patch('src.extensions.smartfix_litellm.debug_log')
     def test_gather_accumulated_stats_json(self, mock_debug_log):
         """Test JSON statistics generation."""
         # Add some usage to the accumulator
@@ -321,7 +321,7 @@ class TestExtendedLiteLlm(unittest.TestCase):
         self.assertEqual(stats_dict['call_count'], 1)
         self.assertIn('token_usage', stats_dict)
 
-    @patch('src.extensions.extended_litellm.debug_log')
+    @patch('src.extensions.smartfix_litellm.debug_log')
     def test_reset_accumulated_stats(self, mock_debug_log):
         """Test that reset clears accumulated statistics."""
         # Add some usage first
@@ -349,15 +349,15 @@ class TestExtendedLiteLlm(unittest.TestCase):
         mock_debug_log.assert_called_with("Accumulated statistics have been reset.")
 
 
-class TestExtendedLiteLlmIntegration(unittest.TestCase):
-    """Integration tests for ExtendedLiteLlm functionality."""
+class TestSmartFixLiteLlmIntegration(unittest.TestCase):
+    """Integration tests for SmartFixLiteLlm functionality."""
 
     @patch('litellm.completion')
-    @patch('src.extensions.extended_litellm.debug_log')
+    @patch('src.extensions.smartfix_litellm.debug_log')
     def test_cost_accumulator_integration(self, mock_debug_log, mock_completion):
-        """Test that cost accumulator integrates properly with ExtendedLiteLlm."""
-        # Create a real ExtendedLiteLlm instance
-        model = ExtendedLiteLlm(model="test-integration-model")
+        """Test that cost accumulator integrates properly with SmartFixLiteLlm."""
+        # Create a real SmartFixLiteLlm instance
+        model = SmartFixLiteLlm(model="test-integration-model")
 
         # Verify it has a cost accumulator
         self.assertIsInstance(model.cost_accumulator, TokenCostAccumulator)

--- a/test/test_smartfix_llm_agent.py
+++ b/test/test_smartfix_llm_agent.py
@@ -19,9 +19,9 @@
 #
 
 """
-Unit tests for ExtendedLlmAgent class.
+Unit tests for SmartFixLlmAgent class.
 
-This module tests the ExtendedLlmAgent functionality with focused tests on
+This module tests the SmartFixLlmAgent functionality with focused tests on
 the extension logic without complex ADK dependencies.
 """
 
@@ -41,62 +41,62 @@ from src.config import get_config  # noqa: E402
 _ = get_config(testing=True)
 
 # Import the classes under test AFTER config initialization
-from src.extensions.extended_llm_agent import ExtendedLlmAgent  # noqa: E402
-from src.extensions.extended_litellm import ExtendedLiteLlm  # noqa: E402
+from src.extensions.smartfix_llm_agent import SmartFixLlmAgent  # noqa: E402
+from src.extensions.smartfix_litellm import SmartFixLiteLlm  # noqa: E402
 
 
-class TestExtendedLlmAgentFunctionality(unittest.TestCase):
-    """Test cases focusing on ExtendedLlmAgent specific functionality."""
+class TestSmartFixLlmAgentFunctionality(unittest.TestCase):
+    """Test cases focusing on SmartFixLlmAgent specific functionality."""
 
     def test_has_extended_model_true(self):
-        """Test has_extended_model returns True when ExtendedLiteLlm reference exists."""
+        """Test has_extended_model returns True when SmartFixLiteLlm reference exists."""
         # Test the method logic directly without full object instantiation
         agent = MagicMock()
-        agent.canonical_model = Mock(spec=ExtendedLiteLlm)
+        agent.canonical_model = Mock(spec=SmartFixLiteLlm)
 
         # Apply the real method to our mock
-        result = ExtendedLlmAgent.has_extended_model(agent)
+        result = SmartFixLlmAgent.has_extended_model(agent)
         self.assertTrue(result)
 
     def test_has_extended_model_false(self):
-        """Test has_extended_model returns False when no ExtendedLiteLlm reference exists."""
+        """Test has_extended_model returns False when no SmartFixLiteLlm reference exists."""
         agent = MagicMock()
-        agent.canonical_model = Mock()  # Not an ExtendedLiteLlm
+        agent.canonical_model = Mock()  # Not a SmartFixLiteLlm
 
-        result = ExtendedLlmAgent.has_extended_model(agent)
+        result = SmartFixLlmAgent.has_extended_model(agent)
         self.assertFalse(result)
 
     def test_get_extended_model_with_reference(self):
-        """Test get_extended_model returns the canonical model when it's ExtendedLiteLlm."""
+        """Test get_extended_model returns the canonical model when it's SmartFixLiteLlm."""
         agent = MagicMock()
-        mock_extended_model = Mock(spec=ExtendedLiteLlm)
+        mock_extended_model = Mock(spec=SmartFixLiteLlm)
         agent.canonical_model = mock_extended_model
 
         # Mock has_extended_model to return True
-        with patch.object(ExtendedLlmAgent, 'has_extended_model', return_value=True):
-            result = ExtendedLlmAgent.get_extended_model(agent)
+        with patch.object(SmartFixLlmAgent, 'has_extended_model', return_value=True):
+            result = SmartFixLlmAgent.get_extended_model(agent)
             self.assertIs(result, mock_extended_model)
 
     def test_reset_accumulated_stats_with_extended_model(self):
-        """Test that reset delegates to ExtendedLiteLlm model."""
+        """Test that reset delegates to SmartFixLiteLlm model."""
         agent = MagicMock()
-        mock_extended_model = Mock(spec=ExtendedLiteLlm)
+        mock_extended_model = Mock(spec=SmartFixLiteLlm)
 
         # The real method calls get_extended_model first
         with patch.object(agent, 'get_extended_model', return_value=mock_extended_model):
-            ExtendedLlmAgent.reset_accumulated_stats(agent)
+            SmartFixLlmAgent.reset_accumulated_stats(agent)
             # Should delegate to the extended model's reset method
             mock_extended_model.reset_accumulated_stats.assert_called_once()
 
 
-class TestExtendedLlmAgentIntegration(unittest.TestCase):
-    """Integration tests for ExtendedLlmAgent with real ExtendedLiteLlm instances."""
+class TestSmartFixLlmAgentIntegration(unittest.TestCase):
+    """Integration tests for SmartFixLlmAgent with real SmartFixLiteLlm instances."""
 
     @patch('litellm.completion')
     def test_extended_model_delegation_logic(self, mock_completion):
-        """Test that ExtendedLlmAgent logic works with ExtendedLiteLlm."""
-        # Create a real ExtendedLiteLlm instance
-        extended_model = ExtendedLiteLlm(model="test-model")
+        """Test that SmartFixLlmAgent logic works with SmartFixLiteLlm."""
+        # Create a real SmartFixLiteLlm instance
+        extended_model = SmartFixLiteLlm(model="test-model")
 
         # Add some usage to the accumulator to simulate usage
         extended_model.cost_accumulator.add_usage(
@@ -133,8 +133,8 @@ class TestExtendedLlmAgentIntegration(unittest.TestCase):
     @patch('litellm.completion')
     def test_model_info_functionality(self, mock_completion):
         """Test get_model_info provides correct information."""
-        # Create a real ExtendedLiteLlm instance
-        extended_model = ExtendedLiteLlm(model="test-model-id")
+        # Create a real SmartFixLiteLlm instance
+        extended_model = SmartFixLiteLlm(model="test-model-id")
 
         # Create a mock agent
         agent = MagicMock()
@@ -142,11 +142,11 @@ class TestExtendedLlmAgentIntegration(unittest.TestCase):
         agent.canonical_model = extended_model
         agent.original_extended_model = extended_model
 
-        result = ExtendedLlmAgent.get_model_info(agent)
+        result = SmartFixLlmAgent.get_model_info(agent)
 
         self.assertEqual(result['agent_name'], "test-agent")
         self.assertEqual(result['model_name'], "test-model-id")
-        self.assertEqual(result['model_type'], "ExtendedLiteLlm")
+        self.assertEqual(result['model_type'], "SmartFixLiteLlm")
         self.assertTrue(result['is_extended'])
         self.assertTrue(result['has_stats'])
         self.assertIn('model_id', result)


### PR DESCRIPTION
**Ticket**
https://contrast.atlassian.net/browse/AIML-84

**Overview**
- Suppress Pydantic warnings from the previously upgraded version of Google ADK.
- Refactored the code to get the MCP tools into several functions, increased timeouts, and rolled-back to version 2025.1.14 because of intermittent broken pipe issues connecting the filesystem MCP server on a Windows runner.
- Also added support for retrying the MCP server connection 3 times.
- Extended ADK's LiteLlm class to support prompt caching on Anthropic models and to gather token usage & cost statistics.
- Extended ADK's LlmAgent class to support reporting accumulated usage and cost statistics
- Removed old token usage reporting from agent_handler.py

**Testing**
Buil checks pass

**Evidence**
Windows runner good run: https://github.com/JacobMagesHaskinsContrast/cSharp-demo/actions/runs/17304579514/job/49124089678

Cost and usage report from the logs showing caching:
<img width="484" height="445" alt="Screenshot 2025-08-28 at 5 31 57 PM" src="https://github.com/user-attachments/assets/0dc079b1-9734-4b00-a5ce-0c82e5cd65ee" />
