### PR TITLE
AIML-539: Add orphan PR reconciliation

### DIFF
--- a/src/contrast_api.py
+++ b/src/contrast_api.py
@@ -76,6 +76,55 @@ def get_sanitized_409_message(response_text: str, credit_info=None) -> tuple[str
     return ("Unable to process request. Please try again or contact Contrast support if the issue persists.", True)
 
 
+def get_open_remediations(contrast_host, contrast_org_id, contrast_app_id,
+                          contrast_auth_key, contrast_api_key) -> list:
+    """Returns remediations the backend believes are in OPEN status.
+
+    Best-effort: returns [] on any error. Must not block main flow.
+
+    Args:
+        contrast_host: The Contrast Security host URL
+        contrast_org_id: The organization ID
+        contrast_app_id: The application ID
+        contrast_auth_key: The Contrast authorization key
+        contrast_api_key: The Contrast API key
+
+    Returns:
+        list: List of open remediation dicts, or empty list on error
+    """
+    api_url = (f"https://{normalize_host(contrast_host)}/api/v4/aiml-remediation/"
+               f"organizations/{contrast_org_id}/applications/{contrast_app_id}/remediations/open")
+
+    headers = {
+        "Authorization": contrast_auth_key,
+        "API-Key": contrast_api_key,
+        "Accept": "application/json",
+        "User-Agent": config.USER_AGENT
+    }
+
+    try:
+        debug_log(f"Fetching open remediations from: {api_url}")
+        response = requests.get(api_url, headers=headers, timeout=30)
+
+        if response.status_code == 200:
+            result = response.json()
+            debug_log(f"Found {len(result)} open remediations")
+            return result
+        else:
+            log(f"Unexpected status {response.status_code} fetching open remediations", is_warning=True)
+            return []
+
+    except requests.exceptions.RequestException as e:
+        log(f"Error fetching open remediations: {e}", is_warning=True)
+        return []
+    except json.JSONDecodeError:
+        log("Error decoding JSON from open remediations endpoint", is_warning=True)
+        return []
+    except Exception as e:
+        log(f"Unexpected error fetching open remediations: {e}", is_warning=True)
+        return []
+
+
 def get_vulnerability_with_prompts(contrast_host, contrast_org_id, contrast_app_id, contrast_auth_key, contrast_api_key,
                                    max_open_prs, github_repo_url, vulnerability_severities, credit_info=None):
     """Fetches a vulnerability to process along with pre-populated prompt templates from the new prompt-details endpoint.

--- a/src/github/github_operations.py
+++ b/src/github/github_operations.py
@@ -171,6 +171,47 @@ class GitHubOperations(ScmOperations):
         else:
             log("NOTE: In testing mode, not exiting on Copilot assignment failure", is_warning=True)
 
+    def get_pr_actual_state(self, pr_number: int) -> Optional[str]:
+        """
+        Returns the actual GitHub state of a PR: 'OPEN', 'MERGED', or 'CLOSED'.
+        Returns None on error (caller should skip this PR).
+
+        Args:
+            pr_number: The PR number to check
+
+        Returns:
+            Optional[str]: 'OPEN', 'MERGED', 'CLOSED', or None on error
+        """
+        try:
+            result = run_command(
+                ['gh', 'pr', 'view', str(pr_number), '--repo', self.config.GITHUB_REPOSITORY,
+                 '--json', 'state,mergedAt'],
+                env=self.get_gh_env(),
+                check=False
+            )
+            if result is None:
+                debug_log(f"Failed to get PR state for PR #{pr_number}")
+                return None
+
+            data = json.loads(result.strip())
+            state = data.get('state', '').lower()
+            merged_at = data.get('mergedAt')
+
+            if state == 'open':
+                return 'OPEN'
+            elif state == 'closed':
+                return 'MERGED' if merged_at else 'CLOSED'
+            else:
+                debug_log(f"Unexpected PR state '{state}' for PR #{pr_number}")
+                return None
+
+        except (json.JSONDecodeError, ValueError) as e:
+            debug_log(f"Error parsing PR state for PR #{pr_number}: {e}")
+            return None
+        except Exception as e:
+            debug_log(f"Exception while getting PR state for PR #{pr_number}: {e}")
+            return None
+
     def get_pr_changed_files_count(self, pr_number: int) -> int:
         """
         Get the number of changed files in a PR using GitHub CLI.

--- a/src/github/github_operations.py
+++ b/src/github/github_operations.py
@@ -185,7 +185,7 @@ class GitHubOperations(ScmOperations):
         try:
             result = run_command(
                 ['gh', 'pr', 'view', str(pr_number), '--repo', self.config.GITHUB_REPOSITORY,
-                 '--json', 'state,mergedAt'],
+                 '--json', 'state'],
                 env=self.get_gh_env(),
                 check=False
             )
@@ -194,13 +194,10 @@ class GitHubOperations(ScmOperations):
                 return None
 
             data = json.loads(result.strip())
-            state = data.get('state', '').lower()
-            merged_at = data.get('mergedAt')
+            state = data.get('state', '').upper()
 
-            if state == 'open':
-                return 'OPEN'
-            elif state == 'closed':
-                return 'MERGED' if merged_at else 'CLOSED'
+            if state in ('OPEN', 'MERGED', 'CLOSED'):
+                return state
             else:
                 debug_log(f"Unexpected PR state '{state}' for PR #{pr_number}")
                 return None

--- a/src/main.py
+++ b/src/main.py
@@ -47,6 +47,7 @@ from src.smartfix.domains.vulnerability.models import Vulnerability
 
 # Import GitHub-specific agent factory
 from src.github.agent_factory import GitHubAgentFactory
+from src.smartfix.domains.workflow.pr_reconciliation import reconcile_open_remediations
 
 config = get_config()
 telemetry_handler.initialize_telemetry()
@@ -237,71 +238,6 @@ def cleanup_asyncio():  # noqa: C901
 
 # Register the cleanup function
 atexit.register(cleanup_asyncio)
-
-
-def reconcile_open_remediations(config, github_ops):
-    """Checks all remediations the backend thinks are OPEN against actual GitHub PR state.
-
-    Calls the appropriate backend transition for any that have drifted.
-    Best-effort: logs warnings on failure, never raises, never exits.
-    """
-    try:
-        open_remediations = contrast_api.get_open_remediations(
-            contrast_host=config.CONTRAST_HOST,
-            contrast_org_id=config.CONTRAST_ORG_ID,
-            contrast_app_id=config.CONTRAST_APP_ID,
-            contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
-            contrast_api_key=config.CONTRAST_API_KEY,
-        )
-
-        if not open_remediations:
-            log("No open remediations to reconcile")
-            return
-
-        log(f"Found {len(open_remediations)} open remediation(s) to check")
-
-        for rem in open_remediations:
-            remediation_id = rem.get('remediationId', 'unknown')
-            vuln_id = rem.get('vulnerabilityId', 'unknown')
-            pr_number = rem.get('pullRequestNumber')
-
-            if pr_number is None:
-                log(f"Remediation {remediation_id} (vuln {vuln_id}) has no PR number, skipping", is_warning=True)
-                continue
-
-            actual_state = github_ops.get_pr_actual_state(pr_number)
-
-            if actual_state is None:
-                log(f"Could not determine state for PR #{pr_number} (remediation {remediation_id}), skipping", is_warning=True)
-                continue
-
-            if actual_state == 'OPEN':
-                debug_log(f"Remediation {remediation_id} (vuln {vuln_id}, PR #{pr_number}): GitHub state is OPEN, no action needed")
-                continue
-
-            log(f"Reconciling remediation {remediation_id} (vuln {vuln_id}, PR #{pr_number}): GitHub state is {actual_state}, notifying backend")
-
-            if actual_state == 'MERGED':
-                contrast_api.notify_remediation_pr_merged(
-                    remediation_id=remediation_id,
-                    contrast_host=config.CONTRAST_HOST,
-                    contrast_org_id=config.CONTRAST_ORG_ID,
-                    contrast_app_id=config.CONTRAST_APP_ID,
-                    contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
-                    contrast_api_key=config.CONTRAST_API_KEY,
-                )
-            elif actual_state == 'CLOSED':
-                contrast_api.notify_remediation_pr_closed(
-                    remediation_id=remediation_id,
-                    contrast_host=config.CONTRAST_HOST,
-                    contrast_org_id=config.CONTRAST_ORG_ID,
-                    contrast_app_id=config.CONTRAST_APP_ID,
-                    contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
-                    contrast_api_key=config.CONTRAST_API_KEY,
-                )
-
-    except Exception as e:
-        log(f"Error during orphan PR reconciliation: {e}", is_warning=True)
 
 
 def main():  # noqa: C901

--- a/src/main.py
+++ b/src/main.py
@@ -239,6 +239,71 @@ def cleanup_asyncio():  # noqa: C901
 atexit.register(cleanup_asyncio)
 
 
+def reconcile_open_remediations(config, github_ops):
+    """Checks all remediations the backend thinks are OPEN against actual GitHub PR state.
+
+    Calls the appropriate backend transition for any that have drifted.
+    Best-effort: logs warnings on failure, never raises, never exits.
+    """
+    try:
+        open_remediations = contrast_api.get_open_remediations(
+            contrast_host=config.CONTRAST_HOST,
+            contrast_org_id=config.CONTRAST_ORG_ID,
+            contrast_app_id=config.CONTRAST_APP_ID,
+            contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
+            contrast_api_key=config.CONTRAST_API_KEY,
+        )
+
+        if not open_remediations:
+            log("No open remediations to reconcile")
+            return
+
+        log(f"Found {len(open_remediations)} open remediation(s) to check")
+
+        for rem in open_remediations:
+            remediation_id = rem.get('remediationId', 'unknown')
+            vuln_id = rem.get('vulnerabilityId', 'unknown')
+            pr_number = rem.get('pullRequestNumber')
+
+            if pr_number is None:
+                log(f"Remediation {remediation_id} (vuln {vuln_id}) has no PR number, skipping", is_warning=True)
+                continue
+
+            actual_state = github_ops.get_pr_actual_state(pr_number)
+
+            if actual_state is None:
+                log(f"Could not determine state for PR #{pr_number} (remediation {remediation_id}), skipping", is_warning=True)
+                continue
+
+            if actual_state == 'OPEN':
+                debug_log(f"Remediation {remediation_id} (vuln {vuln_id}, PR #{pr_number}): GitHub state is OPEN, no action needed")
+                continue
+
+            log(f"Reconciling remediation {remediation_id} (vuln {vuln_id}, PR #{pr_number}): GitHub state is {actual_state}, notifying backend")
+
+            if actual_state == 'MERGED':
+                contrast_api.notify_remediation_pr_merged(
+                    remediation_id=remediation_id,
+                    contrast_host=config.CONTRAST_HOST,
+                    contrast_org_id=config.CONTRAST_ORG_ID,
+                    contrast_app_id=config.CONTRAST_APP_ID,
+                    contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
+                    contrast_api_key=config.CONTRAST_API_KEY,
+                )
+            elif actual_state == 'CLOSED':
+                contrast_api.notify_remediation_pr_closed(
+                    remediation_id=remediation_id,
+                    contrast_host=config.CONTRAST_HOST,
+                    contrast_org_id=config.CONTRAST_ORG_ID,
+                    contrast_app_id=config.CONTRAST_APP_ID,
+                    contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
+                    contrast_api_key=config.CONTRAST_API_KEY,
+                )
+
+    except Exception as e:
+        log(f"Error during orphan PR reconciliation: {e}", is_warning=True)
+
+
 def main():  # noqa: C901
     """Main orchestration logic."""
 
@@ -264,6 +329,11 @@ def main():  # noqa: C901
 
     # --- Initial Setup ---
     git_ops.configure_git_user()
+
+    # --- Reconcile Orphaned Open Remediations ---
+    log("\n::group::--- Reconciling open remediations against GitHub ---")
+    reconcile_open_remediations(config, github_ops)
+    log("\n::endgroup::")
 
     # Check Open PR Limit
     log("\n::group::--- Checking Open PR Limit ---")

--- a/src/smartfix/domains/scm/scm_operations.py
+++ b/src/smartfix/domains/scm/scm_operations.py
@@ -43,6 +43,19 @@ class ScmOperations(ABC):
         pass
 
     @abstractmethod
+    def get_pr_actual_state(self, pr_number: int) -> Optional[str]:
+        """
+        Returns the actual SCM state of a PR: 'OPEN', 'MERGED', or 'CLOSED'.
+
+        Args:
+            pr_number (int): The PR number to check
+
+        Returns:
+            Optional[str]: 'OPEN', 'MERGED', 'CLOSED', or None on error
+        """
+        pass
+
+    @abstractmethod
     def get_pr_changed_files_count(self, pr_number: int) -> int:
         """
         Gets the number of changed files in a PR.

--- a/src/smartfix/domains/workflow/pr_reconciliation.py
+++ b/src/smartfix/domains/workflow/pr_reconciliation.py
@@ -1,0 +1,86 @@
+# -
+# #%L
+# Contrast AI SmartFix
+# %%
+# Copyright (C) 2025 Contrast Security, Inc.
+# %%
+# Contact: support@contrastsecurity.com
+# License: Commercial
+# NOTICE: This Software and the patented inventions embodied within may only be
+# used as part of Contrast Security's commercial offerings. Even though it is
+# made available through public repositories, use of this Software is subject to
+# the applicable End User Licensing Agreement found at
+# https://www.contrastsecurity.com/enduser-terms-0317a or as otherwise agreed
+# between Contrast Security and the End User. The Software may not be reverse
+# engineered, modified, repackaged, sold, redistributed or otherwise used in a
+# way not consistent with the End User License Agreement.
+# #L%
+#
+
+from src import contrast_api
+from src.utils import debug_log, log
+
+
+def reconcile_open_remediations(config, github_ops):
+    """Checks all remediations the backend thinks are OPEN against actual GitHub PR state.
+
+    Calls the appropriate backend transition for any that have drifted.
+    Best-effort: logs warnings on failure, never raises, never exits.
+    """
+    try:
+        open_remediations = contrast_api.get_open_remediations(
+            contrast_host=config.CONTRAST_HOST,
+            contrast_org_id=config.CONTRAST_ORG_ID,
+            contrast_app_id=config.CONTRAST_APP_ID,
+            contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
+            contrast_api_key=config.CONTRAST_API_KEY,
+        )
+
+        if not open_remediations:
+            log("No open remediations to reconcile")
+            return
+
+        log(f"Found {len(open_remediations)} open remediation(s) to check")
+
+        for rem in open_remediations:
+            remediation_id = rem.get('remediationId', 'unknown')
+            vuln_id = rem.get('vulnerabilityId', 'unknown')
+            pr_number = rem.get('pullRequestNumber')
+
+            if pr_number is None:
+                log(f"Remediation {remediation_id} (vuln {vuln_id}) has no PR number, skipping", is_warning=True)
+                continue
+
+            actual_state = github_ops.get_pr_actual_state(pr_number)
+
+            if actual_state is None:
+                log(f"Could not determine state for PR #{pr_number} (remediation {remediation_id}), skipping", is_warning=True)
+                continue
+
+            if actual_state == 'OPEN':
+                debug_log(f"Remediation {remediation_id} (vuln {vuln_id}, PR #{pr_number}): GitHub state is OPEN, no action needed")
+                continue
+
+            log(f"Reconciling remediation {remediation_id} (vuln {vuln_id}, PR #{pr_number}): GitHub state is {actual_state}, notifying backend")
+
+            if actual_state == 'MERGED':
+                contrast_api.notify_remediation_pr_merged(
+                    remediation_id=remediation_id,
+                    contrast_host=config.CONTRAST_HOST,
+                    contrast_org_id=config.CONTRAST_ORG_ID,
+                    contrast_app_id=config.CONTRAST_APP_ID,
+                    contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
+                    contrast_api_key=config.CONTRAST_API_KEY,
+                )
+            elif actual_state == 'CLOSED':
+                contrast_api.notify_remediation_pr_closed(
+                    remediation_id=remediation_id,
+                    contrast_host=config.CONTRAST_HOST,
+                    contrast_org_id=config.CONTRAST_ORG_ID,
+                    contrast_app_id=config.CONTRAST_APP_ID,
+                    contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
+                    contrast_api_key=config.CONTRAST_API_KEY,
+                )
+
+    except Exception as e:
+        log(f"Error during orphan PR reconciliation: {e}", is_warning=True)

--- a/src/smartfix/domains/workflow/pr_reconciliation.py
+++ b/src/smartfix/domains/workflow/pr_reconciliation.py
@@ -35,18 +35,22 @@ def reconcile_open_remediations(config, github_ops):
             contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
             contrast_api_key=config.CONTRAST_API_KEY,
         )
+    except Exception as e:
+        log(f"Error fetching open remediations: {e}", is_warning=True)
+        return
 
-        if not open_remediations:
-            log("No open remediations to reconcile")
-            return
+    if not open_remediations:
+        log("No open remediations to reconcile")
+        return
 
-        log(f"Found {len(open_remediations)} open remediation(s) to check")
+    log(f"Found {len(open_remediations)} open remediation(s) to check")
 
-        for rem in open_remediations:
-            remediation_id = rem.get('remediationId', 'unknown')
-            vuln_id = rem.get('vulnerabilityId', 'unknown')
-            pr_number = rem.get('pullRequestNumber')
+    for rem in open_remediations:
+        remediation_id = rem.get('remediationId', 'unknown')
+        vuln_id = rem.get('vulnerabilityId', 'unknown')
+        pr_number = rem.get('pullRequestNumber')
 
+        try:
             if pr_number is None:
                 log(f"Remediation {remediation_id} (vuln {vuln_id}) has no PR number, skipping", is_warning=True)
                 continue
@@ -81,6 +85,5 @@ def reconcile_open_remediations(config, github_ops):
                     contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
                     contrast_api_key=config.CONTRAST_API_KEY,
                 )
-
-    except Exception as e:
-        log(f"Error during orphan PR reconciliation: {e}", is_warning=True)
+        except Exception as e:
+            log(f"Error reconciling remediation {remediation_id} (vuln {vuln_id}, PR #{pr_number}): {e}", is_warning=True)

--- a/test/contrast_api/test_contrast_api_get_open_remediations.py
+++ b/test/contrast_api/test_contrast_api_get_open_remediations.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+import unittest
+import json
+from unittest.mock import patch, MagicMock
+import requests
+
+from src import contrast_api
+
+
+class TestContrastApiGetOpenRemediations(unittest.TestCase):
+    """Test cases for get_open_remediations in contrast_api module."""
+
+    def _call_get_open_remediations(self, **overrides):
+        defaults = {
+            'contrast_host': 'test.contrastsecurity.com',
+            'contrast_org_id': 'test-org-id',
+            'contrast_app_id': 'test-app-id',
+            'contrast_auth_key': 'test-auth-key',
+            'contrast_api_key': 'test-api-key',
+        }
+        return contrast_api.get_open_remediations(**{**defaults, **overrides})
+
+    @patch('src.contrast_api.requests.get')
+    def test_returns_list_on_200(self, mock_get):
+        """Test successful API call returns the list of open remediations."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                'remediationId': 'abc-123',
+                'vulnerabilityId': 'VULN-001',
+                'pullRequestNumber': 42,
+                'pullRequestUrl': 'https://github.com/org/repo/pull/42',
+            }
+        ]
+        mock_get.return_value = mock_response
+
+        result = self._call_get_open_remediations()
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['remediationId'], 'abc-123')
+
+    @patch('src.contrast_api.requests.get')
+    def test_returns_empty_list_on_200_with_no_remediations(self, mock_get):
+        """Test successful API call with empty response returns empty list."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        result = self._call_get_open_remediations()
+
+        self.assertEqual(result, [])
+
+    @patch('src.contrast_api.requests.get')
+    def test_returns_empty_list_on_non_200(self, mock_get):
+        """Test non-200 status code returns empty list."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_get.return_value = mock_response
+
+        result = self._call_get_open_remediations()
+
+        self.assertEqual(result, [])
+
+    @patch('src.contrast_api.requests.get')
+    def test_returns_empty_list_on_request_exception(self, mock_get):
+        """Test request exception returns empty list."""
+        mock_get.side_effect = requests.exceptions.ConnectionError("Connection refused")
+
+        result = self._call_get_open_remediations()
+
+        self.assertEqual(result, [])
+
+    @patch('src.contrast_api.requests.get')
+    def test_returns_empty_list_on_json_decode_error(self, mock_get):
+        """Test JSON decode error returns empty list."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = json.JSONDecodeError("msg", "doc", 0)
+        mock_get.return_value = mock_response
+
+        result = self._call_get_open_remediations()
+
+        self.assertEqual(result, [])
+
+    @patch('src.contrast_api.requests.get')
+    def test_returns_empty_list_on_unexpected_exception(self, mock_get):
+        """Test unexpected exception returns empty list."""
+        mock_get.side_effect = RuntimeError("unexpected")
+
+        result = self._call_get_open_remediations()
+
+        self.assertEqual(result, [])
+
+    @patch('src.contrast_api.requests.get')
+    def test_calls_correct_url(self, mock_get):
+        """Test that the correct API URL is called."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        self._call_get_open_remediations()
+
+        args, kwargs = mock_get.call_args
+        self.assertIn('/remediations/open', args[0])
+        self.assertIn('test-org-id', args[0])
+        self.assertIn('test-app-id', args[0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_get_pr_actual_state.py
+++ b/test/test_get_pr_actual_state.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+import unittest
+import json
+from unittest.mock import patch, MagicMock
+
+from src.github.github_operations import GitHubOperations
+
+
+class TestGetPrActualState(unittest.TestCase):
+    """Test cases for GitHubOperations.get_pr_actual_state."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        with patch('src.github.github_operations.get_config') as mock_config:
+            mock_config.return_value = MagicMock(
+                GITHUB_TOKEN="test-token",
+                GITHUB_REPOSITORY="test-owner/test-repo",
+                testing=True,
+                coding_agent=None
+            )
+            self.github_ops = GitHubOperations()
+
+    @patch('src.github.github_operations.run_command')
+    def test_returns_open_for_open_pr(self, mock_run_command):
+        """Test returns OPEN when PR is open."""
+        mock_run_command.return_value = json.dumps({'state': 'OPEN', 'mergedAt': None})
+        result = self.github_ops.get_pr_actual_state(42)
+        self.assertEqual(result, 'OPEN')
+
+    @patch('src.github.github_operations.run_command')
+    def test_returns_merged_for_closed_pr_with_merged_at(self, mock_run_command):
+        """Test returns MERGED when PR is closed with mergedAt set."""
+        mock_run_command.return_value = json.dumps({'state': 'CLOSED', 'mergedAt': '2025-03-01T12:00:00Z'})
+        result = self.github_ops.get_pr_actual_state(42)
+        self.assertEqual(result, 'MERGED')
+
+    @patch('src.github.github_operations.run_command')
+    def test_returns_closed_for_closed_pr_without_merged_at(self, mock_run_command):
+        """Test returns CLOSED when PR is closed without mergedAt."""
+        mock_run_command.return_value = json.dumps({'state': 'CLOSED', 'mergedAt': None})
+        result = self.github_ops.get_pr_actual_state(42)
+        self.assertEqual(result, 'CLOSED')
+
+    @patch('src.github.github_operations.run_command')
+    def test_returns_none_when_command_fails(self, mock_run_command):
+        """Test returns None when gh command fails."""
+        mock_run_command.return_value = None
+        result = self.github_ops.get_pr_actual_state(42)
+        self.assertIsNone(result)
+
+    @patch('src.github.github_operations.run_command')
+    def test_returns_none_on_invalid_json(self, mock_run_command):
+        """Test returns None when response is invalid JSON."""
+        mock_run_command.return_value = "not json"
+        result = self.github_ops.get_pr_actual_state(42)
+        self.assertIsNone(result)
+
+    @patch('src.github.github_operations.run_command')
+    def test_returns_none_on_unexpected_state(self, mock_run_command):
+        """Test returns None when PR state is unexpected."""
+        mock_run_command.return_value = json.dumps({'state': 'DRAFT', 'mergedAt': None})
+        result = self.github_ops.get_pr_actual_state(42)
+        self.assertIsNone(result)
+
+    @patch('src.github.github_operations.run_command')
+    def test_returns_none_on_exception(self, mock_run_command):
+        """Test returns None when an exception occurs."""
+        mock_run_command.side_effect = RuntimeError("unexpected error")
+        result = self.github_ops.get_pr_actual_state(42)
+        self.assertIsNone(result)
+
+    @patch('src.github.github_operations.run_command')
+    def test_passes_repo_flag(self, mock_run_command):
+        """Test that --repo flag is passed with the correct repository."""
+        mock_run_command.return_value = json.dumps({'state': 'OPEN', 'mergedAt': None})
+        self.github_ops.get_pr_actual_state(42)
+
+        args = mock_run_command.call_args[0][0]
+        self.assertIn('--repo', args)
+        repo_index = args.index('--repo')
+        self.assertEqual(args[repo_index + 1], 'test-owner/test-repo')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_get_pr_actual_state.py
+++ b/test/test_get_pr_actual_state.py
@@ -23,24 +23,31 @@ class TestGetPrActualState(unittest.TestCase):
 
     @patch('src.github.github_operations.run_command')
     def test_returns_open_for_open_pr(self, mock_run_command):
-        """Test returns OPEN when PR is open."""
-        mock_run_command.return_value = json.dumps({'state': 'OPEN', 'mergedAt': None})
+        """Test returns OPEN when PR state is OPEN."""
+        mock_run_command.return_value = json.dumps({'state': 'OPEN'})
         result = self.github_ops.get_pr_actual_state(42)
         self.assertEqual(result, 'OPEN')
 
     @patch('src.github.github_operations.run_command')
-    def test_returns_merged_for_closed_pr_with_merged_at(self, mock_run_command):
-        """Test returns MERGED when PR is closed with mergedAt set."""
-        mock_run_command.return_value = json.dumps({'state': 'CLOSED', 'mergedAt': '2025-03-01T12:00:00Z'})
+    def test_returns_merged_for_merged_pr(self, mock_run_command):
+        """Test returns MERGED when PR state is MERGED."""
+        mock_run_command.return_value = json.dumps({'state': 'MERGED'})
         result = self.github_ops.get_pr_actual_state(42)
         self.assertEqual(result, 'MERGED')
 
     @patch('src.github.github_operations.run_command')
-    def test_returns_closed_for_closed_pr_without_merged_at(self, mock_run_command):
-        """Test returns CLOSED when PR is closed without mergedAt."""
-        mock_run_command.return_value = json.dumps({'state': 'CLOSED', 'mergedAt': None})
+    def test_returns_closed_for_closed_pr(self, mock_run_command):
+        """Test returns CLOSED when PR state is CLOSED."""
+        mock_run_command.return_value = json.dumps({'state': 'CLOSED'})
         result = self.github_ops.get_pr_actual_state(42)
         self.assertEqual(result, 'CLOSED')
+
+    @patch('src.github.github_operations.run_command')
+    def test_handles_lowercase_state(self, mock_run_command):
+        """Test handles lowercase state values from gh CLI."""
+        mock_run_command.return_value = json.dumps({'state': 'merged'})
+        result = self.github_ops.get_pr_actual_state(42)
+        self.assertEqual(result, 'MERGED')
 
     @patch('src.github.github_operations.run_command')
     def test_returns_none_when_command_fails(self, mock_run_command):
@@ -59,7 +66,7 @@ class TestGetPrActualState(unittest.TestCase):
     @patch('src.github.github_operations.run_command')
     def test_returns_none_on_unexpected_state(self, mock_run_command):
         """Test returns None when PR state is unexpected."""
-        mock_run_command.return_value = json.dumps({'state': 'DRAFT', 'mergedAt': None})
+        mock_run_command.return_value = json.dumps({'state': 'DRAFT'})
         result = self.github_ops.get_pr_actual_state(42)
         self.assertIsNone(result)
 
@@ -73,7 +80,7 @@ class TestGetPrActualState(unittest.TestCase):
     @patch('src.github.github_operations.run_command')
     def test_passes_repo_flag(self, mock_run_command):
         """Test that --repo flag is passed with the correct repository."""
-        mock_run_command.return_value = json.dumps({'state': 'OPEN', 'mergedAt': None})
+        mock_run_command.return_value = json.dumps({'state': 'OPEN'})
         self.github_ops.get_pr_actual_state(42)
 
         args = mock_run_command.call_args[0][0]

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -64,6 +64,10 @@ class TestMain(unittest.TestCase):
         self.mock_api = self.api_patcher.start()
         self.mock_api.return_value = None
 
+        # Mock reconciliation to avoid real API calls
+        self.reconcile_patcher = patch('src.main.reconcile_open_remediations')
+        self.mock_reconcile = self.reconcile_patcher.start()
+
         # Mock requests for version checking
         self.requests_patcher = patch('src.version_check.requests.get')
         self.mock_requests_get = self.requests_patcher.start()
@@ -82,6 +86,7 @@ class TestMain(unittest.TestCase):
         self.subproc_patcher.stop()
         self.git_patcher.stop()
         self.api_patcher.stop()
+        self.reconcile_patcher.stop()
         self.requests_patcher.stop()
         self.exit_patcher.stop()
         reset_config()

--- a/test/test_reconcile_open_remediations.py
+++ b/test/test_reconcile_open_remediations.py
@@ -127,12 +127,29 @@ class TestReconcileOpenRemediations(unittest.TestCase):
         mock_contrast_api.notify_remediation_pr_closed.assert_called_once()
 
     @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
-    def test_exception_does_not_propagate(self, mock_contrast_api):
-        """Test that an exception during reconciliation does not propagate."""
+    def test_fetch_exception_does_not_propagate(self, mock_contrast_api):
+        """Test that an exception fetching open remediations does not propagate."""
         mock_contrast_api.get_open_remediations.side_effect = RuntimeError("unexpected")
 
         # Should not raise
         reconcile_open_remediations(self.mock_config, self.mock_github_ops)
+
+    @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
+    def test_per_remediation_exception_continues_to_next(self, mock_contrast_api):
+        """Test that an exception on one remediation doesn't skip the rest."""
+        mock_contrast_api.get_open_remediations.return_value = [
+            {'remediationId': 'rem-1', 'vulnerabilityId': 'vuln-1', 'pullRequestNumber': 10},
+            {'remediationId': 'rem-2', 'vulnerabilityId': 'vuln-2', 'pullRequestNumber': 20},
+        ]
+        # First call raises, second returns CLOSED
+        self.mock_github_ops.get_pr_actual_state.side_effect = [RuntimeError("boom"), 'CLOSED']
+
+        reconcile_open_remediations(self.mock_config, self.mock_github_ops)
+
+        # Both PRs should have been checked
+        self.assertEqual(self.mock_github_ops.get_pr_actual_state.call_count, 2)
+        # Second remediation should still have been reconciled
+        mock_contrast_api.notify_remediation_pr_closed.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/test/test_reconcile_open_remediations.py
+++ b/test/test_reconcile_open_remediations.py
@@ -3,7 +3,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
-from src.main import reconcile_open_remediations
+from src.smartfix.domains.workflow.pr_reconciliation import reconcile_open_remediations
 
 
 class TestReconcileOpenRemediations(unittest.TestCase):
@@ -20,7 +20,7 @@ class TestReconcileOpenRemediations(unittest.TestCase):
         )
         self.mock_github_ops = MagicMock()
 
-    @patch('src.main.contrast_api')
+    @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
     def test_empty_list_makes_no_github_calls(self, mock_contrast_api):
         """Test that an empty open remediations list results in no GitHub calls."""
         mock_contrast_api.get_open_remediations.return_value = []
@@ -31,7 +31,7 @@ class TestReconcileOpenRemediations(unittest.TestCase):
         mock_contrast_api.notify_remediation_pr_merged.assert_not_called()
         mock_contrast_api.notify_remediation_pr_closed.assert_not_called()
 
-    @patch('src.main.contrast_api')
+    @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
     def test_open_pr_no_action(self, mock_contrast_api):
         """Test that a remediation with an OPEN PR triggers no transition."""
         mock_contrast_api.get_open_remediations.return_value = [
@@ -44,7 +44,7 @@ class TestReconcileOpenRemediations(unittest.TestCase):
         mock_contrast_api.notify_remediation_pr_merged.assert_not_called()
         mock_contrast_api.notify_remediation_pr_closed.assert_not_called()
 
-    @patch('src.main.contrast_api')
+    @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
     def test_closed_pr_calls_notify_closed(self, mock_contrast_api):
         """Test that a CLOSED PR triggers notify_remediation_pr_closed."""
         mock_contrast_api.get_open_remediations.return_value = [
@@ -64,7 +64,7 @@ class TestReconcileOpenRemediations(unittest.TestCase):
         )
         mock_contrast_api.notify_remediation_pr_merged.assert_not_called()
 
-    @patch('src.main.contrast_api')
+    @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
     def test_merged_pr_calls_notify_merged(self, mock_contrast_api):
         """Test that a MERGED PR triggers notify_remediation_pr_merged."""
         mock_contrast_api.get_open_remediations.return_value = [
@@ -84,7 +84,7 @@ class TestReconcileOpenRemediations(unittest.TestCase):
         )
         mock_contrast_api.notify_remediation_pr_closed.assert_not_called()
 
-    @patch('src.main.contrast_api')
+    @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
     def test_null_pr_number_skips(self, mock_contrast_api):
         """Test that a remediation with null pullRequestNumber is skipped."""
         mock_contrast_api.get_open_remediations.return_value = [
@@ -97,7 +97,7 @@ class TestReconcileOpenRemediations(unittest.TestCase):
         mock_contrast_api.notify_remediation_pr_merged.assert_not_called()
         mock_contrast_api.notify_remediation_pr_closed.assert_not_called()
 
-    @patch('src.main.contrast_api')
+    @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
     def test_get_pr_actual_state_returns_none_skips(self, mock_contrast_api):
         """Test that None from get_pr_actual_state skips the remediation."""
         mock_contrast_api.get_open_remediations.return_value = [
@@ -110,7 +110,7 @@ class TestReconcileOpenRemediations(unittest.TestCase):
         mock_contrast_api.notify_remediation_pr_merged.assert_not_called()
         mock_contrast_api.notify_remediation_pr_closed.assert_not_called()
 
-    @patch('src.main.contrast_api')
+    @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
     def test_multiple_remediations_reconciled_independently(self, mock_contrast_api):
         """Test that multiple remediations are each reconciled independently."""
         mock_contrast_api.get_open_remediations.return_value = [
@@ -126,7 +126,7 @@ class TestReconcileOpenRemediations(unittest.TestCase):
         mock_contrast_api.notify_remediation_pr_merged.assert_called_once()
         mock_contrast_api.notify_remediation_pr_closed.assert_called_once()
 
-    @patch('src.main.contrast_api')
+    @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
     def test_exception_does_not_propagate(self, mock_contrast_api):
         """Test that an exception during reconciliation does not propagate."""
         mock_contrast_api.get_open_remediations.side_effect = RuntimeError("unexpected")

--- a/test/test_reconcile_open_remediations.py
+++ b/test/test_reconcile_open_remediations.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from src.main import reconcile_open_remediations
+
+
+class TestReconcileOpenRemediations(unittest.TestCase):
+    """Test cases for reconcile_open_remediations function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_config = MagicMock(
+            CONTRAST_HOST='test.contrastsecurity.com',
+            CONTRAST_ORG_ID='test-org-id',
+            CONTRAST_APP_ID='test-app-id',
+            CONTRAST_AUTHORIZATION_KEY='test-auth-key',
+            CONTRAST_API_KEY='test-api-key',
+        )
+        self.mock_github_ops = MagicMock()
+
+    @patch('src.main.contrast_api')
+    def test_empty_list_makes_no_github_calls(self, mock_contrast_api):
+        """Test that an empty open remediations list results in no GitHub calls."""
+        mock_contrast_api.get_open_remediations.return_value = []
+
+        reconcile_open_remediations(self.mock_config, self.mock_github_ops)
+
+        self.mock_github_ops.get_pr_actual_state.assert_not_called()
+        mock_contrast_api.notify_remediation_pr_merged.assert_not_called()
+        mock_contrast_api.notify_remediation_pr_closed.assert_not_called()
+
+    @patch('src.main.contrast_api')
+    def test_open_pr_no_action(self, mock_contrast_api):
+        """Test that a remediation with an OPEN PR triggers no transition."""
+        mock_contrast_api.get_open_remediations.return_value = [
+            {'remediationId': 'rem-1', 'vulnerabilityId': 'vuln-1', 'pullRequestNumber': 42}
+        ]
+        self.mock_github_ops.get_pr_actual_state.return_value = 'OPEN'
+
+        reconcile_open_remediations(self.mock_config, self.mock_github_ops)
+
+        mock_contrast_api.notify_remediation_pr_merged.assert_not_called()
+        mock_contrast_api.notify_remediation_pr_closed.assert_not_called()
+
+    @patch('src.main.contrast_api')
+    def test_closed_pr_calls_notify_closed(self, mock_contrast_api):
+        """Test that a CLOSED PR triggers notify_remediation_pr_closed."""
+        mock_contrast_api.get_open_remediations.return_value = [
+            {'remediationId': 'rem-1', 'vulnerabilityId': 'vuln-1', 'pullRequestNumber': 42}
+        ]
+        self.mock_github_ops.get_pr_actual_state.return_value = 'CLOSED'
+
+        reconcile_open_remediations(self.mock_config, self.mock_github_ops)
+
+        mock_contrast_api.notify_remediation_pr_closed.assert_called_once_with(
+            remediation_id='rem-1',
+            contrast_host='test.contrastsecurity.com',
+            contrast_org_id='test-org-id',
+            contrast_app_id='test-app-id',
+            contrast_auth_key='test-auth-key',
+            contrast_api_key='test-api-key',
+        )
+        mock_contrast_api.notify_remediation_pr_merged.assert_not_called()
+
+    @patch('src.main.contrast_api')
+    def test_merged_pr_calls_notify_merged(self, mock_contrast_api):
+        """Test that a MERGED PR triggers notify_remediation_pr_merged."""
+        mock_contrast_api.get_open_remediations.return_value = [
+            {'remediationId': 'rem-1', 'vulnerabilityId': 'vuln-1', 'pullRequestNumber': 42}
+        ]
+        self.mock_github_ops.get_pr_actual_state.return_value = 'MERGED'
+
+        reconcile_open_remediations(self.mock_config, self.mock_github_ops)
+
+        mock_contrast_api.notify_remediation_pr_merged.assert_called_once_with(
+            remediation_id='rem-1',
+            contrast_host='test.contrastsecurity.com',
+            contrast_org_id='test-org-id',
+            contrast_app_id='test-app-id',
+            contrast_auth_key='test-auth-key',
+            contrast_api_key='test-api-key',
+        )
+        mock_contrast_api.notify_remediation_pr_closed.assert_not_called()
+
+    @patch('src.main.contrast_api')
+    def test_null_pr_number_skips(self, mock_contrast_api):
+        """Test that a remediation with null pullRequestNumber is skipped."""
+        mock_contrast_api.get_open_remediations.return_value = [
+            {'remediationId': 'rem-1', 'vulnerabilityId': 'vuln-1', 'pullRequestNumber': None}
+        ]
+
+        reconcile_open_remediations(self.mock_config, self.mock_github_ops)
+
+        self.mock_github_ops.get_pr_actual_state.assert_not_called()
+        mock_contrast_api.notify_remediation_pr_merged.assert_not_called()
+        mock_contrast_api.notify_remediation_pr_closed.assert_not_called()
+
+    @patch('src.main.contrast_api')
+    def test_get_pr_actual_state_returns_none_skips(self, mock_contrast_api):
+        """Test that None from get_pr_actual_state skips the remediation."""
+        mock_contrast_api.get_open_remediations.return_value = [
+            {'remediationId': 'rem-1', 'vulnerabilityId': 'vuln-1', 'pullRequestNumber': 42}
+        ]
+        self.mock_github_ops.get_pr_actual_state.return_value = None
+
+        reconcile_open_remediations(self.mock_config, self.mock_github_ops)
+
+        mock_contrast_api.notify_remediation_pr_merged.assert_not_called()
+        mock_contrast_api.notify_remediation_pr_closed.assert_not_called()
+
+    @patch('src.main.contrast_api')
+    def test_multiple_remediations_reconciled_independently(self, mock_contrast_api):
+        """Test that multiple remediations are each reconciled independently."""
+        mock_contrast_api.get_open_remediations.return_value = [
+            {'remediationId': 'rem-1', 'vulnerabilityId': 'vuln-1', 'pullRequestNumber': 10},
+            {'remediationId': 'rem-2', 'vulnerabilityId': 'vuln-2', 'pullRequestNumber': 20},
+            {'remediationId': 'rem-3', 'vulnerabilityId': 'vuln-3', 'pullRequestNumber': 30},
+        ]
+        self.mock_github_ops.get_pr_actual_state.side_effect = ['OPEN', 'MERGED', 'CLOSED']
+
+        reconcile_open_remediations(self.mock_config, self.mock_github_ops)
+
+        self.assertEqual(self.mock_github_ops.get_pr_actual_state.call_count, 3)
+        mock_contrast_api.notify_remediation_pr_merged.assert_called_once()
+        mock_contrast_api.notify_remediation_pr_closed.assert_called_once()
+
+    @patch('src.main.contrast_api')
+    def test_exception_does_not_propagate(self, mock_contrast_api):
+        """Test that an exception during reconciliation does not propagate."""
+        mock_contrast_api.get_open_remediations.side_effect = RuntimeError("unexpected")
+
+        # Should not raise
+        reconcile_open_remediations(self.mock_config, self.mock_github_ops)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Jira
https://contrast.atlassian.net/browse/AIML-539

## Summary
- Adds reconciliation step before PR limit check that detects and fixes orphaned remediations
- New `get_open_remediations()` in `contrast_api.py` - calls backend endpoint, returns `[]` on any error
- New `get_pr_actual_state()` in `GitHubOperations` - checks actual GitHub PR state via `gh pr view`
- New `reconcile_open_remediations()` in `main.py` - compares backend state with GitHub, calls appropriate transition
- Best-effort: all errors are logged as warnings, never block the main flow

## Context
When GitHub drops webhook events for SmartFix PR close/merge, remediation records get stuck in OPEN status, blocking new fixes and counting against MAX_OPEN_PRS. This reconciliation runs before the PR limit check so freed slots are reflected immediately.

Depends on AIML-538 (backend endpoint in aiml-services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)