### PR TITLE
AIML-574: Auto-regenerate requirements.lock when dependabot bumps requirements.txt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
           cache: 'pip' # Enable built-in pip caching

--- a/.github/workflows/dependabot-lock-sync.yml
+++ b/.github/workflows/dependabot-lock-sync.yml
@@ -42,12 +42,17 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
       - name: Install uv
         shell: bash
         run: |
           echo ""
           echo "📦 Installing uv package manager..."
-          pip install uv==0.10.2 > /tmp/uv-install.log || (cat /tmp/uv-install.log && exit 1)
+          python -m pip install uv==0.10.2 > /tmp/uv-install.log || (cat /tmp/uv-install.log && exit 1)
           echo "✅ uv installed successfully"
 
       - name: Regenerate requirements.lock

--- a/.github/workflows/dependabot-lock-sync.yml
+++ b/.github/workflows/dependabot-lock-sync.yml
@@ -45,12 +45,9 @@ jobs:
           python-version: '3.13'
 
       - name: Install uv
-        shell: bash
-        run: |
-          echo ""
-          echo "📦 Installing uv package manager..."
-          python -m pip install uv==0.10.2 > /tmp/uv-install.log || (cat /tmp/uv-install.log && exit 1)
-          echo "✅ uv installed successfully"
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3
+        with:
+          version: "0.10.2"
 
       - name: Regenerate requirements.lock
         run: uv pip compile src/requirements.txt --no-cache -o src/requirements.lock

--- a/.github/workflows/dependabot-lock-sync.yml
+++ b/.github/workflows/dependabot-lock-sync.yml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync-lock-file:

--- a/.github/workflows/dependabot-lock-sync.yml
+++ b/.github/workflows/dependabot-lock-sync.yml
@@ -17,9 +17,6 @@
 # #L%
 #
 
-# When dependabot opens a pip PR that modifies src/requirements.txt, regenerate
-# src/requirements.lock and commit the result back to the dependabot branch.
-
 name: Dependabot Lock File Sync
 
 on:

--- a/.github/workflows/dependabot-lock-sync.yml
+++ b/.github/workflows/dependabot-lock-sync.yml
@@ -43,7 +43,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        shell: bash
+        run: |
+          echo ""
+          echo "📦 Installing uv package manager..."
+          pip install uv==0.10.2 > /tmp/uv-install.log || (cat /tmp/uv-install.log && exit 1)
+          echo "✅ uv installed successfully"
 
       - name: Regenerate requirements.lock
         run: uv pip compile src/requirements.txt --no-cache -o src/requirements.lock

--- a/.github/workflows/dependabot-lock-sync.yml
+++ b/.github/workflows/dependabot-lock-sync.yml
@@ -34,7 +34,7 @@ jobs:
   sync-lock-file:
     name: Regenerate requirements.lock
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4

--- a/.github/workflows/dependabot-lock-sync.yml
+++ b/.github/workflows/dependabot-lock-sync.yml
@@ -1,0 +1,61 @@
+#-
+# #%L
+# Contrast AI SmartFix
+# %%
+# Copyright (C) 2026 Contrast Security, Inc.
+# %%
+# Contact: support@contrastsecurity.com
+# License: Commercial
+# NOTICE: This Software and the patented inventions embodied within may only be
+# used as part of Contrast Security's commercial offerings. Even though it is
+# made available through public repositories, use of this Software is subject to
+# the applicable End User Licensing Agreement found at
+# https://www.contrastsecurity.com/enduser-terms-0317a or as otherwise agreed
+# between Contrast Security and the End User. The Software may not be reverse
+# engineered, modified, repackaged, sold, redistributed or otherwise used in a
+# way not consistent with the End User License Agreement.
+# #L%
+#
+
+# When dependabot opens a pip PR that modifies src/requirements.txt, regenerate
+# src/requirements.lock and commit the result back to the dependabot branch.
+
+name: Dependabot Lock File Sync
+
+on:
+  pull_request:
+    paths:
+      - 'src/requirements.txt'
+
+permissions:
+  contents: write
+
+jobs:
+  sync-lock-file:
+    name: Regenerate requirements.lock
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Regenerate requirements.lock
+        run: uv pip compile src/requirements.txt --no-cache -o src/requirements.lock
+
+      - name: Commit updated lock file
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/requirements.lock
+          if git diff --cached --quiet; then
+            echo "requirements.lock unchanged, nothing to commit"
+          else
+            git commit -m "AIML-574: Regenerate requirements.lock for dependabot bump"
+            git push
+          fi

--- a/.github/workflows/dependabot-lock-sync.yml
+++ b/.github/workflows/dependabot-lock-sync.yml
@@ -37,13 +37,13 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 

--- a/action.yml
+++ b/action.yml
@@ -194,7 +194,7 @@ runs:
     # Checkout with reduced verbosity (only if not already checked out)
     - name: Checkout repository
       if: steps.check_git.outputs.already_checked_out != 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
@@ -210,7 +210,7 @@ runs:
 
     # Reduce Python setup verbosity
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.13'
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dependabot-lock-sync.yml` — triggers on pull requests from `dependabot[bot]` that modify `src/requirements.txt`
- Installs `uv`, runs `uv pip compile src/requirements.txt --no-cache -o src/requirements.lock`, and commits the updated lock file back to the dependabot branch

## Jira

[AIML-574](https://contrast.atlassian.net/browse/AIML-574)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIML-574]: https://contrast.atlassian.net/browse/AIML-574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ