### PR TITLE
AIML-577: Add 7-day cooldown to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,12 @@ updates:
     directory: "/src"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- Adds native `cooldown: default-days: 7` to both `pip` and `github-actions` ecosystems in `.github/dependabot.yml`

This uses GitHub's built-in Dependabot cooldown feature (available since July 2025) to delay routine version bump PRs by 7 days, reducing PR noise while still allowing security updates to come through immediately.

Jira: https://contrast.atlassian.net/browse/AIML-577

## Test plan

- [ ] Verify Dependabot PRs for routine version bumps are delayed ~7 days after a new version is published
- [ ] Verify security-related Dependabot PRs still arrive promptly (cooldown does not apply to security updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)