### PR TITLE
SS-107, SS-110, SS-111, and SS-112 remove redundant otel key

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -56,7 +56,7 @@ class Config:
         self.testing = testing
 
         # --- Preset ---
-        self.VERSION = "v1.0.11"
+        self.VERSION = "v1.0.15"
         self.USER_AGENT = f"contrast-smart-fix {self.VERSION}"
 
         # --- Paths (initialized early for use in command detection) ---

--- a/src/main.py
+++ b/src/main.py
@@ -341,11 +341,6 @@ def _main_impl(vuln_count):  # noqa: C901
             op_span.set_attribute("contrast.finding.source", "runtime")
             op_span.set_attribute("contrast.finding.rule_id", vulnerability.rule_name)
             op_span.set_attribute("contrast.smartfix.coding_agent", config.CODING_AGENT.lower())
-            if config.CODING_AGENT == CodingAgents.SMARTFIX.name:
-                op_span.set_attribute(
-                    "contrast.smartfix.llm_provider",
-                    "contrast" if config.USE_CONTRAST_LLM else "byollm",
-                )
 
             try:
                 context = RemediationContext(

--- a/src/smartfix/domains/telemetry/otel_provider.py
+++ b/src/smartfix/domains/telemetry/otel_provider.py
@@ -76,7 +76,6 @@ def initialize_otel(config) -> None:
         resource = Resource.create({
             SERVICE_NAME: "smartfix",
             "service.version": config.VERSION,
-            "contrast.org_id": config.CONTRAST_ORG_ID,
             "vcs.repository.url.full": f"{config.GITHUB_SERVER_URL}/{config.GITHUB_REPOSITORY}",
             "vcs.repository.name": config.GITHUB_REPOSITORY.split("/")[-1],
             "vcs.owner.name": config.GITHUB_REPOSITORY.split("/")[0],

--- a/src/smartfix/extensions/smartfix_litellm.py
+++ b/src/smartfix/extensions/smartfix_litellm.py
@@ -443,7 +443,7 @@ class SmartFixLiteLlm(LiteLlm):
                 llm_span.set_attribute("gen_ai.system", _derive_system(model))
                 llm_span.set_attribute("gen_ai.request.model", model)
                 llm_span.set_attribute("gen_ai.operation.name", "chat")
-                llm_span.set_attribute("gen_ai.retry.attempt", attempt)
+                llm_span.set_attribute("contrast.smartfix.retry_attempt", attempt)
                 max_tokens = completion_args.get("max_tokens")
                 if max_tokens is not None:
                     llm_span.set_attribute("gen_ai.request.max_tokens", max_tokens)
@@ -458,9 +458,9 @@ class SmartFixLiteLlm(LiteLlm):
                     llm_span.set_attribute("gen_ai.usage.input_tokens", input_tokens)
                     llm_span.set_attribute("gen_ai.usage.output_tokens", output_tokens)
                     if cache_read:
-                        llm_span.set_attribute("gen_ai.usage.cache_read_input_tokens", cache_read)
+                        llm_span.set_attribute("gen_ai.usage.cache_read.input_tokens", cache_read)
                     if cache_write:
-                        llm_span.set_attribute("gen_ai.usage.cache_creation_input_tokens", cache_write)
+                        llm_span.set_attribute("gen_ai.usage.cache_creation.input_tokens", cache_write)
 
                     return response
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -323,7 +323,6 @@ class TestMain(unittest.TestCase):
         self.assertEqual(attrs.get("contrast.finding.source"), "runtime")
         self.assertEqual(attrs.get("contrast.finding.rule_id"), "sql-injection")
         self.assertEqual(attrs.get("contrast.smartfix.coding_agent"), "smartfix")
-        self.assertEqual(attrs.get("contrast.smartfix.llm_provider"), "byollm")
 
     def test_fix_vulnerability_span_response_attributes_no_changes(self):
         """fix-vulnerability span has fix_applied=False and pr_created=False when no code changes."""

--- a/test/test_otel_provider.py
+++ b/test/test_otel_provider.py
@@ -86,7 +86,6 @@ class TestOtelProvider(unittest.TestCase):
         attrs = otel_provider._tracer_provider.resource.attributes
         self.assertEqual(attrs["service.name"], "smartfix")
         self.assertEqual(attrs["service.version"], cfg.VERSION)
-        self.assertEqual(attrs["contrast.org_id"], cfg.CONTRAST_ORG_ID)
         self.assertEqual(
             attrs["vcs.repository.url.full"],
             f"{cfg.GITHUB_SERVER_URL}/{cfg.GITHUB_REPOSITORY}",

--- a/test/test_otel_spans.py
+++ b/test/test_otel_spans.py
@@ -275,10 +275,10 @@ class TestLlmCallSpan(unittest.TestCase):
         import src.smartfix.domains.telemetry.otel_provider as otel_provider
         model = "test-retry-model"
         with otel_provider.start_span(f"chat {model}") as span:
-            span.set_attribute("gen_ai.retry.attempt", 0)
+            span.set_attribute("contrast.smartfix.retry_attempt", 0)
 
         spans = _spans_named(self.exporter, f"chat {model}")
-        self.assertEqual(spans[0].attributes["gen_ai.retry.attempt"], 0)
+        self.assertEqual(spans[0].attributes["contrast.smartfix.retry_attempt"], 0)
 
     def test_llm_span_has_usage_input_and_output_tokens(self):
         import src.smartfix.domains.telemetry.otel_provider as otel_provider

--- a/test/test_otel_spans.py
+++ b/test/test_otel_spans.py
@@ -271,7 +271,7 @@ class TestLlmCallSpan(unittest.TestCase):
         spans = _spans_named(self.exporter, f"chat {model}")
         self.assertEqual(spans[0].attributes["gen_ai.operation.name"], "chat")
 
-    def test_llm_span_has_gen_ai_retry_attempt(self):
+    def test_llm_span_has_contrast_smartfix_retry_attempt(self):
         import src.smartfix.domains.telemetry.otel_provider as otel_provider
         model = "test-retry-model"
         with otel_provider.start_span(f"chat {model}") as span:

--- a/test/test_smartfix_litellm.py
+++ b/test/test_smartfix_litellm.py
@@ -506,7 +506,7 @@ class TestCallLlmWithRetryOtelSpan(unittest.TestCase):
 
     @patch('src.smartfix.extensions.smartfix_litellm.debug_log')
     def test_span_has_request_attributes(self, _mock_log):
-        """gen_ai.system, gen_ai.request.model, gen_ai.operation.name, gen_ai.retry.attempt are set."""
+        """gen_ai.system, gen_ai.request.model, gen_ai.operation.name, contrast.smartfix.retry_attempt are set."""
         mock_response = self._make_mock_response()
         self.model.llm_client = MagicMock()
         self.model.llm_client.acompletion = AsyncMock(return_value=mock_response)
@@ -529,7 +529,7 @@ class TestCallLlmWithRetryOtelSpan(unittest.TestCase):
         self.assertEqual(attrs.get("gen_ai.system"), "anthropic")
         self.assertEqual(attrs.get("gen_ai.request.model"), "anthropic/claude-3-opus")
         self.assertEqual(attrs.get("gen_ai.operation.name"), "chat")
-        self.assertEqual(attrs.get("gen_ai.retry.attempt"), 0)
+        self.assertEqual(attrs.get("contrast.smartfix.retry_attempt"), 0)
 
     @patch('src.smartfix.extensions.smartfix_litellm.debug_log')
     def test_span_has_response_model_attribute(self, _mock_log):

--- a/tests/otel/verify_spans.py
+++ b/tests/otel/verify_spans.py
@@ -243,8 +243,8 @@ def verify_llm_span(span: Span, parent_id: str) -> Checker:
             str(span.attr("gen_ai.request.model")))
     c.check(span.attr("gen_ai.operation.name") == "chat",
             "gen_ai.operation.name == 'chat'", str(span.attr("gen_ai.operation.name")))
-    c.check(span.has_attr("gen_ai.retry.attempt"), "Has gen_ai.retry.attempt",
-            str(span.attr("gen_ai.retry.attempt")))
+    c.check(span.has_attr("contrast.smartfix.retry_attempt"), "Has contrast.smartfix.retry_attempt",
+            str(span.attr("contrast.smartfix.retry_attempt")))
     c.check(span.has_attr("gen_ai.usage.input_tokens"), "Has gen_ai.usage.input_tokens",
             str(span.attr("gen_ai.usage.input_tokens")))
     c.check(span.has_attr("gen_ai.usage.output_tokens"), "Has gen_ai.usage.output_tokens",
@@ -319,7 +319,7 @@ def verify_trace(spans: List[Span]) -> bool:
         else:
             print(f"\n    ── chat spans ({len(llm_spans)} LLM calls) ──")
             for j, llm in enumerate(llm_spans):
-                attempt = llm.attr("gen_ai.retry.attempt", "?")
+                attempt = llm.attr("contrast.smartfix.retry_attempt", "?")
                 model = llm.attr("gen_ai.request.model", llm.name)
                 print(f"\n      [{j+1}] {llm.name}  attempt={attempt}  model={model}")
                 c = verify_llm_span(llm, op.span_id)


### PR DESCRIPTION
**Ticket**
http://contrast.atlassian.net/browse/SS-107
https://contrast.atlassian.net/browse/SS-110
https://contrast.atlassian.net/browse/SS-111
https://contrast.atlassian.net/browse/SS-112

**Description**
Per Shane's request:
- removes a redundant "org_id" OTel key.  
- remove `llm_provider` attribute
- rename `retry_attempt`
- rename `cache_read_input_tokens` and `cache_creation_input_tokens` keys

Also updated the internal version number b/c I noticed that I forgot to do that in the last release.


**Evidence from Grafana**
<img width="840" height="668" alt="Screenshot 2026-04-13 at 3 11 58 PM" src="https://github.com/user-attachments/assets/174c5236-267e-4e92-8899-038fcb7ae1c6" />
<img width="872" height="591" alt="Screenshot 2026-04-13 at 3 12 06 PM" src="https://github.com/user-attachments/assets/45da0f5c-9af4-4708-a433-71c85ce06d13" />
<img width="841" height="479" alt="Screenshot 2026-04-13 at 3 11 38 PM" src="https://github.com/user-attachments/assets/72ee04d1-347e-4d22-8072-4167427c8be1" />

