### PR TITLE
AIML-670: Default OTel endpoint and headers to Contrast backend

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -395,17 +395,14 @@ runs:
         echo "✅ Environment setup complete"
         echo ""
 
-    # Set default OTel endpoint and headers to the Contrast backend if not already configured.
-    # Users can override by setting OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_HEADERS
-    # in their workflow env before invoking this action.
+    # Set default OTel endpoint to the Contrast backend if not already configured.
+    # Users can override by setting OTEL_EXPORTER_OTLP_ENDPOINT in their workflow env.
+    # Auth headers are always derived from Contrast credentials in code — not configurable here.
     - name: Set OTel defaults
       shell: bash
       run: |
         if [ -z "${OTEL_EXPORTER_OTLP_ENDPOINT}" ]; then
           echo "OTEL_EXPORTER_OTLP_ENDPOINT=https://${{ inputs.contrast_host }}/aiml/otel" >> $GITHUB_ENV
-        fi
-        if [ -z "${OTEL_EXPORTER_OTLP_HEADERS}" ]; then
-          echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=${{ inputs.contrast_authorization_key }},API-Key=${{ inputs.contrast_api_key }}" >> $GITHUB_ENV
         fi
 
     # Run the main SmartFix analysis script with clear start/end markers - cross-platform compatible

--- a/action.yml
+++ b/action.yml
@@ -395,6 +395,19 @@ runs:
         echo "✅ Environment setup complete"
         echo ""
 
+    # Set default OTel endpoint and headers to the Contrast backend if not already configured.
+    # Users can override by setting OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_HEADERS
+    # in their workflow env before invoking this action.
+    - name: Set OTel defaults
+      shell: bash
+      run: |
+        if [ -z "${OTEL_EXPORTER_OTLP_ENDPOINT}" ]; then
+          echo "OTEL_EXPORTER_OTLP_ENDPOINT=https://${{ inputs.contrast_host }}/aiml/otel" >> $GITHUB_ENV
+        fi
+        if [ -z "${OTEL_EXPORTER_OTLP_HEADERS}" ]; then
+          echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=${{ inputs.contrast_authorization_key }},API-Key=${{ inputs.contrast_api_key }}" >> $GITHUB_ENV
+        fi
+
     # Run the main SmartFix analysis script with clear start/end markers - cross-platform compatible
     - name: Run Contrast AI SmartFix
       shell: bash

--- a/src/smartfix/domains/telemetry/otel_provider.py
+++ b/src/smartfix/domains/telemetry/otel_provider.py
@@ -24,10 +24,12 @@ Handles TracerProvider and MeterProvider lifecycle for SmartFix.
 
 Design notes:
 - Enabled iff OTEL_EXPORTER_OTLP_ENDPOINT (or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is set.
+- Auth headers (Authorization, API-Key) are always derived from Contrast config credentials
+  and are never overridable via environment variables. This keeps auth coupled to the Contrast
+  service account and prevents accidental misconfiguration.
 - Both OTLPSpanExporter and OTLPMetricExporter are constructed with explicit endpoint and
-  headers parsed from env vars. This ensures auth headers are used even when the action runs
+  headers passed directly. This ensures auth headers are used even when the action runs
   as a GitHub composite action, where step-level env vars may not propagate automatically.
-- Headers are parsed from OTEL_EXPORTER_OTLP_HEADERS (comma-separated key=value pairs).
 - Header keys (not values) are logged to confirm auth headers are present.
 - Traces export to <base_endpoint>/v1/traces, metrics to <base_endpoint>/v1/metrics.
 - When disabled, the default SDK NoOpTracerProvider remains — all span and metric calls are
@@ -65,23 +67,15 @@ _meter_provider = None
 _shutdown_called = False
 
 
-def _parse_headers(headers_raw: str) -> dict:
-    """Parse OTEL_EXPORTER_OTLP_HEADERS value (comma-separated key=value pairs) into a dict."""
-    headers = {}
-    if headers_raw:
-        for part in headers_raw.split(","):
-            if "=" in part:
-                k, v = part.split("=", 1)
-                headers[k.strip()] = v.strip()
-    return headers
-
-
 def initialize_otel(config) -> None:
     """
     Initialise the OTel TracerProvider and MeterProvider if an OTLP endpoint is configured.
 
     Reads OTEL_EXPORTER_OTLP_ENDPOINT (or the traces-specific variant). If neither
     is set, returns immediately leaving the SDK default NoOpTracerProvider in place.
+
+    Auth headers are always built from config.CONTRAST_AUTHORIZATION_KEY and
+    config.CONTRAST_API_KEY — they are not read from any environment variable.
 
     Also sets OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT based on
     ENABLE_FULL_TELEMETRY so that instrumentation libraries (LiteLLM, ADK) do not
@@ -90,7 +84,7 @@ def initialize_otel(config) -> None:
 
     Args:
         config: Config object with VERSION, CONTRAST_ORG_ID, GITHUB_SERVER_URL,
-                GITHUB_REPOSITORY attributes.
+                GITHUB_REPOSITORY, CONTRAST_AUTHORIZATION_KEY, CONTRAST_API_KEY attributes.
     """
     global _tracer_provider, _meter_provider, _shutdown_called
     _shutdown_called = False
@@ -120,11 +114,14 @@ def initialize_otel(config) -> None:
             "vcs.provider.name": "github",
         })
 
-        # Parse headers explicitly from env so they're passed directly to the exporters.
-        # This is necessary when running as a GitHub composite action where step-level
-        # env vars (OTEL_EXPORTER_OTLP_HEADERS) may not propagate automatically.
-        headers = _parse_headers(os.environ.get("OTEL_EXPORTER_OTLP_HEADERS", ""))
-        exporter_kwargs = {"headers": headers} if headers else {}
+        # Auth headers are always derived from Contrast credentials — not from any env var.
+        # This keeps telemetry auth coupled to the Contrast service account and ensures
+        # they propagate correctly within the GitHub composite action environment.
+        headers = {
+            "Authorization": config.CONTRAST_AUTHORIZATION_KEY,
+            "API-Key": config.CONTRAST_API_KEY,
+        }
+        exporter_kwargs = {"headers": headers}
 
         # When using OTEL_EXPORTER_OTLP_ENDPOINT (base URL), append signal-specific paths.
         # When using OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, use as-is (already the full URL).

--- a/test/test_otel_provider.py
+++ b/test/test_otel_provider.py
@@ -37,6 +37,8 @@ def _config(**kwargs):
         GITHUB_REPOSITORY="Contrast-Security-OSS/contrast-ai-smartfix-action",
         GITHUB_RUN_ID="12345678",
         ENABLE_FULL_TELEMETRY=True,
+        CONTRAST_AUTHORIZATION_KEY="test-auth-key",
+        CONTRAST_API_KEY="test-api-key",
     )
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -127,6 +129,21 @@ class TestOtelProvider(unittest.TestCase):
             mock_metric_cls.call_args.kwargs["endpoint"],
             "http://localhost:4318/v1/metrics",
         )
+
+    @patch("src.smartfix.domains.telemetry.otel_provider.OTLPMetricExporter")
+    @patch("src.smartfix.domains.telemetry.otel_provider.OTLPSpanExporter")
+    def test_auth_headers_come_from_config_not_env(self, mock_span_cls, mock_metric_cls):
+        """Auth headers are always derived from config credentials, never from env vars."""
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
+        mock_span_cls.return_value = MagicMock()
+        mock_metric_cls.return_value = MagicMock()
+        cfg = _config(CONTRAST_AUTHORIZATION_KEY="my-auth", CONTRAST_API_KEY="my-api")
+
+        otel_provider.initialize_otel(cfg)
+
+        expected_headers = {"Authorization": "my-auth", "API-Key": "my-api"}
+        self.assertEqual(mock_span_cls.call_args.kwargs["headers"], expected_headers)
+        self.assertEqual(mock_metric_cls.call_args.kwargs["headers"], expected_headers)
 
     def test_initialize_is_noop_when_endpoint_absent(self):
         """initialize_otel() does nothing when OTEL_EXPORTER_OTLP_ENDPOINT is not set."""


### PR DESCRIPTION
## Summary

- Adds a `Set OTel defaults` step in `action.yml` that defaults `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` to the Contrast backend OTel endpoint if not already set by the caller
- Uses the existing `contrast_host`, `contrast_authorization_key`, and `contrast_api_key` inputs to construct the defaults
- Users can override by setting these env vars in their workflow before invoking this action

Jira: [AIML-670](https://contrast.atlassian.net/browse/AIML-670)

[AIML-670]: https://contrast.atlassian.net/browse/AIML-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ