### PR TITLE
TS-38988: Fix CODEOWNERS last-match-wins semantics and Set[str] type annotations

### DIFF
--- a/src/github/github_operations.py
+++ b/src/github/github_operations.py
@@ -20,7 +20,7 @@
 import os
 import json
 import re
-from typing import List, Optional, TypedDict
+from typing import List, Optional, Set, TypedDict
 from src.utils import run_command, debug_log, log, error_exit, CommandExecutionError
 from src.smartfix.shared.failure_categories import FailureCategory
 from src.config import get_config
@@ -1548,7 +1548,7 @@ class GitHubOperations(ScmOperations):
             log(f"Could not retrieve changed files for PR #{pr_number}: {e}", is_warning=True)
             return []
 
-    def add_reviewers_to_pr(self, pr_number: int, reviewers: set) -> bool:
+    def add_reviewers_to_pr(self, pr_number: int, reviewers: Set[str]) -> bool:
         """Request review from the given set of GitHub handles on a pull request.
 
         Uses `gh pr edit --add-reviewer` to assign reviewers.

--- a/src/smartfix/domains/scm/codeowners.py
+++ b/src/smartfix/domains/scm/codeowners.py
@@ -51,9 +51,10 @@ def find_codeowners_file(repo_root: Path) -> Optional[Path]:
 def get_reviewers_for_files(changed_files: List[str], repo_root: Path) -> Set[str]:
     """Return the set of reviewer handles from CODEOWNERS that match any changed file.
 
-    Parses the CODEOWNERS file (if present) and returns all owners whose patterns
-    match at least one of the changed files. The @ prefix is stripped from each
-    handle; team refs (e.g. org/team) are kept intact.
+    Parses the CODEOWNERS file (if present) and follows gitignore-style last-match-wins
+    semantics: for each changed file the last matching pattern's owners apply. Owners are
+    then unioned across all changed files.  The @ prefix is stripped from each handle;
+    team refs (e.g. org/team) are kept intact.
 
     Returns an empty set when no CODEOWNERS file exists or no patterns match.
     """
@@ -65,9 +66,12 @@ def get_reviewers_for_files(changed_files: List[str], repo_root: Path) -> Set[st
     reviewers: Set[str] = set()
 
     for changed_file in changed_files:
+        last_match: Optional[List[str]] = None
         for pattern, owners in entries:
             if _matches(pattern, changed_file):
-                reviewers.update(owners)
+                last_match = owners
+        if last_match:
+            reviewers.update(last_match)
 
     return reviewers
 

--- a/src/smartfix/domains/scm/scm_operations.py
+++ b/src/smartfix/domains/scm/scm_operations.py
@@ -6,7 +6,7 @@ for implementing SCM platform-specific operations (GitHub, GitLab, BitBucket, et
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 
 class ScmOperations(ABC):
@@ -331,13 +331,13 @@ class ScmOperations(ABC):
         pass
 
     @abstractmethod
-    def add_reviewers_to_pr(self, pr_number: int, reviewers: set) -> bool:
+    def add_reviewers_to_pr(self, pr_number: int, reviewers: Set[str]) -> bool:
         """
         Requests review from the given handles on a pull request.
 
         Args:
             pr_number (int): The PR number
-            reviewers (set): GitHub/SCM handles to request review from
+            reviewers (Set[str]): GitHub/SCM handles to request review from
 
         Returns:
             bool: True on success or empty reviewers, False on error

--- a/test/test_codeowners.py
+++ b/test/test_codeowners.py
@@ -221,14 +221,23 @@ class TestGetReviewersForFiles(unittest.TestCase):
 
         self.assertEqual(result, {"default-owner"})
 
-    def test_later_pattern_adds_owners_for_matching_files(self):
-        """All matching patterns contribute owners (union semantics)."""
+    def test_later_pattern_wins_for_same_file(self):
+        """Last matching pattern wins per file (gitignore-style semantics)."""
         self._write_codeowners("* @default-owner\n*.py @python-owner\n")
 
         result = get_reviewers_for_files(["src/main.py"], self.repo_root)
 
         self.assertIn("python-owner", result)
-        self.assertIn("default-owner", result)
+        self.assertNotIn("default-owner", result)
+
+    def test_last_match_per_file_unioned_across_files(self):
+        """Last match per file, owners unioned across all changed files."""
+        self._write_codeowners("* @default-owner\n*.py @python-owner\n")
+
+        result = get_reviewers_for_files(["src/main.py", "README.md"], self.repo_root)
+
+        self.assertIn("python-owner", result)   # last match for .py file
+        self.assertIn("default-owner", result)  # last (and only) match for .md file
 
     def test_no_duplicate_owners(self):
         """Same owner listed in multiple matching patterns appears only once."""


### PR DESCRIPTION
## Summary

Follow-up to #154. Two corrections to the CODEOWNERS reviewer logic that weren't caught before the original PR merged:

- **Last-match-wins semantics**: The initial implementation unioned owners from _all_ matching patterns for a given file. CODEOWNERS actually follows gitignore-style semantics: for each changed file, only the **last** matching pattern's owners apply. Owners are then unioned across all changed files. The test `test_later_pattern_adds_owners_for_matching_files` has been renamed and corrected to assert this behavior.

- **Type annotation tightening**: `reviewers: set` → `reviewers: Set[str]` in both `ScmOperations` and `GitHubOperations`, with `Set` imported from `typing`.

## Test plan

- [x] `test_later_pattern_wins_for_same_file` — asserts last match wins per file
- [x] `test_last_match_per_file_unioned_across_files` — asserts owners are unioned across files with different last matches
- [x] All 892 tests pass