### PR TITLE
AIML-141: cleanup smartfix vuln & remediation labels on PR close/merge

### DIFF
--- a/src/closed_handler.py
+++ b/src/closed_handler.py
@@ -169,6 +169,34 @@ def _notify_remediation_service(remediation_id: str, pr_number: int = None):
         log(f"Failed to notify Remediation service about closed PR for remediation {remediation_id}.", is_error=True)
 
 
+def _cleanup_smartfix_labels(pull_request: dict, labels: list) -> None:
+    """Best-effort: remove SmartFix-managed labels from the PR (and linked issue
+    in the external-agent flow). Never raises — failures are logged and the
+    handler completes regardless."""
+    try:
+        pr_number = pull_request.get("number")
+        if not pr_number:
+            debug_log("No PR number in event payload; skipping label cleanup.")
+            return
+
+        github_ops = GitHubOperations()
+        smartfix_labels = github_ops.filter_smartfix_labels(labels)
+        if not smartfix_labels:
+            debug_log("No SmartFix labels on PR; skipping label cleanup.")
+            return
+
+        debug_log(f"Cleaning up SmartFix labels: {smartfix_labels}")
+        github_ops.remove_labels_from_pr(pr_number, smartfix_labels)
+
+        branch_name = pull_request.get("head", {}).get("ref") or ""
+        if branch_name.startswith(("claude/issue-", "copilot/fix")):
+            issue_number = github_ops.extract_issue_number_from_branch(branch_name)
+            if issue_number:
+                github_ops.remove_labels_from_issue(issue_number, smartfix_labels)
+    except Exception as e:
+        log(f"Best-effort SmartFix label cleanup raised: {e}", is_error=True)
+
+
 def handle_closed_pr():
     """Handles the logic when a pull request is closed without merging."""
     telemetry_handler.initialize_telemetry()
@@ -204,6 +232,8 @@ def handle_closed_pr():
         contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
         contrast_api_key=config.CONTRAST_API_KEY
     )
+
+    _cleanup_smartfix_labels(pull_request, labels)
 
     log("--- Closed Contrast AI SmartFix Pull Request Handling Complete ---")
 

--- a/src/github/constants.py
+++ b/src/github/constants.py
@@ -30,3 +30,7 @@ GITHUB_MAX_ISSUE_BODY_SIZE = 32000
 # GitHub API Query Limits
 GITHUB_PR_LIST_LIMIT = 100
 GITHUB_WORKFLOW_RUN_LIMIT = 50
+
+# SmartFix-managed PR/issue label prefixes — used to identify labels SmartFix
+# attaches (and now removes on PR close/merge).
+SMARTFIX_LABEL_PREFIXES = ("smartfix-id:", "contrast-vuln-id:")

--- a/src/github/github_operations.py
+++ b/src/github/github_operations.py
@@ -31,7 +31,8 @@ from src.github.constants import (
     GITHUB_MAX_PR_BODY_SIZE,
     GITHUB_MAX_ISSUE_BODY_SIZE,
     GITHUB_PR_LIST_LIMIT,
-    GITHUB_WORKFLOW_RUN_LIMIT
+    GITHUB_WORKFLOW_RUN_LIMIT,
+    SMARTFIX_LABEL_PREFIXES,
 )
 
 
@@ -768,6 +769,37 @@ class GitHubOperations(ScmOperations):
             log(f"Failed to add labels to issue #{issue_number}: {e}", is_error=True)
             return False
 
+    def remove_labels_from_issue(self, issue_number: int, labels: List[str]) -> bool:
+        """
+        Remove labels from an existing issue.
+
+        Args:
+            issue_number: The issue number to remove labels from
+            labels: List of label names to remove
+
+        Returns:
+            bool: True if labels were successfully removed (or there was nothing to remove), False otherwise
+        """
+        if not labels:
+            debug_log("No labels provided to remove from issue")
+            return True
+
+        log(f"Removing labels from issue #{issue_number}: {labels}")
+        remove_labels_command = [
+            "gh", "issue", "edit",
+            "--repo", self.config.GITHUB_REPOSITORY,
+            str(issue_number),
+            "--remove-label", ",".join(labels)
+        ]
+
+        try:
+            run_command(remove_labels_command, env=self.get_gh_env(), check=True)
+            log(f"Successfully removed labels from issue #{issue_number}: {labels}")
+            return True
+        except Exception as e:
+            log(f"Failed to remove labels from issue #{issue_number}: {e}", is_error=True)
+            return False
+
     def find_issue_with_label(self, label: str) -> int:
         """
         Searches for a GitHub issue with a specific label.
@@ -1141,6 +1173,58 @@ class GitHubOperations(ScmOperations):
         except Exception as e:
             log(f"Failed to add labels to PR #{pr_number}: {e}", is_error=True)
             return False
+
+    def remove_labels_from_pr(self, pr_number: int, labels: List[str]) -> bool:
+        """
+        Remove labels from an existing pull request.
+
+        Args:
+            pr_number: The PR number to remove labels from
+            labels: List of label names to remove
+
+        Returns:
+            bool: True if labels were successfully removed (or there was nothing to remove), False otherwise
+        """
+        if not labels:
+            debug_log("No labels provided to remove from PR")
+            return True
+
+        log(f"Removing labels from PR #{pr_number}: {labels}")
+        remove_labels_command = [
+            "gh", "pr", "edit",
+            "--repo", self.config.GITHUB_REPOSITORY,
+            str(pr_number),
+            "--remove-label", ",".join(labels)
+        ]
+
+        try:
+            run_command(remove_labels_command, env=self.get_gh_env(), check=True)
+            log(f"Successfully removed labels from PR #{pr_number}: {labels}")
+            return True
+        except Exception as e:
+            log(f"Failed to remove labels from PR #{pr_number}: {e}", is_error=True)
+            return False
+
+    def filter_smartfix_labels(self, labels: list) -> List[str]:
+        """
+        Filter a label list down to those SmartFix manages — labels prefixed
+        with smartfix-id: or contrast-vuln-id:.
+
+        Args:
+            labels: List of label dicts (each with a "name" key) or label name strings
+
+        Returns:
+            List[str]: Names of SmartFix-managed labels, in input order
+        """
+        names: List[str] = []
+        for label in labels:
+            if isinstance(label, dict):
+                name = label.get("name", "")
+            else:
+                name = str(label)
+            if name.startswith(SMARTFIX_LABEL_PREFIXES):
+                names.append(name)
+        return names
 
     def get_issue_comments(self, issue_number: int, author: str = None) -> List[dict]:
         """

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -147,6 +147,34 @@ def _notify_remediation_service(remediation_id: str):
         log(f"Failed to notify Remediation service about merged PR for remediation {remediation_id}.", is_error=True)
 
 
+def _cleanup_smartfix_labels(pull_request: dict, labels: list) -> None:
+    """Best-effort: remove SmartFix-managed labels from the PR (and linked issue
+    in the external-agent flow). Never raises — failures are logged and the
+    handler completes regardless."""
+    try:
+        pr_number = pull_request.get("number")
+        if not pr_number:
+            debug_log("No PR number in event payload; skipping label cleanup.")
+            return
+
+        github_ops = GitHubOperations()
+        smartfix_labels = github_ops.filter_smartfix_labels(labels)
+        if not smartfix_labels:
+            debug_log("No SmartFix labels on PR; skipping label cleanup.")
+            return
+
+        debug_log(f"Cleaning up SmartFix labels: {smartfix_labels}")
+        github_ops.remove_labels_from_pr(pr_number, smartfix_labels)
+
+        branch_name = pull_request.get("head", {}).get("ref") or ""
+        if branch_name.startswith(("claude/issue-", "copilot/fix")):
+            issue_number = github_ops.extract_issue_number_from_branch(branch_name)
+            if issue_number:
+                github_ops.remove_labels_from_issue(issue_number, smartfix_labels)
+    except Exception as e:
+        log(f"Best-effort SmartFix label cleanup raised: {e}", is_error=True)
+
+
 def handle_merged_pr():
     """Handles the logic when a pull request is merged."""
     telemetry_handler.initialize_telemetry()
@@ -181,6 +209,8 @@ def handle_merged_pr():
         contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
         contrast_api_key=config.CONTRAST_API_KEY
     )
+
+    _cleanup_smartfix_labels(pull_request, labels)
 
     log("--- Merged Contrast AI SmartFix Pull Request Handling Complete ---")
 

--- a/test/test_closed_handler.py
+++ b/test/test_closed_handler.py
@@ -409,5 +409,135 @@ class TestClosedHandler(unittest.TestCase):
         self.assertEqual(coding_agent_call, "INTERNAL-SMARTFIX")
 
 
+class TestCleanupSmartfixLabels(unittest.TestCase):
+    """Tests for closed_handler._cleanup_smartfix_labels."""
+
+    def setUp(self):
+        self.exit_patcher = patch('sys.exit')
+        self.mock_exit = self.exit_patcher.start()
+        reset_config()
+
+    def tearDown(self):
+        self.exit_patcher.stop()
+        reset_config()
+
+    def _build_mock_ops(self, smartfix_label_names, issue_number=None,
+                        remove_pr_ok=True, remove_issue_ok=True):
+        ops = MagicMock()
+        ops.filter_smartfix_labels.return_value = smartfix_label_names
+        ops.extract_issue_number_from_branch.return_value = issue_number
+        ops.remove_labels_from_pr.return_value = remove_pr_ok
+        ops.remove_labels_from_issue.return_value = remove_issue_ok
+        return ops
+
+    def test_internal_smartfix_branch_removes_pr_labels_only(self):
+        """Internal smartfix branch: remove from PR, never touch any issue."""
+        pull_request = {"number": 99, "head": {"ref": "smartfix/remediation-abc"}}
+        labels = [{"name": "smartfix-id:abc"}, {"name": "wontfix"},
+                  {"name": "contrast-vuln-id:VULN-xyz"}]
+        ops = self._build_mock_ops(["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"])
+
+        with patch('src.closed_handler.GitHubOperations', return_value=ops):
+            closed_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_called_once_with(
+            99, ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"]
+        )
+        ops.remove_labels_from_issue.assert_not_called()
+        ops.extract_issue_number_from_branch.assert_not_called()
+
+    def test_claude_issue_branch_also_removes_issue_labels(self):
+        """External-agent claude/issue- branch: remove from PR and from linked issue."""
+        pull_request = {"number": 99, "head": {"ref": "claude/issue-75-20250908-1723"}}
+        labels = [{"name": "smartfix-id:abc"}, {"name": "contrast-vuln-id:VULN-xyz"}]
+        ops = self._build_mock_ops(
+            ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"], issue_number=75
+        )
+
+        with patch('src.closed_handler.GitHubOperations', return_value=ops):
+            closed_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_called_once_with(
+            99, ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"]
+        )
+        ops.extract_issue_number_from_branch.assert_called_once_with("claude/issue-75-20250908-1723")
+        ops.remove_labels_from_issue.assert_called_once_with(
+            75, ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"]
+        )
+
+    def test_copilot_fix_branch_also_removes_issue_labels(self):
+        """External-agent copilot/fix branch: remove from PR and from linked issue."""
+        pull_request = {"number": 99, "head": {"ref": "copilot/fix-42"}}
+        labels = [{"name": "smartfix-id:abc"}]
+        ops = self._build_mock_ops(["smartfix-id:abc"], issue_number=42)
+
+        with patch('src.closed_handler.GitHubOperations', return_value=ops):
+            closed_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_called_once_with(99, ["smartfix-id:abc"])
+        ops.remove_labels_from_issue.assert_called_once_with(42, ["smartfix-id:abc"])
+
+    def test_no_smartfix_labels_is_a_noop(self):
+        """No SmartFix labels: do not touch the PR or issue at all."""
+        pull_request = {"number": 99, "head": {"ref": "smartfix/remediation-abc"}}
+        labels = [{"name": "bug"}, {"name": "wontfix"}]
+        ops = self._build_mock_ops([])
+
+        with patch('src.closed_handler.GitHubOperations', return_value=ops):
+            closed_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_not_called()
+        ops.remove_labels_from_issue.assert_not_called()
+
+    def test_missing_pr_number_is_a_noop(self):
+        """No PR number: nothing to clean."""
+        pull_request = {"head": {"ref": "smartfix/remediation-abc"}}
+        labels = [{"name": "smartfix-id:abc"}]
+        ops = self._build_mock_ops(["smartfix-id:abc"])
+
+        with patch('src.closed_handler.GitHubOperations', return_value=ops):
+            closed_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_not_called()
+        ops.remove_labels_from_issue.assert_not_called()
+        ops.filter_smartfix_labels.assert_not_called()
+
+    def test_remove_failure_does_not_raise(self):
+        """remove_labels_from_pr returning False does not propagate as an exception."""
+        pull_request = {"number": 99, "head": {"ref": "smartfix/remediation-abc"}}
+        labels = [{"name": "smartfix-id:abc"}]
+        ops = self._build_mock_ops(["smartfix-id:abc"], remove_pr_ok=False)
+
+        with patch('src.closed_handler.GitHubOperations', return_value=ops):
+            try:
+                closed_handler._cleanup_smartfix_labels(pull_request, labels)
+            except Exception as e:
+                self.fail(f"_cleanup_smartfix_labels raised: {e}")
+
+    def test_external_agent_with_unparseable_issue_skips_issue_cleanup(self):
+        """External-agent branch but issue number can't be extracted: skip issue removal, not raise."""
+        pull_request = {"number": 99, "head": {"ref": "claude/issue-bogus"}}
+        labels = [{"name": "smartfix-id:abc"}]
+        ops = self._build_mock_ops(["smartfix-id:abc"], issue_number=None)
+
+        with patch('src.closed_handler.GitHubOperations', return_value=ops):
+            closed_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_called_once_with(99, ["smartfix-id:abc"])
+        ops.remove_labels_from_issue.assert_not_called()
+
+    def test_unexpected_exception_is_swallowed(self):
+        """An unexpected exception (e.g. GitHubOperations construction failure) is logged, not re-raised."""
+        pull_request = {"number": 99, "head": {"ref": "smartfix/remediation-abc"}}
+        labels = [{"name": "smartfix-id:abc"}]
+
+        with patch('src.closed_handler.GitHubOperations',
+                   side_effect=RuntimeError("config blew up")):
+            try:
+                closed_handler._cleanup_smartfix_labels(pull_request, labels)
+            except Exception as e:
+                self.fail(f"_cleanup_smartfix_labels propagated exception: {e}")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_github_operations.py
+++ b/test/test_github_operations.py
@@ -1442,6 +1442,113 @@ class TestGitHubOperations(unittest.TestCase):
 
         self.assertIsNone(result)
 
+    @patch('src.github.github_operations.run_command')
+    def test_remove_labels_from_pr_success(self, mock_run_command):
+        """remove_labels_from_pr issues a single gh pr edit --remove-label call against the configured repo."""
+        mock_run_command.return_value = "Success"
+
+        result = self.github_ops.remove_labels_from_pr(
+            123, ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"]
+        )
+
+        self.assertTrue(result)
+        mock_run_command.assert_called_once_with(
+            [
+                "gh", "pr", "edit",
+                "--repo", "test-owner/test-repo",
+                "123",
+                "--remove-label", "smartfix-id:abc,contrast-vuln-id:VULN-xyz",
+            ],
+            env=unittest.mock.ANY,
+            check=True,
+        )
+
+    @patch('src.github.github_operations.run_command')
+    def test_remove_labels_from_pr_empty_list_noop(self, mock_run_command):
+        """remove_labels_from_pr with no labels returns True without invoking gh."""
+        result = self.github_ops.remove_labels_from_pr(123, [])
+
+        self.assertTrue(result)
+        mock_run_command.assert_not_called()
+
+    @patch('src.github.github_operations.run_command')
+    def test_remove_labels_from_pr_failure(self, mock_run_command):
+        """remove_labels_from_pr returns False when gh fails."""
+        mock_run_command.side_effect = Exception("gh failure")
+
+        result = self.github_ops.remove_labels_from_pr(123, ["smartfix-id:abc"])
+
+        self.assertFalse(result)
+
+    @patch('src.github.github_operations.run_command')
+    def test_remove_labels_from_issue_success(self, mock_run_command):
+        """remove_labels_from_issue issues a single gh issue edit --remove-label call."""
+        mock_run_command.return_value = "Success"
+
+        result = self.github_ops.remove_labels_from_issue(
+            45, ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"]
+        )
+
+        self.assertTrue(result)
+        mock_run_command.assert_called_once_with(
+            [
+                "gh", "issue", "edit",
+                "--repo", "test-owner/test-repo",
+                "45",
+                "--remove-label", "smartfix-id:abc,contrast-vuln-id:VULN-xyz",
+            ],
+            env=unittest.mock.ANY,
+            check=True,
+        )
+
+    @patch('src.github.github_operations.run_command')
+    def test_remove_labels_from_issue_empty_list_noop(self, mock_run_command):
+        """remove_labels_from_issue with no labels returns True without invoking gh."""
+        result = self.github_ops.remove_labels_from_issue(45, [])
+
+        self.assertTrue(result)
+        mock_run_command.assert_not_called()
+
+    @patch('src.github.github_operations.run_command')
+    def test_remove_labels_from_issue_failure(self, mock_run_command):
+        """remove_labels_from_issue returns False when gh fails."""
+        mock_run_command.side_effect = Exception("gh failure")
+
+        result = self.github_ops.remove_labels_from_issue(45, ["smartfix-id:abc"])
+
+        self.assertFalse(result)
+
+    def test_filter_smartfix_labels_dict_input(self):
+        """filter_smartfix_labels picks SmartFix-prefixed names from event-payload dicts."""
+        labels = [
+            {"name": "smartfix-id:abc"},
+            {"name": "wontfix"},
+            {"name": "contrast-vuln-id:VULN-xyz"},
+            {"name": "bug"},
+        ]
+
+        result = self.github_ops.filter_smartfix_labels(labels)
+
+        self.assertEqual(result, ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"])
+
+    def test_filter_smartfix_labels_string_input(self):
+        """filter_smartfix_labels also accepts plain name strings."""
+        labels = ["smartfix-id:abc", "wontfix", "contrast-vuln-id:VULN-xyz"]
+
+        result = self.github_ops.filter_smartfix_labels(labels)
+
+        self.assertEqual(result, ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"])
+
+    def test_filter_smartfix_labels_empty(self):
+        """filter_smartfix_labels returns [] for empty input."""
+        self.assertEqual(self.github_ops.filter_smartfix_labels([]), [])
+
+    def test_filter_smartfix_labels_none_match(self):
+        """filter_smartfix_labels returns [] when nothing matches the SmartFix prefixes."""
+        labels = [{"name": "bug"}, {"name": "wontfix"}, {"name": "smartfix"}]
+
+        self.assertEqual(self.github_ops.filter_smartfix_labels(labels), [])
+
 
 class TestGetPrChangedFiles(unittest.TestCase):
 

--- a/test/test_merge_handler.py
+++ b/test/test_merge_handler.py
@@ -378,5 +378,135 @@ class TestMergeHandler(unittest.TestCase):
         )
 
 
+class TestCleanupSmartfixLabels(unittest.TestCase):
+    """Tests for merge_handler._cleanup_smartfix_labels."""
+
+    def setUp(self):
+        self.exit_patcher = patch('sys.exit')
+        self.mock_exit = self.exit_patcher.start()
+        reset_config()
+
+    def tearDown(self):
+        self.exit_patcher.stop()
+        reset_config()
+
+    def _build_mock_ops(self, smartfix_label_names, issue_number=None,
+                        remove_pr_ok=True, remove_issue_ok=True):
+        ops = MagicMock()
+        ops.filter_smartfix_labels.return_value = smartfix_label_names
+        ops.extract_issue_number_from_branch.return_value = issue_number
+        ops.remove_labels_from_pr.return_value = remove_pr_ok
+        ops.remove_labels_from_issue.return_value = remove_issue_ok
+        return ops
+
+    def test_internal_smartfix_branch_removes_pr_labels_only(self):
+        """Internal smartfix branch: remove from PR, never touch any issue."""
+        pull_request = {"number": 99, "head": {"ref": "smartfix/remediation-abc"}}
+        labels = [{"name": "smartfix-id:abc"}, {"name": "wontfix"},
+                  {"name": "contrast-vuln-id:VULN-xyz"}]
+        ops = self._build_mock_ops(["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"])
+
+        with patch('src.merge_handler.GitHubOperations', return_value=ops):
+            merge_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_called_once_with(
+            99, ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"]
+        )
+        ops.remove_labels_from_issue.assert_not_called()
+        ops.extract_issue_number_from_branch.assert_not_called()
+
+    def test_claude_issue_branch_also_removes_issue_labels(self):
+        """External-agent claude/issue- branch: remove from PR and from linked issue."""
+        pull_request = {"number": 99, "head": {"ref": "claude/issue-75-20250908-1723"}}
+        labels = [{"name": "smartfix-id:abc"}, {"name": "contrast-vuln-id:VULN-xyz"}]
+        ops = self._build_mock_ops(
+            ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"], issue_number=75
+        )
+
+        with patch('src.merge_handler.GitHubOperations', return_value=ops):
+            merge_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_called_once_with(
+            99, ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"]
+        )
+        ops.extract_issue_number_from_branch.assert_called_once_with("claude/issue-75-20250908-1723")
+        ops.remove_labels_from_issue.assert_called_once_with(
+            75, ["smartfix-id:abc", "contrast-vuln-id:VULN-xyz"]
+        )
+
+    def test_copilot_fix_branch_also_removes_issue_labels(self):
+        """External-agent copilot/fix branch: remove from PR and from linked issue."""
+        pull_request = {"number": 99, "head": {"ref": "copilot/fix-42"}}
+        labels = [{"name": "smartfix-id:abc"}]
+        ops = self._build_mock_ops(["smartfix-id:abc"], issue_number=42)
+
+        with patch('src.merge_handler.GitHubOperations', return_value=ops):
+            merge_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_called_once_with(99, ["smartfix-id:abc"])
+        ops.remove_labels_from_issue.assert_called_once_with(42, ["smartfix-id:abc"])
+
+    def test_no_smartfix_labels_is_a_noop(self):
+        """No SmartFix labels: do not touch the PR or issue at all."""
+        pull_request = {"number": 99, "head": {"ref": "smartfix/remediation-abc"}}
+        labels = [{"name": "bug"}, {"name": "wontfix"}]
+        ops = self._build_mock_ops([])
+
+        with patch('src.merge_handler.GitHubOperations', return_value=ops):
+            merge_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_not_called()
+        ops.remove_labels_from_issue.assert_not_called()
+
+    def test_missing_pr_number_is_a_noop(self):
+        """No PR number: nothing to clean."""
+        pull_request = {"head": {"ref": "smartfix/remediation-abc"}}
+        labels = [{"name": "smartfix-id:abc"}]
+        ops = self._build_mock_ops(["smartfix-id:abc"])
+
+        with patch('src.merge_handler.GitHubOperations', return_value=ops):
+            merge_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_not_called()
+        ops.remove_labels_from_issue.assert_not_called()
+        ops.filter_smartfix_labels.assert_not_called()
+
+    def test_remove_failure_does_not_raise(self):
+        """remove_labels_from_pr returning False does not propagate as an exception."""
+        pull_request = {"number": 99, "head": {"ref": "smartfix/remediation-abc"}}
+        labels = [{"name": "smartfix-id:abc"}]
+        ops = self._build_mock_ops(["smartfix-id:abc"], remove_pr_ok=False)
+
+        with patch('src.merge_handler.GitHubOperations', return_value=ops):
+            try:
+                merge_handler._cleanup_smartfix_labels(pull_request, labels)
+            except Exception as e:
+                self.fail(f"_cleanup_smartfix_labels raised: {e}")
+
+    def test_external_agent_with_unparseable_issue_skips_issue_cleanup(self):
+        """External-agent branch but issue number can't be extracted: skip issue removal, not raise."""
+        pull_request = {"number": 99, "head": {"ref": "claude/issue-bogus"}}
+        labels = [{"name": "smartfix-id:abc"}]
+        ops = self._build_mock_ops(["smartfix-id:abc"], issue_number=None)
+
+        with patch('src.merge_handler.GitHubOperations', return_value=ops):
+            merge_handler._cleanup_smartfix_labels(pull_request, labels)
+
+        ops.remove_labels_from_pr.assert_called_once_with(99, ["smartfix-id:abc"])
+        ops.remove_labels_from_issue.assert_not_called()
+
+    def test_unexpected_exception_is_swallowed(self):
+        """An unexpected exception (e.g. GitHubOperations construction failure) is logged, not re-raised."""
+        pull_request = {"number": 99, "head": {"ref": "smartfix/remediation-abc"}}
+        labels = [{"name": "smartfix-id:abc"}]
+
+        with patch('src.merge_handler.GitHubOperations',
+                   side_effect=RuntimeError("config blew up")):
+            try:
+                merge_handler._cleanup_smartfix_labels(pull_request, labels)
+            except Exception as e:
+                self.fail(f"_cleanup_smartfix_labels propagated exception: {e}")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- When a SmartFix PR is closed or merged, remove the SmartFix-managed labels (`smartfix-id:*`, `contrast-vuln-id:*`) from the PR — and from the linked external-agent issue when applicable.
- Best-effort: cleanup runs after notification + telemetry, and any failure is logged without crashing the handler.
- 516 insertions across 7 files (1 constant, 1 ops module, 2 handlers, 3 test files).

## Why This Change Exists
SmartFix attaches `contrast-vuln-id:VULN-*` and `smartfix-id:*` labels when it opens a PR (and on the linked issue, for external-agent flows). When the PR closes or merges, those labels stay attached — accumulating as visual cruft in the GitHub UI for no functional purpose: the remediation is terminated, the vuln entry won't be re-keyed.

The ticket scoped this narrowly ("maybe just the remediation id"). We went broader after looking at the data: once a PR is in a terminal state, `contrast-vuln-id` is just as obsolete as `smartfix-id` — neither serves a purpose on a closed/merged PR.

## Approach We Chose
A small mechanical helper at the end of each handler that:
1. Filters the PR's labels for SmartFix-managed prefixes (`smartfix-id:`, `contrast-vuln-id:`).
2. Removes them from the PR via `gh pr edit --remove-label`.
3. If the branch is `claude/issue-*` or `copilot/fix-*` (external-agent flow), also removes them from the linked issue via `gh issue edit --remove-label`.

Cleanup runs **after** the Contrast notification and telemetry calls. If notification fails, the labels remain — they're the input for retry/debug. Cleanup itself is best-effort: a single outer `try/except` ensures the handler always completes, even if `GitHubOperations()` construction or any inner call fails unexpectedly.

The two handlers duplicate the helper rather than share via a new module, matching the existing duplication pattern between `_load_github_event`, `_validate_pr_event`, etc. (rule of three — handlers already have multiple paired private helpers). A future "deduplicate the handlers" ticket can sweep all of them together.

## Outcome of This Change
- Terminated SmartFix PRs no longer carry the two label families.
- For external-agent flows (Claude Code / Copilot), the linked issue is also cleaned.
- Notification + telemetry behavior unchanged; cleanup is purely additive at the tail.

## Reviewer Guide
1. Start with `src/closed_handler.py` and `src/merge_handler.py` — the new `_cleanup_smartfix_labels` helper plus the call site at the end of each handler.
2. Then `src/github/github_operations.py` for the three new methods (`remove_labels_from_pr`, `remove_labels_from_issue`, `filter_smartfix_labels`) — mirror the existing `add_labels_to_*` shape.
3. Then `src/github/constants.py` for the new `SMARTFIX_LABEL_PREFIXES` tuple.
4. Tests last — they assert exact `gh` command argument lists (no `MagicMock` looseness), so any regression in command construction breaks them.

## Logic Walkthrough
### 1. Problem framing
Both handlers reach a common state at their tail: the remediation has been notified, telemetry has been sent, and the only thing left is the "complete" log line. That's where label cleanup belongs.

### 2. Core implementation
`_cleanup_smartfix_labels(pull_request, labels)` lives near the top of each handler. It instantiates `GitHubOperations`, filters labels via `filter_smartfix_labels`, and calls `remove_labels_from_pr` / `remove_labels_from_issue` as appropriate. The whole body is wrapped in a single `try/except` that catches any exception, logs once, and returns.

### 3. Supporting changes
The three new `GitHubOperations` methods are mechanical mirrors of the existing add-label methods:
- `remove_labels_from_pr` → `gh pr edit --repo ... --remove-label ...`
- `remove_labels_from_issue` → `gh issue edit --repo ... --remove-label ...`
- `filter_smartfix_labels` → in-process filter; accepts label-dict (event payload) or label-name (string) inputs

### 4. Edge cases and safeguards
- No PR number in event → no-op, log and return.
- No SmartFix-prefixed labels on the PR → no-op.
- External-agent branch but issue number can't be parsed → clean PR, skip issue.
- `remove_labels_from_*` returning `False` → already logged inside the method; helper continues.
- Any unexpected exception (e.g. config/init failure) → caught, logged once, handler completes.

### 5. How the tests prove it
- Unit tests for the three `GitHubOperations` methods assert the exact `gh` command list (including `--repo`, `--remove-label`, comma-joined labels). Empty input is a true no-op. Failures return `False` without raising.
- `_cleanup_smartfix_labels` tests cover all branches: internal-only, external `claude/issue-`, external `copilot/fix-`, no labels, no PR number, unparseable issue number, and an unexpected exception during `GitHubOperations()` construction (asserts no propagation).

## What Changed
### `src/github/`
- `constants.py` — new `SMARTFIX_LABEL_PREFIXES = ("smartfix-id:", "contrast-vuln-id:")`.
- `github_operations.py` — three new methods on `GitHubOperations` (mirror of `add_labels_to_*`); imports the new constant.

### `src/`
- `closed_handler.py` — new `_cleanup_smartfix_labels` private helper + one call site at the end of `handle_closed_pr` (after telemetry).
- `merge_handler.py` — same change in `handle_merged_pr`.

### `test/`
- `test_github_operations.py` — 9 new tests for the three methods (success, empty-list no-op, command failure, dict input, string input, unmatched prefixes).
- `test_closed_handler.py`, `test_merge_handler.py` — 7 new tests each on `_cleanup_smartfix_labels` covering all branches, including the exception-swallow guarantee.

## Testing
- **Unit:** `./test/run_tests.sh test.test_github_operations test.test_closed_handler test.test_merge_handler --skip-install` → 157 tests, all pass (+24 net new vs. baseline).
- **Lint:** `flake8` clean across all touched files.
- **End-to-end against a real test repo** (`contrast-security-app-test/smartfix-e2e-test`): ran `closed_handler.py` and `merge_handler.py` directly against pre-staged real PRs (#11, #12) with both label families attached. Notification API call succeeded, then both label families disappeared from the PR. Verified via `gh pr view --json labels` post-run.
- **act harness** for repeatable local runs lives at `e2e/act/aiml-141/` in the e2e-test repo (out of scope for this PR).

## Risks / Rollout / Follow-ups
- **Risk:** label removal fails post-notification → mitigated by the best-effort wrapper; worst case is labels lingering (current behavior).
- **Token scope:** the action's `GITHUB_TOKEN` already has `pull-requests: write` and `issues: write`. The remove-label calls require the same scopes the add-label calls already use. No new permissions needed.
- **Out of scope:** the existing handler/`_extract_*` duplication noted above is real but not addressed here. A "deduplicate handlers" ticket would sweep cleanly.
- **Out of scope:** `get_pr_changed_files_count` in `github_operations.py` issues `gh pr view <pr>` without `--repo` (relies on cwd's git remote). Not exercised by AIML-141; surface separately if needed.
