### PR TITLE
AIML-686: Swap LLM proxy from v1 to v2 endpoint

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -211,7 +211,7 @@ class Config:
         if (is_smartfix_coding_agent
                 and self.USE_CONTRAST_LLM
                 and self._get_env_var("AGENT_MODEL", required=False) is None):
-            self.AGENT_MODEL = "contrast/claude-sonnet-4-5"
+            self.AGENT_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
         # Validate AWS Bedrock configuration if applicable
         self._validate_aws_bedrock_config()

--- a/src/smartfix/domains/agents/sub_agent_executor.py
+++ b/src/smartfix/domains/agents/sub_agent_executor.py
@@ -94,7 +94,7 @@ class SubAgentExecutor:
             query: User query/prompt for the agent
             system_prompt: System prompt for agent instructions
             remediation_id: Remediation ID for error tracking
-            session_id: Session ID for Contrast LLM tracking
+            session_id: ADK session ID for agent execution tracking
             additional_tools: Optional list of extra tools to add to the agent
 
         Returns:
@@ -154,7 +154,7 @@ class SubAgentExecutor:
         Args:
             target_folder: Path to the folder for filesystem access
             remediation_id: Remediation ID for error tracking
-            session_id: Session ID for Contrast LLM tracking
+            session_id: ADK session ID for agent execution tracking
             system_prompt: System prompt for agent instructions
             additional_tools: Optional list of extra tools (e.g., BuildTool) to include
 
@@ -192,7 +192,6 @@ class SubAgentExecutor:
                     extra_headers={
                         "Api-Key": f"{self.config.CONTRAST_API_KEY}",
                         "Authorization": f"{self.config.CONTRAST_AUTHORIZATION_KEY}",
-                        "x-contrast-llm-session-id": f"{session_id}"
                     }
                 )
                 debug_log(f"Creating fix agent ({agent_name}) with model contrast_llm")

--- a/src/smartfix/domains/agents/sub_agent_executor.py
+++ b/src/smartfix/domains/agents/sub_agent_executor.py
@@ -35,7 +35,7 @@ from typing import Optional
 from src.utils import debug_log, log, error_exit, tail_string
 from src.smartfix.shared.failure_categories import FailureCategory
 from src.smartfix.domains.telemetry import telemetry_handler
-from src.smartfix.domains.providers import setup_contrast_provider, CONTRAST_CLAUDE_SONNET_4_5
+from src.smartfix.domains.providers import setup_contrast_provider
 
 from .mcp_manager import MCPToolsetManager
 
@@ -185,7 +185,7 @@ class SubAgentExecutor:
             if hasattr(self.config, 'USE_CONTRAST_LLM') and self.config.USE_CONTRAST_LLM:
                 setup_contrast_provider()
                 model_instance = SmartFixLiteLlm(
-                    model=CONTRAST_CLAUDE_SONNET_4_5,
+                    model=self.config.AGENT_MODEL,
                     temperature=0.2,
                     stream_options={"include_usage": True},
                     system=system_prompt,  # Use standard system parameter

--- a/src/smartfix/domains/providers/__init__.py
+++ b/src/smartfix/domains/providers/__init__.py
@@ -3,7 +3,7 @@ import os
 from src.utils import normalize_host
 
 # Contrast LLM model constants
-CONTRAST_CLAUDE_SONNET_4_5 = "contrast/claude-sonnet-4-5"
+CONTRAST_CLAUDE_SONNET_4_5 = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
 
 def setup_contrast_provider() -> None:
@@ -40,5 +40,5 @@ def setup_contrast_provider() -> None:
     })
 
     # Configure to use Contrast proxy (still uses Anthropic API format)
-    os.environ["ANTHROPIC_API_BASE"] = f"https://{normalize_host(config.CONTRAST_HOST)}/api/v4/llm-proxy/organizations/{config.CONTRAST_ORG_ID}"
+    os.environ["ANTHROPIC_API_BASE"] = f"https://{normalize_host(config.CONTRAST_HOST)}/api/llm-proxy/v2/organizations/{config.CONTRAST_ORG_ID}/anthropic"
     os.environ["ANTHROPIC_API_KEY"] = f"{config.CONTRAST_API_KEY}"

--- a/src/smartfix/extensions/smartfix_litellm.py
+++ b/src/smartfix/extensions/smartfix_litellm.py
@@ -79,6 +79,8 @@ litellm.suppress_debug_info = os.environ.get("DEBUG_MODE", "").lower() != "true"
 
 def _derive_system(model: str) -> str:
     """Map a LiteLLM model string to the OTel gen_ai.system attribute value."""
+    if model == CONTRAST_CLAUDE_SONNET_4_5:
+        return "contrast"
     m = model.lower()
     if m.startswith("contrast/"):
         return "contrast"
@@ -591,8 +593,7 @@ class SmartFixLiteLlm(LiteLlm):
         )
 
         # For Contrast models, ensure we have a system message before role conversion
-        model_lower = self.model.lower()
-        if "contrast/" in model_lower and "claude" in model_lower:
+        if self.model == CONTRAST_CLAUDE_SONNET_4_5:
             debug_log("Pre-processing messages for Contrast model")
             messages = self._ensure_system_message_for_contrast(messages)
 

--- a/src/smartfix/extensions/smartfix_litellm.py
+++ b/src/smartfix/extensions/smartfix_litellm.py
@@ -36,6 +36,7 @@ from pydantic import Field
 from opentelemetry import context as otel_context
 from opentelemetry.trace import StatusCode
 
+from src.smartfix.domains.providers import CONTRAST_CLAUDE_SONNET_4_5
 from src.smartfix.domains.telemetry import otel_provider
 from src.smartfix.domains.telemetry import smartfix_metrics
 from src.config import get_config
@@ -333,9 +334,10 @@ class SmartFixLiteLlm(LiteLlm):
         model_lower = self.model.lower()
         debug_log(f"_apply_role_conversion_and_caching called with model: {self.model}")
 
-        # Early return for Contrast models - no caching or role conversion needed
-        if ("contrast/" in model_lower and "claude" in model_lower):
-            debug_log(f"Contrast model detected: {self.model} - skipping caching and role conversion")
+        # Early return for Contrast LLM model - server-side caching is automatic, no client-side
+        # cache_control breakpoints or role conversion needed.
+        if self.model == CONTRAST_CLAUDE_SONNET_4_5:
+            debug_log(f"Contrast LLM model detected: {self.model} - skipping caching and role conversion")
             return
 
         # Early return if model doesn't support caching

--- a/test/test_agent_infrastructure.py
+++ b/test/test_agent_infrastructure.py
@@ -258,7 +258,7 @@ class TestSubAgentExecutor(unittest.TestCase):
         headers = call_kwargs['extra_headers']
         self.assertEqual(headers['Api-Key'], 'test-api-key')
         self.assertEqual(headers['Authorization'], 'test-auth-key')
-        self.assertEqual(headers['x-contrast-llm-session-id'], 'session-456')
+        self.assertNotIn('x-contrast-llm-session-id', headers)
 
     @patch('src.smartfix.domains.agents.sub_agent_executor.error_exit')
     @patch('src.config.get_config')

--- a/test/test_config_integration.py
+++ b/test/test_config_integration.py
@@ -100,7 +100,7 @@ class TestConfigIntegration(unittest.TestCase):
         self.assertEqual(config.CODING_AGENT, 'SMARTFIX')
         self.assertTrue(config.USE_CONTRAST_LLM)
         # Default agent model should use Contrast LLM constant
-        self.assertEqual(config.AGENT_MODEL, 'contrast/claude-sonnet-4-5')
+        self.assertEqual(config.AGENT_MODEL, 'us.anthropic.claude-sonnet-4-5-20250929-v1:0')
 
     def test_coding_agent_smartfix_with_byollm(self):
         """Test that SMARTFIX coding agent works with USE_CONTRAST_LLM=False (BYOLLM)."""

--- a/test/test_contrast_llm_config.py
+++ b/test/test_contrast_llm_config.py
@@ -3,6 +3,7 @@
 import unittest
 import os
 from src.config import get_config, reset_config
+from src.smartfix.domains.providers import CONTRAST_CLAUDE_SONNET_4_5
 
 
 class TestContrastLlmConfig(unittest.TestCase):
@@ -25,6 +26,7 @@ class TestContrastLlmConfig(unittest.TestCase):
             'CONTRAST_APP_ID': 'test-app-id',
             'CONTRAST_AUTHORIZATION_KEY': 'test-auth-key',
             'CONTRAST_API_KEY': 'test-api-key',
+            'GITHUB_SERVER_URL': 'https://github.com',
             # Use non-Bedrock model to avoid AWS validation when USE_CONTRAST_LLM=false
             'AGENT_MODEL': 'anthropic/claude-sonnet-4-5'
         }
@@ -148,7 +150,6 @@ class TestContrastLlmConfig(unittest.TestCase):
 
     def test_contrast_llm_defaults_agent_model_to_constant(self):
         """When USE_CONTRAST_LLM=true and AGENT_MODEL is unset, config defaults to CONTRAST_CLAUDE_SONNET_4_5."""
-        from src.smartfix.domains.providers import CONTRAST_CLAUDE_SONNET_4_5
         os.environ['USE_CONTRAST_LLM'] = 'true'
         if 'AGENT_MODEL' in os.environ:
             del os.environ['AGENT_MODEL']

--- a/test/test_contrast_llm_config.py
+++ b/test/test_contrast_llm_config.py
@@ -146,6 +146,16 @@ class TestContrastLlmConfig(unittest.TestCase):
         config = get_config(testing=True)
         self.assertFalse(config.USE_CONTRAST_LLM)
 
+    def test_contrast_llm_defaults_agent_model_to_constant(self):
+        """When USE_CONTRAST_LLM=true and AGENT_MODEL is unset, config defaults to CONTRAST_CLAUDE_SONNET_4_5."""
+        from src.smartfix.domains.providers import CONTRAST_CLAUDE_SONNET_4_5
+        os.environ['USE_CONTRAST_LLM'] = 'true'
+        if 'AGENT_MODEL' in os.environ:
+            del os.environ['AGENT_MODEL']
+        reset_config()
+        config = get_config(testing=True)
+        self.assertEqual(config.AGENT_MODEL, CONTRAST_CLAUDE_SONNET_4_5)
+
     def test_setup_contrast_provider_uses_v2_endpoint(self):
         """setup_contrast_provider() points ANTHROPIC_API_BASE at the v2 LLM proxy endpoint."""
         from src.smartfix.domains.providers import setup_contrast_provider

--- a/test/test_contrast_llm_config.py
+++ b/test/test_contrast_llm_config.py
@@ -146,6 +146,24 @@ class TestContrastLlmConfig(unittest.TestCase):
         config = get_config(testing=True)
         self.assertFalse(config.USE_CONTRAST_LLM)
 
+    def test_setup_contrast_provider_uses_v2_endpoint(self):
+        """setup_contrast_provider() points ANTHROPIC_API_BASE at the v2 LLM proxy endpoint."""
+        from src.smartfix.domains.providers import setup_contrast_provider
+
+        # Use the env vars established in setUp (CONTRAST_HOST=test.contrastsecurity.com,
+        # CONTRAST_ORG_ID=test-org-id); reset_config() picks them up.
+        reset_config()
+
+        setup_contrast_provider()
+
+        api_base = os.environ.get('ANTHROPIC_API_BASE')
+        self.assertEqual(
+            api_base,
+            'https://test.contrastsecurity.com/api/llm-proxy/v2/organizations/test-org-id/anthropic'
+        )
+        # Guard against regression to the v1 path shape
+        self.assertNotIn('/api/v4/llm-proxy/', api_base)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_smartfix_litellm.py
+++ b/test/test_smartfix_litellm.py
@@ -591,5 +591,57 @@ class TestCallLlmWithRetryOtelSpan(unittest.TestCase):
         self.assertIn("error.type", attrs)
 
 
+class TestGenerateContentAsyncDoesNotStream(unittest.TestCase):
+    """Regression: SmartFixLiteLlm must not set stream on the completion call.
+
+    The v2 Contrast LLM proxy returns HTTP 406 for streaming requests, so the
+    Contrast call path must never pass stream=True (or any truthy stream value)
+    into acompletion.  This test locks in the current non-streaming behaviour
+    so a future refactor cannot silently regress it.
+    """
+
+    def setUp(self):
+        with patch('litellm.completion'):
+            self.model = SmartFixLiteLlm(model="contrast/claude-sonnet-4-5")
+
+    def _consume(self, gen):
+        async def _drain():
+            async for _ in gen:
+                pass
+        asyncio.run(_drain())
+
+    @patch('google.adk.models.lite_llm._model_response_to_generate_content_response')
+    @patch('src.smartfix.extensions.smartfix_litellm._get_completion_inputs')
+    def test_completion_args_omit_stream_for_contrast_model(
+        self, mock_inputs, mock_response_converter
+    ):
+        """generate_content_async must not insert 'stream' into completion_args."""
+        # _get_completion_inputs returns (messages, tools, response_format, generation_params)
+        mock_inputs.return_value = ([], None, None, None)
+        mock_response_converter.return_value = MagicMock()
+
+        # Capture completion_args via _call_llm_with_retry mock
+        fake_response = MagicMock()
+        fake_response.get = lambda key, default=None: default
+        fake_response.model = "contrast/claude-sonnet-4-5"
+        self.model._call_llm_with_retry = AsyncMock(return_value=fake_response)
+
+        # Skip helpers that touch llm_request internals
+        self.model._maybe_append_user_content = MagicMock()
+        self.model._ensure_system_message_for_contrast = MagicMock(return_value=[])
+        self.model._apply_role_conversion_and_caching = MagicMock()
+        # Provide concrete value for the parent-class attribute the method reads
+        self.model._additional_args = {}
+
+        self._consume(self.model.generate_content_async(MagicMock(), stream=False))
+
+        self.model._call_llm_with_retry.assert_called_once()
+        completion_args = self.model._call_llm_with_retry.call_args[0][0]
+        self.assertNotIn(
+            "stream", completion_args,
+            "completion_args must not set 'stream'; v2 Contrast LLM proxy returns HTTP 406 on streaming"
+        )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_smartfix_litellm.py
+++ b/test/test_smartfix_litellm.py
@@ -35,6 +35,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 # Test setup imports (path is set up by conftest.py)
 from src.smartfix.extensions.smartfix_litellm import SmartFixLiteLlm, TokenCostAccumulator, _derive_system
+from src.smartfix.domains.providers import CONTRAST_CLAUDE_SONNET_4_5
 
 
 class TestTokenCostAccumulator(unittest.TestCase):
@@ -389,6 +390,10 @@ class TestDeriveSystem(unittest.TestCase):
         """Production Contrast LLM model string must report provider as 'contrast', not 'anthropic'."""
         self.assertEqual(_derive_system("contrast/claude-sonnet-4-5"), "contrast")
 
+    def test_contrast_claude_sonnet_v2_model_id_returns_contrast(self):
+        """v2 model id (bare Bedrock id, no contrast/ prefix) must still resolve to 'contrast'."""
+        self.assertEqual(_derive_system(CONTRAST_CLAUDE_SONNET_4_5), "contrast")
+
     def test_anthropic_prefix_returns_anthropic(self):
         self.assertEqual(_derive_system("anthropic/claude-3-opus"), "anthropic")
 
@@ -602,7 +607,7 @@ class TestGenerateContentAsyncDoesNotStream(unittest.TestCase):
 
     def setUp(self):
         with patch('litellm.completion'):
-            self.model = SmartFixLiteLlm(model="contrast/claude-sonnet-4-5")
+            self.model = SmartFixLiteLlm(model=CONTRAST_CLAUDE_SONNET_4_5)
 
     def _consume(self, gen):
         async def _drain():
@@ -623,7 +628,7 @@ class TestGenerateContentAsyncDoesNotStream(unittest.TestCase):
         # Capture completion_args via _call_llm_with_retry mock
         fake_response = MagicMock()
         fake_response.get = lambda key, default=None: default
-        fake_response.model = "contrast/claude-sonnet-4-5"
+        fake_response.model = CONTRAST_CLAUDE_SONNET_4_5
         self.model._call_llm_with_retry = AsyncMock(return_value=fake_response)
 
         # Skip helpers that touch llm_request internals

--- a/test/test_sub_agent_executor.py
+++ b/test/test_sub_agent_executor.py
@@ -366,7 +366,7 @@ class TestSubAgentExecutorAgentCreation(unittest.TestCase):
             headers = call_kwargs["extra_headers"]
             self.assertEqual(headers["Api-Key"], "test-api-key")
             self.assertEqual(headers["Authorization"], "test-auth-key")
-            self.assertEqual(headers["x-contrast-llm-session-id"], "session-456")
+            self.assertNotIn("x-contrast-llm-session-id", headers)
             # Verify agent was created with fix agent name
             mock_agent_class.assert_called_once()
             agent_kwargs = mock_agent_class.call_args[1]


### PR DESCRIPTION
## Summary
- Route Contrast-LLM SmartFix traffic through the metered v2 proxy (`/api/llm-proxy/v2/organizations/{org}/anthropic`).
- Drop the legacy `x-contrast-llm-session-id` header — v2 is sessionless.
- Fold in a small log-line fix (former follow-up F2): the v2 model id no longer slips into the misleading "does not support caching" debug branch.

## Why This Change Exists
- AIML-654 (SmartFix token migration) requires moving Contrast-LLM calls from the v1 (unmetered) proxy to v2 (prepaid-balance enforced). The v2 endpoint is already in production use by `contrast-triage`.
- Per the 2026-04-30 decision (see AIML-685 close), the migration ships unconditionally — no feature flag. EA customers already have v2 balances from other services; lack-of-balance is the natural per-customer gate via HTTP 402 (handled separately in AIML-687).

## Approach We Chose
- Single-source-of-truth model constant (`CONTRAST_CLAUDE_SONNET_4_5`) updated to the bare Bedrock id `us.anthropic.claude-sonnet-4-5-20250929-v1:0`. v2's `FlexibleBedrockService` respects `body.model` verbatim, unlike v1's `ConfigOverrideBedrockService` which rewrote it server-side.
- LiteLLM provider routing pinned via `litellm.register_model({...: {"litellm_provider": "anthropic"}})`, so the bare id (no `contrast/` prefix) still routes correctly. Explicit `register_model` overrides default name-based provider detection.
- Header drop is naturally coupled to the URL swap: stg's v1 endpoint returns 400 without `x-contrast-llm-session-id`, so old code on the v1 path can't accidentally dual-target.
- Folded F2 (single-line behavioral parity): replace the substring guard `"contrast/" in model_lower and "claude" in model_lower` with `self.model == CONTRAST_CLAUDE_SONNET_4_5`. After the model id changed, the substring guard stopped firing and the Contrast model fell through to the "does not support caching" log branch — misleading only, since Anthropic auto-caches server-side.

## Outcome of This Change
- SmartFix Contrast-LLM calls hit the v2 endpoint and succeed end-to-end against stg.
- Per-customer cost tracking via the prepaid balance system now applies to SmartFix automatically.
- No streaming-related regression (v2 returns 406 on streaming; LiteLLM defaults non-streaming and we lock that with a new regression test).

## Reviewer Guide
1. Start with `src/smartfix/domains/providers/__init__.py` — model id + URL swap.
2. Then `src/smartfix/domains/agents/sub_agent_executor.py:192-195` — header drop + docstring refresh.
3. Then `src/smartfix/extensions/smartfix_litellm.py:337` — folded log-line fix.
4. Tests last: `test/test_contrast_llm_config.py`, `test/test_smartfix_litellm.py`, and the two flipped session-id assertions.

## Logic Walkthrough
### 1. Problem framing
SmartFix's Contrast-LLM path (`USE_CONTRAST_LLM=true`) routed to the v1 proxy, which is unmetered and predates the prepaid-balance system. AIML-654 mandates v2 for all Contrast-LLM clients ahead of GA.

### 2. Core implementation
Two surface changes, both via `setup_contrast_provider`: the proxy URL (env var `ANTHROPIC_API_BASE`) and the registered model id. The header drop happens in the per-call `extra_headers` build in `sub_agent_executor`.

### 3. Supporting changes
The model-id constant change is what couples the LiteLLM body to v2's expectations. `register_model` keeps the Anthropic provider routing regardless of the new id shape, so we don't need a `contrast/` prefix.

### 4. Edge cases and safeguards
- Streaming: v2 returns HTTP 406 if `stream=true`. LiteLLM defaults non-streaming and `stream_options={"include_usage": True}` (already in place) doesn't flip streaming on. New regression test locks this contract.
- Session-id header: removed from `extra_headers` and asserted absent in the two infra tests.

### 5. How the tests prove it
- `test_contrast_llm_config.py` asserts `setup_contrast_provider` configures the v2 URL.
- `test_smartfix_litellm.py` adds a streaming-disabled regression assertion on the Contrast path.
- `test_agent_infrastructure.py` and `test_sub_agent_executor.py` flip session-id `assertIn` → `assertNotIn`.

## What Changed
### Provider configuration
- `src/smartfix/domains/providers/__init__.py:6` — model id: `contrast/claude-sonnet-4-5` → `us.anthropic.claude-sonnet-4-5-20250929-v1:0` (bare Bedrock id; v2 respects `body.model`).
- `src/smartfix/domains/providers/__init__.py:43` — `ANTHROPIC_API_BASE`: v1 path → `{base}/api/llm-proxy/v2/organizations/{org}/anthropic`.

### Header & docstrings
- `src/smartfix/domains/agents/sub_agent_executor.py:192-195` — drop `x-contrast-llm-session-id` from `extra_headers`. v2 is sessionless.
- `src/smartfix/domains/agents/sub_agent_executor.py:97,157` — refresh stale session-id docstrings.

### Log-line fix (folded former F2)
- `src/smartfix/extensions/smartfix_litellm.py:337` — substring guard → equality check against `CONTRAST_CLAUDE_SONNET_4_5`. Functionally identical; the v2 model id now triggers the correct "skip caching for Contrast LLM" log branch.

### Tests
- `test/test_contrast_llm_config.py` — new test asserting the v2 URL.
- `test/test_smartfix_litellm.py` — streaming-disabled regression on the Contrast path.
- `test/test_agent_infrastructure.py:261`, `test/test_sub_agent_executor.py:369` — flipped session-id assertions to `assertNotIn`.

## Testing
- **Automated:** `make test` → 858/858 passing on `88122e1`.
- **Cloud verification:** GH Actions run [25383003064](https://github.com/contrast-security-app-test/smartfix-e2e-test/actions/runs/25383003064) green; generated fix-PR [#14](https://github.com/contrast-security-app-test/smartfix-e2e-test/pull/14). v2 endpoint hit confirmed via Datadog trace against `aiml-llm-proxy-api`'s `v2/anthropic/v1/messages` (218,910 input tokens, 200 OK).
- **Direct API probe:** stg v2 returns 200 with the SmartFix header set (Api-Key + Authorization, no session-id); stg v1 returns 400 without session-id, confirming the header drop is coupled to the URL swap as expected.

## Risks / Rollout / Follow-ups
- **Cutover dependency:** AIML-686 acceptance criteria call for confirming Nationwide's v2 token-balance is provisioned (Ben / AIML-586). Per meeting context, EA customers already have v2 balances from other services so this should already hold.
- **402 handling out of scope:** AIML-687 covers prepaid-balance error paths.
- **Verification-scaffolding improvements live in the test repo, not here.** During verification we found and shipped (in `smartfix-e2e-test`) a `pull_request: closed` workflow that fires `closed_handler.py` (closes the loop on `RemediationPr` rows when a SmartFix PR is closed in the UI), and a `cleanup_remediations.sh` recovery script for stuck-OPEN rows.
- **F7 follow-up filed (action repo):** `formatter.py:53-66` swallows non-zero formatter exit codes (`run_command(check=False)` with `format_success = True` regardless of return code). Cosmetic-looking but means the action ships PRs without verifying the auto-detected formatter actually ran. Captured in `docs/smartfix-status.md` (F7); out of scope here.
