### PR TITLE
AIML-697 Token usage attribution headers

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -268,6 +268,7 @@ def _main_impl(vuln_count):  # noqa: C901
             vuln_title = vulnerability_data['vulnerabilityTitle']
             remediation_id = vulnerability_data['remediationId']
             session_id = vulnerability_data.get('sessionId')
+            vuln_language = vulnerability_data.get('language')
 
             # Validate and create prompt configuration for SmartFix agent
             try:
@@ -310,6 +311,7 @@ def _main_impl(vuln_count):  # noqa: C901
             vuln_title = vulnerability_data['vulnerabilityTitle']
             remediation_id = vulnerability_data['remediationId']
             session_id = None  # External agents don't use Contrast LLM sessions
+            vuln_language = vulnerability_data.get('language')
 
             # No prompts required for external agents
             prompts = PromptConfiguration()
@@ -373,6 +375,7 @@ def _main_impl(vuln_count):  # noqa: C901
                     repo_config=repo_config,
                     skip_writing_security_test=config.SKIP_WRITING_SECURITY_TEST,
                     session_id=session_id,
+                    language=vuln_language,
                 )
 
                 # Propagate a build command discovered by a previous agent run so the next

--- a/src/smartfix/domains/agents/smartfix_agent.py
+++ b/src/smartfix/domains/agents/smartfix_agent.py
@@ -251,6 +251,9 @@ class SmartFixAgent(CodingAgentStrategy):
             context.remediation_id,
             context.session_id,
             additional_tools=[build_tool],
+            vuln_uuid=context.vulnerability.uuid,
+            repo_slug=get_config().GITHUB_REPOSITORY,
+            language=context.language or "",
         )
 
         log("--- AI Agent Fix Attempt Completed ---")

--- a/src/smartfix/domains/agents/smartfix_agent.py
+++ b/src/smartfix/domains/agents/smartfix_agent.py
@@ -232,7 +232,8 @@ class SmartFixAgent(CodingAgentStrategy):
                 "5. Do NOT skip the build step or mark the task complete without a recorded successful build."
             )
 
-        custom_instructions = load_custom_instructions(repo_path, get_config()) or ""
+        config = get_config()
+        custom_instructions = load_custom_instructions(repo_path, config) or ""
         debug_log(
             f"Custom instructions appended ({len(custom_instructions)} chars)"
             if custom_instructions
@@ -252,7 +253,7 @@ class SmartFixAgent(CodingAgentStrategy):
             context.session_id,
             additional_tools=[build_tool],
             vuln_uuid=context.vulnerability.uuid,
-            repo_slug=get_config().GITHUB_REPOSITORY,
+            repo_slug=config.GITHUB_REPOSITORY,
             language=context.language or "",
         )
 

--- a/src/smartfix/domains/agents/sub_agent_executor.py
+++ b/src/smartfix/domains/agents/sub_agent_executor.py
@@ -84,7 +84,10 @@ class SubAgentExecutor:
         system_prompt: str,
         remediation_id: str,
         session_id: str = None,
-        additional_tools: list = None
+        additional_tools: list = None,
+        vuln_uuid: str = "",
+        repo_slug: str = "",
+        language: str = "",
     ) -> str:
         """
         Run the agent end-to-end: create session, create agent, execute, return summary.
@@ -96,6 +99,9 @@ class SubAgentExecutor:
             remediation_id: Remediation ID for error tracking
             session_id: ADK session ID for agent execution tracking
             additional_tools: Optional list of extra tools to add to the agent
+            vuln_uuid: Vulnerability UUID for LLM usage attribution
+            repo_slug: GitHub repository slug for LLM usage attribution
+            language: Source language for LLM usage attribution
 
         Returns:
             str: Summary from the agent execution
@@ -121,7 +127,8 @@ class SubAgentExecutor:
 
         agent = await self.create_agent(
             repo_root, remediation_id, session_id, system_prompt=system_prompt,
-            additional_tools=additional_tools
+            additional_tools=additional_tools,
+            vuln_uuid=vuln_uuid, repo_slug=repo_slug, language=language,
         )
         if not agent:
             log(
@@ -146,7 +153,10 @@ class SubAgentExecutor:
         remediation_id: str,
         session_id: str,
         system_prompt: Optional[str] = None,
-        additional_tools: list = None
+        additional_tools: list = None,
+        vuln_uuid: str = "",
+        repo_slug: str = "",
+        language: str = "",
     ) -> Optional[Agent]:
         """
         Create an ADK Agent.
@@ -157,6 +167,9 @@ class SubAgentExecutor:
             session_id: ADK session ID for agent execution tracking
             system_prompt: System prompt for agent instructions
             additional_tools: Optional list of extra tools (e.g., BuildTool) to include
+            vuln_uuid: Vulnerability UUID for LLM usage attribution
+            repo_slug: GitHub repository slug for LLM usage attribution
+            language: Source language for LLM usage attribution
 
         Returns:
             Agent: Configured ADK agent instance
@@ -184,15 +197,25 @@ class SubAgentExecutor:
             # Check if we should use Contrast LLM with custom headers
             if hasattr(self.config, 'USE_CONTRAST_LLM') and self.config.USE_CONTRAST_LLM:
                 setup_contrast_provider()
+                headers = {
+                    "Api-Key": f"{self.config.CONTRAST_API_KEY}",
+                    "Authorization": f"{self.config.CONTRAST_AUTHORIZATION_KEY}",
+                    "x-contrast-llm-feature": "SMARTFIX",
+                }
+                if vuln_uuid:
+                    headers["x-contrast-llm-fingerprint"] = vuln_uuid
+                if remediation_id:
+                    headers["x-contrast-llm-session-id"] = remediation_id
+                if repo_slug:
+                    headers["x-contrast-llm-repo"] = repo_slug
+                if language:
+                    headers["x-contrast-llm-source-language"] = language
                 model_instance = SmartFixLiteLlm(
                     model=self.config.AGENT_MODEL,
                     temperature=0.2,
                     stream_options={"include_usage": True},
-                    system=system_prompt,  # Use standard system parameter
-                    extra_headers={
-                        "Api-Key": f"{self.config.CONTRAST_API_KEY}",
-                        "Authorization": f"{self.config.CONTRAST_AUTHORIZATION_KEY}",
-                    }
+                    system=system_prompt,
+                    extra_headers=headers,
                 )
                 debug_log(f"Creating fix agent ({agent_name}) with model contrast_llm")
             else:

--- a/src/smartfix/domains/agents/sub_agent_executor.py
+++ b/src/smartfix/domains/agents/sub_agent_executor.py
@@ -205,6 +205,8 @@ class SubAgentExecutor:
                 if vuln_uuid:
                     headers["x-contrast-llm-fingerprint"] = vuln_uuid
                 if remediation_id:
+                    # session-id is the remediation_id, not the ADK session_id.
+                    # It groups all LLM calls for a single SmartFix PR attempt.
                     headers["x-contrast-llm-session-id"] = remediation_id
                 if repo_slug:
                     headers["x-contrast-llm-repo"] = repo_slug

--- a/src/smartfix/domains/vulnerability/context.py
+++ b/src/smartfix/domains/vulnerability/context.py
@@ -239,3 +239,4 @@ class RemediationContext:
     skip_writing_security_test: bool = False
     session_id: Optional[str] = None
     issue_body: Optional[str] = None
+    language: Optional[str] = None

--- a/test/test_agent_infrastructure.py
+++ b/test/test_agent_infrastructure.py
@@ -258,7 +258,8 @@ class TestSubAgentExecutor(unittest.TestCase):
         headers = call_kwargs['extra_headers']
         self.assertEqual(headers['Api-Key'], 'test-api-key')
         self.assertEqual(headers['Authorization'], 'test-auth-key')
-        self.assertNotIn('x-contrast-llm-session-id', headers)
+        self.assertEqual(headers['x-contrast-llm-feature'], 'SMARTFIX')
+        self.assertEqual(headers['x-contrast-llm-session-id'], 'test-123')
 
     @patch('src.smartfix.domains.agents.sub_agent_executor.error_exit')
     @patch('src.config.get_config')

--- a/test/test_agent_infrastructure.py
+++ b/test/test_agent_infrastructure.py
@@ -195,7 +195,7 @@ class TestSubAgentExecutor(unittest.TestCase):
         # Mock config
         config_mock = MagicMock()
         config_mock.AGENT_MODEL = 'test-model'
-        config_mock.USE_CONTRAST_LLM = 'false'
+        config_mock.USE_CONTRAST_LLM = False
         mock_get_config.return_value = config_mock
 
         # Mock MCP manager
@@ -226,7 +226,7 @@ class TestSubAgentExecutor(unittest.TestCase):
         # Mock config with Contrast LLM enabled
         config_mock = MagicMock()
         config_mock.AGENT_MODEL = 'test-model'
-        config_mock.USE_CONTRAST_LLM = 'true'
+        config_mock.USE_CONTRAST_LLM = True
         config_mock.CONTRAST_API_KEY = 'test-api-key'
         config_mock.CONTRAST_AUTHORIZATION_KEY = 'test-auth-key'
         mock_get_config.return_value = config_mock

--- a/test/test_smartfix_agent.py
+++ b/test/test_smartfix_agent.py
@@ -49,7 +49,7 @@ def _make_context(
     user_build_command=None,
     user_format_command=None,
     repo_path="/tmp/test",
-    language="Java",
+    language=None,
 ):
     """Build a real RemediationContext for tests that exercise _run_fix_agent_execution."""
     vulnerability = Vulnerability(

--- a/test/test_smartfix_agent.py
+++ b/test/test_smartfix_agent.py
@@ -33,7 +33,54 @@ from pathlib import Path
 
 from src.smartfix.domains.agents.smartfix_agent import SmartFixAgent
 from src.smartfix.domains.vulnerability import RemediationContext
+from src.smartfix.domains.vulnerability.context import (
+    PromptConfiguration, BuildConfiguration, RepositoryConfiguration
+)
+from src.smartfix.domains.vulnerability.models import Vulnerability, VulnerabilitySeverity
 from src.smartfix.shared.failure_categories import FailureCategory
+
+
+def _make_context(
+    remediation_id="test-remediation",
+    session_id="test-session",
+    fix_system_prompt="Fix system prompt",
+    fix_user_prompt="Fix user prompt",
+    build_command=None,
+    user_build_command=None,
+    user_format_command=None,
+    repo_path="/tmp/test",
+    language="Java",
+):
+    """Build a real RemediationContext for tests that exercise _run_fix_agent_execution."""
+    vulnerability = Vulnerability(
+        uuid="sample-vuln-uuid",
+        title="Sample Vulnerability",
+        rule_name="sample-rule",
+        severity=VulnerabilitySeverity.HIGH,
+    )
+    prompts = PromptConfiguration(
+        fix_system_prompt=fix_system_prompt,
+        fix_user_prompt=fix_user_prompt,
+    )
+    build_config = BuildConfiguration(
+        build_command=build_command,
+        user_build_command=user_build_command,
+        user_format_command=user_format_command,
+    )
+    repo_config = RepositoryConfiguration(
+        repo_path=repo_path,
+        base_branch="main",
+    )
+    return RemediationContext(
+        remediation_id=remediation_id,
+        vulnerability=vulnerability,
+        prompts=prompts,
+        build_config=build_config,
+        repo_config=repo_config,
+        skip_writing_security_test=False,
+        session_id=session_id,
+        language=language,
+    )
 
 
 class TestSmartFixAgentSuccessScenarios(unittest.TestCase):
@@ -243,19 +290,13 @@ class TestSmartFixAgentBuildToolIntegration(unittest.TestCase):
         mock_event_loop.return_value = "<pr_body>Fix applied</pr_body>"
 
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = False
-        context.build_config.user_build_command = "mvn test"
-        context.build_config.user_format_command = None
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix"
-        context.prompts.fix_user_prompt = "Fix"
-        context.remediation_id = "test-build-tool"
-        context.session_id = "session-bt"
-        context.skip_writing_security_test = False
+        context = _make_context(
+            remediation_id="test-build-tool",
+            session_id="session-bt",
+            fix_system_prompt="Fix",
+            fix_user_prompt="Fix",
+            user_build_command="mvn test",
+        )
 
         with patch.object(agent, '_extract_analytics_data'):
             agent.remediate(context)
@@ -358,19 +399,12 @@ class TestSmartFixAgentCustomInstructions(unittest.TestCase):
         mock_event_loop.return_value = "<pr_body>Fixed</pr_body>"
 
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = False
-        context.build_config.user_build_command = None
-        context.build_config.user_format_command = None
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix system"
-        context.prompts.fix_user_prompt = "Fix this vulnerability"
-        context.remediation_id = "test-ci-123"
-        context.session_id = "session-ci"
-        context.skip_writing_security_test = False
+        context = _make_context(
+            remediation_id="test-ci-123",
+            session_id="session-ci",
+            fix_system_prompt="Fix system",
+            fix_user_prompt="Fix this vulnerability",
+        )
 
         with patch.object(agent, '_extract_analytics_data'):
             agent.remediate(context)
@@ -389,19 +423,12 @@ class TestSmartFixAgentCustomInstructions(unittest.TestCase):
         mock_event_loop.return_value = "<pr_body>Fixed</pr_body>"
 
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = False
-        context.build_config.user_build_command = None
-        context.build_config.user_format_command = None
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix system"
-        context.prompts.fix_user_prompt = "Fix this vulnerability"
-        context.remediation_id = "test-no-ci"
-        context.session_id = "session-no-ci"
-        context.skip_writing_security_test = False
+        context = _make_context(
+            remediation_id="test-no-ci",
+            session_id="session-no-ci",
+            fix_system_prompt="Fix system",
+            fix_user_prompt="Fix this vulnerability",
+        )
 
         with patch.object(agent, '_extract_analytics_data'):
             agent.remediate(context)

--- a/test/test_sub_agent_executor.py
+++ b/test/test_sub_agent_executor.py
@@ -311,6 +311,8 @@ class TestSubAgentExecutorAgentCreation(unittest.TestCase):
             call_kwargs = mock_llm_class.call_args[1]
             self.assertEqual(call_kwargs["model"], "claude-sonnet-4.5")
             self.assertEqual(call_kwargs["temperature"], 0.2)
+            # Attribution headers should not be present for non-Contrast LLM
+            self.assertNotIn("extra_headers", call_kwargs)
             # Verify agent was created
             mock_agent_class.assert_called_once()
             agent_kwargs = mock_agent_class.call_args[1]
@@ -366,7 +368,12 @@ class TestSubAgentExecutorAgentCreation(unittest.TestCase):
             headers = call_kwargs["extra_headers"]
             self.assertEqual(headers["Api-Key"], "test-api-key")
             self.assertEqual(headers["Authorization"], "test-auth-key")
-            self.assertNotIn("x-contrast-llm-session-id", headers)
+            self.assertEqual(headers["x-contrast-llm-feature"], "SMARTFIX")
+            self.assertEqual(headers["x-contrast-llm-session-id"], "test-123")
+            # Attribution headers with empty defaults should be absent
+            self.assertNotIn("x-contrast-llm-fingerprint", headers)
+            self.assertNotIn("x-contrast-llm-repo", headers)
+            self.assertNotIn("x-contrast-llm-source-language", headers)
             # Verify agent was created with fix agent name
             mock_agent_class.assert_called_once()
             agent_kwargs = mock_agent_class.call_args[1]
@@ -411,6 +418,125 @@ class TestSubAgentExecutorAgentCreation(unittest.TestCase):
             call_args = mock_error_exit.call_args[0]
             self.assertEqual(call_args[0], "test-123")
             self.assertIn("INVALID_LLM_CONFIG", call_args[1])
+
+
+class TestSubAgentExecutorAttributionHeaders(unittest.TestCase):
+    """Test LLM usage attribution headers for Contrast LLM path."""
+
+    def test_contrast_llm_includes_all_attribution_headers(self):
+        """
+        Given all attribution parameters are provided,
+        when creating an agent with Contrast LLM,
+        then all x-contrast-llm-* headers should be present.
+        """
+        with patch('src.config.get_config') as mock_config, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLiteLlm') as mock_llm_class, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLlmAgent') as mock_agent_class, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.setup_contrast_provider'):
+
+            mock_config.return_value = Mock(
+                MAX_EVENTS_PER_AGENT=120,
+                USE_CONTRAST_LLM=True,
+                AGENT_MODEL="contrast/claude-sonnet-4-5",
+                CONTRAST_API_KEY="test-api-key",
+                CONTRAST_AUTHORIZATION_KEY="test-auth-key",
+            )
+            executor = SubAgentExecutor()
+            executor.mcp_manager.get_tools = AsyncMock(return_value=[Mock()])
+            mock_llm_class.return_value = Mock()
+            mock_agent_class.return_value = Mock()
+
+            asyncio.run(executor.create_agent(
+                target_folder=Path("/tmp/test"),
+                remediation_id="rem-001",
+                session_id="sess-001",
+                system_prompt="Fix the vulnerability",
+                vuln_uuid="3MUU-1GC8-U6DE-KDUO",
+                repo_slug="Contrast-Security-Inc/employee-management",
+                language="Java",
+            ))
+
+            headers = mock_llm_class.call_args[1]["extra_headers"]
+            self.assertEqual(headers["x-contrast-llm-feature"], "SMARTFIX")
+            self.assertEqual(headers["x-contrast-llm-fingerprint"], "3MUU-1GC8-U6DE-KDUO")
+            self.assertEqual(headers["x-contrast-llm-session-id"], "rem-001")
+            self.assertEqual(headers["x-contrast-llm-repo"], "Contrast-Security-Inc/employee-management")
+            self.assertEqual(headers["x-contrast-llm-source-language"], "Java")
+
+    def test_contrast_llm_omits_empty_attribution_headers(self):
+        """
+        Given attribution parameters are empty strings,
+        when creating an agent with Contrast LLM,
+        then optional x-contrast-llm-* headers should be absent.
+        """
+        with patch('src.config.get_config') as mock_config, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLiteLlm') as mock_llm_class, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLlmAgent') as mock_agent_class, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.setup_contrast_provider'):
+
+            mock_config.return_value = Mock(
+                MAX_EVENTS_PER_AGENT=120,
+                USE_CONTRAST_LLM=True,
+                AGENT_MODEL="contrast/claude-sonnet-4-5",
+                CONTRAST_API_KEY="test-api-key",
+                CONTRAST_AUTHORIZATION_KEY="test-auth-key",
+            )
+            executor = SubAgentExecutor()
+            executor.mcp_manager.get_tools = AsyncMock(return_value=[Mock()])
+            mock_llm_class.return_value = Mock()
+            mock_agent_class.return_value = Mock()
+
+            asyncio.run(executor.create_agent(
+                target_folder=Path("/tmp/test"),
+                remediation_id="",
+                session_id="sess-001",
+                system_prompt="Fix the vulnerability",
+                vuln_uuid="",
+                repo_slug="",
+                language="",
+            ))
+
+            headers = mock_llm_class.call_args[1]["extra_headers"]
+            # Feature header is always present
+            self.assertEqual(headers["x-contrast-llm-feature"], "SMARTFIX")
+            # All others should be absent when their source values are empty
+            self.assertNotIn("x-contrast-llm-fingerprint", headers)
+            self.assertNotIn("x-contrast-llm-session-id", headers)
+            self.assertNotIn("x-contrast-llm-repo", headers)
+            self.assertNotIn("x-contrast-llm-source-language", headers)
+
+    def test_standard_llm_does_not_receive_attribution_headers(self):
+        """
+        Given attribution parameters are provided,
+        when creating an agent with a standard (non-Contrast) LLM,
+        then no extra_headers should be passed to SmartFixLiteLlm.
+        """
+        with patch('src.config.get_config') as mock_config, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLiteLlm') as mock_llm_class, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLlmAgent') as mock_agent_class:
+
+            mock_config.return_value = Mock(
+                MAX_EVENTS_PER_AGENT=120,
+                USE_CONTRAST_LLM=False,
+                AGENT_MODEL="claude-sonnet-4-5",
+            )
+            executor = SubAgentExecutor()
+            executor.mcp_manager.get_tools = AsyncMock(return_value=[Mock()])
+            mock_llm_class.return_value = Mock()
+            mock_agent_class.return_value = Mock()
+
+            asyncio.run(executor.create_agent(
+                target_folder=Path("/tmp/test"),
+                remediation_id="rem-001",
+                session_id="sess-001",
+                system_prompt="Fix the vulnerability",
+                vuln_uuid="3MUU-1GC8-U6DE-KDUO",
+                repo_slug="Contrast-Security-Inc/employee-management",
+                language="Java",
+            ))
+
+            call_kwargs = mock_llm_class.call_args[1]
+            self.assertNotIn("extra_headers", call_kwargs)
 
 
 class TestSubAgentExecutorFunctionProcessing(unittest.TestCase):

--- a/test/test_vulnerability_context.py
+++ b/test/test_vulnerability_context.py
@@ -361,6 +361,29 @@ class TestRemediationContext(unittest.TestCase):
         self.assertIsInstance(context, RemediationContext)
         self.assertEqual(context.session_id, None)
 
+    def test_create_with_language(self):
+        """Test successful creation of remediation context with language."""
+        context = RemediationContext(
+            remediation_id="api-remediation-789",
+            vulnerability=self.valid_vulnerability,
+            prompts=self.prompts,
+            build_config=self.build_config,
+            repo_config=self.repo_config,
+            language="Java",
+        )
+        self.assertEqual(context.language, "Java")
+
+    def test_create_without_language_defaults_to_none(self):
+        """Test that language defaults to None when not provided."""
+        context = RemediationContext(
+            remediation_id="api-remediation-789",
+            vulnerability=self.valid_vulnerability,
+            prompts=self.prompts,
+            build_config=self.build_config,
+            repo_config=self.repo_config,
+        )
+        self.assertIsNone(context.language)
+
     def test_validate_raw_prompts_data_valid(self):
         """Test validate_raw_prompts_data with valid prompts data."""
         prompts_data = {


### PR DESCRIPTION
**Ticket:**
- https://contrast.atlassian.net/browse/AIML-697 (Smartfix)

**Overview:**
SmartFix now sends LLM usage attribution metadata to the LLM proxy so that token consumption can be tracked per feature, vulnerability, repository, and language. This is part of the Northstar GA LLM Token Controls epic (AIML-586).

**What Changed:**
- sub_agent_executor.py: Build a dict of x-contrast-llm-* headers (feature, fingerprint, session-id, repo, source-language) and pass them as extra_headers to SmartFixLiteLlm. Headers with empty values are omitted. Headers are only sent on the LLM proxy path, not on BYOLLM where the requests don't go to the proxy

**Review Notes:**
- Start at sub_agent_executor.py:197 where the headers dict is built. The x-contrast-llm-feature header is always "SMARTFIX". The other four are conditional on non-empty values. The language value comes from the prompt-details API response (exposed by AIML-736). fingerprint is the vulnerability UUID, session-id is the remediation ID.

**How I Tested:**
1. Stand up the local Docker stack (make aiml-run in aiml-services)
2. Run the smartfix action locally against a repo with Contrast vulnerabilities, with USE_CONTRAST_LLM=true
3. After a successful LLM call, query aiml_llm_proxy_api.llm_token_usage and verify:
  - feature = SMARTFIX
  - fingerprint = the vulnerability's Contrast UUID
  - session_id = the remediation ID (as binary UUID)
  - repo_slug = the GITHUB_REPOSITORY value
  - source_language = the language from the API (e.g. Java)
  - is_byo_llm = 0

**Evidence:**
```
mysql> SELECT feature, fingerprint, HEX(session_id) AS session_id, repo_slug, source_language, is_byo_llm, cost_nano_usd   FROM llm_token_usage   ORDER BY created_at DESC   LIMIT 5;
+----------+---------------------+----------------------------------+---------------------------------------------------+-----------------+------------+---------------+
| feature  | fingerprint         | session_id                       | repo_slug                                         | source_language | is_byo_llm | cost_nano_usd |
+----------+---------------------+----------------------------------+---------------------------------------------------+-----------------+------------+---------------+
| SMARTFIX | 2CMO-YF7T-210H-AK7W | 9FB779006A284686B25E1EBA4D4AA1FE | Contrast-Security-Inc/employee-management-service | Java            |          0 |      98160300 |
| SMARTFIX | 2CMO-YF7T-210H-AK7W | 9FB779006A284686B25E1EBA4D4AA1FE | Contrast-Security-Inc/employee-management-service | Java            |          0 |      81513300 |
| SMARTFIX | 2CMO-YF7T-210H-AK7W | 9FB779006A284686B25E1EBA4D4AA1FE | Contrast-Security-Inc/employee-management-service | Java            |          0 |      56769300 |
| SMARTFIX | 2CMO-YF7T-210H-AK7W | 9FB779006A284686B25E1EBA4D4AA1FE | Contrast-Security-Inc/employee-management-service | Java            |          0 |      57957300 |
| SMARTFIX | 2CMO-YF7T-210H-AK7W | 9FB779006A284686B25E1EBA4D4AA1FE | Contrast-Security-Inc/employee-management-service | Java            |          0 |      47718300 |
+----------+---------------------+----------------------------------+---------------------------------------------------+-----------------+------------+---------------+
```