### PR TITLE
AIML-752: tolerate scheme on contrast_host in OTel endpoint

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -400,9 +400,16 @@ runs:
     # Auth headers are always derived from Contrast credentials in code — not configurable here.
     - name: Set OTel defaults
       shell: bash
+      env:
+        INPUT_CONTRAST_HOST: ${{ inputs.contrast_host }}
       run: |
         if [ -z "${OTEL_EXPORTER_OTLP_ENDPOINT}" ]; then
-          echo "OTEL_EXPORTER_OTLP_ENDPOINT=https://${{ inputs.contrast_host }}/aiml/otel" >> $GITHUB_ENV
+          # Strip any scheme/trailing slash so we don't build "https://https://host/..." (fails DNS silently in OTel exporter).
+          HOST="${INPUT_CONTRAST_HOST}"
+          HOST="${HOST#https://}"
+          HOST="${HOST#http://}"
+          HOST="${HOST%/}"
+          echo "OTEL_EXPORTER_OTLP_ENDPOINT=https://${HOST}/aiml/otel" >> $GITHUB_ENV
         fi
 
 

--- a/action.yml
+++ b/action.yml
@@ -404,11 +404,14 @@ runs:
         INPUT_CONTRAST_HOST: ${{ inputs.contrast_host }}
       run: |
         if [ -z "${OTEL_EXPORTER_OTLP_ENDPOINT}" ]; then
-          # Strip any scheme/trailing slash so we don't build "https://https://host/..." (fails DNS silently in OTel exporter).
+          # Mirrors Python normalize_host: remove ALL occurrences of https:// and http://
+          # (handles double-scheme inputs like http://https://host) then strip all trailing slashes.
           HOST="${INPUT_CONTRAST_HOST}"
-          HOST="${HOST#https://}"
-          HOST="${HOST#http://}"
-          HOST="${HOST%/}"
+          HOST="${HOST//https:\/\//}"
+          HOST="${HOST//http:\/\//}"
+          while [ "${HOST%/}" != "${HOST}" ]; do
+            HOST="${HOST%/}"
+          done
           echo "OTEL_EXPORTER_OTLP_ENDPOINT=https://${HOST}/aiml/otel" >> $GITHUB_ENV
         fi
 

--- a/test/test_action_otel_endpoint.py
+++ b/test/test_action_otel_endpoint.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -
+# #%L
+# Contrast AI SmartFix
+# %%
+# Copyright (C) 2025 Contrast Security, Inc.
+# %%
+# Contact: support@contrastsecurity.com
+# License: Commercial
+# NOTICE: This Software and the patented inventions embodied within may only be
+# used as part of Contrast Security's commercial offerings. Even though it is
+# made available through public repositories, use of this Software is subject to
+# the applicable End User Licensing Agreement found at
+# https://www.contrastsecurity.com/enduser-terms-0317a or as otherwise agreed
+# between Contrast Security and the End User. The Software may not be reverse
+# engineered, modified, repackaged, sold, redistributed or otherwise used in a
+# way not consistent with the End User License Agreement.
+# #L%
+#
+
+import subprocess
+import unittest
+
+# The shell normalization logic extracted from action.yml "Set OTel defaults" step.
+# Must be kept in sync with that step if the logic changes.
+_NORMALIZE_SHELL = """
+HOST="${INPUT_CONTRAST_HOST}"
+HOST="${HOST//https:\\/\\//}"
+HOST="${HOST//http:\\/\\//}"
+while [ "${HOST%/}" != "${HOST}" ]; do
+  HOST="${HOST%/}"
+done
+echo "https://${HOST}/aiml/otel"
+"""
+
+
+def _normalize_via_shell(contrast_host: str) -> str:
+    result = subprocess.run(
+        ["bash", "-c", _NORMALIZE_SHELL],
+        env={"INPUT_CONTRAST_HOST": contrast_host},
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+class TestActionOtelEndpoint(unittest.TestCase):
+    """Tests for the OTel endpoint shell normalization in action.yml."""
+
+    def test_plain_hostname(self):
+        self.assertEqual(_normalize_via_shell("example.com"), "https://example.com/aiml/otel")
+
+    def test_https_prefix_stripped(self):
+        self.assertEqual(_normalize_via_shell("https://example.com"), "https://example.com/aiml/otel")
+
+    def test_http_prefix_stripped(self):
+        self.assertEqual(_normalize_via_shell("http://example.com"), "https://example.com/aiml/otel")
+
+    def test_single_trailing_slash_stripped(self):
+        self.assertEqual(_normalize_via_shell("https://example.com/"), "https://example.com/aiml/otel")
+
+    def test_multiple_trailing_slashes_stripped(self):
+        self.assertEqual(_normalize_via_shell("https://example.com///"), "https://example.com/aiml/otel")
+
+    def test_double_scheme_stripped(self):
+        self.assertEqual(_normalize_via_shell("http://https://example.com"), "https://example.com/aiml/otel")
+
+    def test_double_https_scheme_stripped(self):
+        self.assertEqual(_normalize_via_shell("https://https://example.com"), "https://example.com/aiml/otel")
+
+    def test_hostname_with_port(self):
+        self.assertEqual(_normalize_via_shell("https://example.com:8080"), "https://example.com:8080/aiml/otel")
+
+    def test_hostname_only_no_trailing_slash(self):
+        self.assertEqual(_normalize_via_shell("example.com"), "https://example.com/aiml/otel")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`action.yml` builds the OTel exporter endpoint by prepending `https://` to `inputs.contrast_host`. If the input already includes a scheme (e.g. `https://teamserver-staging.contsec.com`), the result becomes `https://https://...`, which the OTLP exporter parses as `host="https"`. It then fails DNS resolution silently from a `BatchSpanProcessor` background thread, flooding the Action log with stack traces while the actual fix workflow continues.

This change strips a leading `http://` or `https://` and any trailing slash from the input before prepending `https://`, so the action tolerates either form of `contrast_host`.

Scope is intentionally narrow — only the OTel endpoint construction. A related latent issue with how `CONTRAST_HOST` is later passed to Python (see `src/github/external_coding_agent.py` `f"https://{CONTRAST_HOST}/..."`) is left for a follow-up.

Jira: [AIML-752](https://contrast.atlassian.net/browse/AIML-752)

## Behavior matrix

| Input | Endpoint before | Endpoint after |
|---|---|---|
| `teamserver-staging.contsec.com` | `https://teamserver-staging.contsec.com/aiml/otel` | (unchanged) |
| `https://teamserver-staging.contsec.com` | `https://https://teamserver-staging.contsec.com/aiml/otel` ❌ | `https://teamserver-staging.contsec.com/aiml/otel` ✅ |
| `https://teamserver-staging.contsec.com/` | `https://https://teamserver-staging.contsec.com//aiml/otel` ❌ | `https://teamserver-staging.contsec.com/aiml/otel` ✅ |

## Test plan

- [x] `make test` passes locally (933 tests).
- [x] Shell logic verified against representative inputs (bare host, scheme-prefixed, trailing slash, empty).
- [ ] Confirm in a real workflow run that the OTel batch exporter no longer logs `NameResolutionError` for host `https`.

[AIML-752]: https://contrast.atlassian.net/browse/AIML-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ