### PR TITLE
AIML-655: Expand OTel span attributes for analytics

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -66,21 +66,23 @@ def main():
     otel_provider.initialize_otel(config)
     atexit.register(otel_provider.shutdown_otel)
 
-    # Use a list so _main_impl can increment it and the finally block sees the
+    # Use lists so _main_impl can mutate them and the finally block sees the
     # correct value even when _main_impl exits via error_exit()/sys.exit().
     vuln_count = [0]
+    prs_created_count = [0]
     try:
         with otel_provider.start_span("smartfix-run") as run_span:
             run_span.set_attribute("session.id", config.GITHUB_RUN_ID)
             try:
-                _main_impl(vuln_count)
+                _main_impl(vuln_count, prs_created_count)
             finally:
                 run_span.set_attribute("contrast.smartfix.vulnerabilities_total", vuln_count[0])
+                run_span.set_attribute("contrast.smartfix.prs_created_total", prs_created_count[0])
     finally:
         otel_provider.shutdown_otel()
 
 
-def _main_impl(vuln_count):  # noqa: C901
+def _main_impl(vuln_count, prs_created_count):  # noqa: C901
     """Main orchestration logic."""
 
     start_time = datetime.now()
@@ -344,6 +346,7 @@ def _main_impl(vuln_count):  # noqa: C901
         # Update tracking variable now that we know we're actually processing this vuln
         previous_vuln_uuid = vuln_uuid
         vuln_count[0] += 1
+        smartfix_metrics.reset_vuln_token_accumulator()
 
         log(f"\n\033[0;33m Selected vuln to fix: {vuln_title} \033[0m")
 
@@ -661,6 +664,7 @@ def _main_impl(vuln_count):  # noqa: C901
                     _op_pr_created = True
                     _op_pr_url = pr_url
                     _op_outcome = "success"
+                    prs_created_count[0] += 1
 
                     processed_one = True  # Mark that we successfully processed one
                     log(f"\n--- Successfully processed vulnerability {vuln_uuid}. Continuing to look for next vulnerability... ---")
@@ -684,11 +688,15 @@ def _main_impl(vuln_count):  # noqa: C901
                 lang = (telemetry_handler.get_telemetry_data().get("appInfo") or {}).get("programmingLanguage")
                 if lang:
                     op_span.set_attribute("contrast.finding.language", lang)
+                op_span.set_attribute("contrast.finding.severity", vulnerability.severity.value)
                 op_span.set_attribute("contrast.smartfix.fix_applied", _op_fix_applied)
                 op_span.set_attribute("contrast.smartfix.files_modified", _op_files_modified)
                 op_span.set_attribute("contrast.smartfix.pr_created", _op_pr_created)
                 if _op_pr_url:
                     op_span.set_attribute("contrast.smartfix.pr_url", _op_pr_url)
+                _total_in, _total_out = smartfix_metrics.get_vuln_token_totals()
+                op_span.set_attribute("contrast.smartfix.total_input_tokens", _total_in)
+                op_span.set_attribute("contrast.smartfix.total_output_tokens", _total_out)
                 smartfix_metrics.record_vulnerability_duration(
                     elapsed_s=time.monotonic() - _op_fix_start,
                     outcome=_op_outcome,

--- a/src/main.py
+++ b/src/main.py
@@ -69,6 +69,9 @@ def main():
     # Use lists so _main_impl can mutate them and the finally block sees the
     # correct value even when _main_impl exits via error_exit()/sys.exit().
     vuln_count = [0]
+    # Only counts PRs created by the SmartFix-internal agent.  External-agent
+    # runs (Copilot, Claude Code) create their PR asynchronously after the
+    # GitHub Issue is filed, so they are not reflected here.
     prs_created_count = [0]
     try:
         with otel_provider.start_span("smartfix-run") as run_span:
@@ -82,7 +85,7 @@ def main():
         otel_provider.shutdown_otel()
 
 
-def _main_impl(vuln_count, prs_created_count):  # noqa: C901
+def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # noqa: C901
     """Main orchestration logic."""
 
     start_time = datetime.now()
@@ -197,6 +200,7 @@ def _main_impl(vuln_count, prs_created_count):  # noqa: C901
 
     while True:
         telemetry_handler.reset_vuln_specific_telemetry()
+        smartfix_metrics.reset_vuln_token_accumulator()
         # Check if we've exceeded the maximum runtime
         current_time = datetime.now()
         elapsed_time = current_time - start_time
@@ -346,7 +350,6 @@ def _main_impl(vuln_count, prs_created_count):  # noqa: C901
         # Update tracking variable now that we know we're actually processing this vuln
         previous_vuln_uuid = vuln_uuid
         vuln_count[0] += 1
-        smartfix_metrics.reset_vuln_token_accumulator()
 
         log(f"\n\033[0;33m Selected vuln to fix: {vuln_title} \033[0m")
 

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -181,6 +181,9 @@ def handle_merged_pr():
     config = get_config()
     telemetry_handler.initialize_telemetry()
     otel_provider.initialize_otel(config)
+    # atexit guard ensures flush even when sys.exit() is called deep in a
+    # helper.  The explicit finally below handles normal flow; shutdown_otel
+    # is idempotent (guarded by _shutdown_called) so double-calling is safe.
     atexit.register(otel_provider.shutdown_otel)
 
     log("--- Handling Merged Contrast AI SmartFix Pull Request ---")

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -188,23 +188,20 @@ def handle_merged_pr():
 
     log("--- Handling Merged Contrast AI SmartFix Pull Request ---")
 
-    # Load and validate event before starting the span so non-merge events
-    # don't produce a smartfix-merge span with pr_merged=true.
+    # Validate event and extract all identifiers before opening the span so that
+    # sys.exit() in any helper does not flush a merge span with pr_merged=true
+    # but without remediation_id / fingerprint (which creates uncorrelatable events).
     event_data = _load_github_event()
     pull_request = _validate_pr_event(event_data)
+    remediation_id, labels = _extract_remediation_info(pull_request)
+    vuln_uuid = _extract_vulnerability_info(labels)
 
     try:
         with otel_provider.start_span("smartfix-merge") as merge_span:
             merge_span.set_attribute("contrast.smartfix.pr_merged", True)
-
-            # Extract remediation and vulnerability information
-            remediation_id, labels = _extract_remediation_info(pull_request)
-            vuln_uuid = _extract_vulnerability_info(labels)
-
             merge_span.set_attribute("contrast.smartfix.remediation_id", remediation_id)
             merge_span.set_attribute("contrast.finding.fingerprint", vuln_uuid)
 
-            # Update telemetry with extracted information
             debug_log(f"Extracted Remediation ID: {remediation_id}")
             telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)
             telemetry_handler.update_telemetry("vulnInfo.vulnId", vuln_uuid)

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -17,6 +17,7 @@
 # #L%
 #
 
+import atexit
 import os
 import json
 import sys
@@ -26,7 +27,7 @@ from src import contrast_api
 from src.config import get_config  # Using get_config function instead of direct import
 from src.utils import debug_log, extract_remediation_id_from_branch, extract_remediation_id_from_labels, log
 from src.github.github_operations import GitHubOperations
-from src.smartfix.domains.telemetry import telemetry_handler
+from src.smartfix.domains.telemetry import otel_provider, telemetry_handler
 
 
 def _load_github_event() -> dict:
@@ -177,40 +178,51 @@ def _cleanup_smartfix_labels(pull_request: dict, labels: list) -> None:
 
 def handle_merged_pr():
     """Handles the logic when a pull request is merged."""
+    config = get_config()
     telemetry_handler.initialize_telemetry()
+    otel_provider.initialize_otel(config)
+    atexit.register(otel_provider.shutdown_otel)
 
     log("--- Handling Merged Contrast AI SmartFix Pull Request ---")
 
-    # Load and validate GitHub event data
-    event_data = _load_github_event()
-    pull_request = _validate_pr_event(event_data)
+    try:
+        with otel_provider.start_span("smartfix-merge") as merge_span:
+            merge_span.set_attribute("contrast.smartfix.pr_merged", True)
 
-    # Extract remediation and vulnerability information
-    remediation_id, labels = _extract_remediation_info(pull_request)
-    vuln_uuid = _extract_vulnerability_info(labels)
+            # Load and validate GitHub event data
+            event_data = _load_github_event()
+            pull_request = _validate_pr_event(event_data)
 
-    # Update telemetry with extracted information
-    debug_log(f"Extracted Remediation ID: {remediation_id}")
-    telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)
-    telemetry_handler.update_telemetry("vulnInfo.vulnId", vuln_uuid)
-    telemetry_handler.update_telemetry("vulnInfo.vulnRule", "unknown")
+            # Extract remediation and vulnerability information
+            remediation_id, labels = _extract_remediation_info(pull_request)
+            vuln_uuid = _extract_vulnerability_info(labels)
 
-    # Notify the Remediation backend service
-    _notify_remediation_service(remediation_id)
+            merge_span.set_attribute("contrast.smartfix.remediation_id", remediation_id)
+            merge_span.set_attribute("contrast.finding.fingerprint", vuln_uuid)
 
-    # Complete telemetry and finish
-    telemetry_handler.update_telemetry("additionalAttributes.prStatus", "MERGED")
-    config = get_config()
-    contrast_api.send_telemetry_data_org(
-        remediation_id=remediation_id,
-        telemetry_data=telemetry_handler.get_telemetry_data(),
-        contrast_host=config.CONTRAST_HOST,
-        contrast_org_id=config.CONTRAST_ORG_ID,
-        contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
-        contrast_api_key=config.CONTRAST_API_KEY
-    )
+            # Update telemetry with extracted information
+            debug_log(f"Extracted Remediation ID: {remediation_id}")
+            telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)
+            telemetry_handler.update_telemetry("vulnInfo.vulnId", vuln_uuid)
+            telemetry_handler.update_telemetry("vulnInfo.vulnRule", "unknown")
 
-    _cleanup_smartfix_labels(pull_request, labels)
+            # Notify the Remediation backend service
+            _notify_remediation_service(remediation_id)
+
+            # Complete telemetry and finish
+            telemetry_handler.update_telemetry("additionalAttributes.prStatus", "MERGED")
+            contrast_api.send_telemetry_data_org(
+                remediation_id=remediation_id,
+                telemetry_data=telemetry_handler.get_telemetry_data(),
+                contrast_host=config.CONTRAST_HOST,
+                contrast_org_id=config.CONTRAST_ORG_ID,
+                contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
+                contrast_api_key=config.CONTRAST_API_KEY
+            )
+
+            _cleanup_smartfix_labels(pull_request, labels)
+    finally:
+        otel_provider.shutdown_otel()
 
     log("--- Merged Contrast AI SmartFix Pull Request Handling Complete ---")
 

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -188,13 +188,14 @@ def handle_merged_pr():
 
     log("--- Handling Merged Contrast AI SmartFix Pull Request ---")
 
+    # Load and validate event before starting the span so non-merge events
+    # don't produce a smartfix-merge span with pr_merged=true.
+    event_data = _load_github_event()
+    pull_request = _validate_pr_event(event_data)
+
     try:
         with otel_provider.start_span("smartfix-merge") as merge_span:
             merge_span.set_attribute("contrast.smartfix.pr_merged", True)
-
-            # Load and validate GitHub event data
-            event_data = _load_github_event()
-            pull_request = _validate_pr_event(event_data)
 
             # Extract remediation and vulnerability information
             remediation_id, labels = _extract_remediation_info(pull_request)

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -183,6 +183,10 @@ def record_vulnerability_duration(
 def record_pr_attempt(outcome: str, rule_name: str, coding_agent: str) -> None:
     """Record a PR creation attempt.
 
+    Note for dashboard consumers: this counter reflects only PRs created by the
+    internal SmartFix agent. External-agent PRs (Copilot, Claude Code) are not
+    counted here, though they may produce merge spans via handle_merged_pr().
+
     Args:
         outcome: "success" or "failure".
         rule_name: Contrast rule name.

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -52,6 +52,11 @@ _cache_tokens_counter = None
 _llm_duration_histogram = None
 _llm_retries_counter = None
 
+# --- Per-vulnerability token accumulator ---
+# Reset at the start of each vulnerability; read in the fix-vulnerability span finally block.
+_vuln_input_tokens: int = 0
+_vuln_output_tokens: int = 0
+
 
 # ---------------------------------------------------------------------------
 # Lazy getters
@@ -124,6 +129,22 @@ def _get_llm_retries_counter():
 
 
 # ---------------------------------------------------------------------------
+# Per-vulnerability token accumulator helpers
+# ---------------------------------------------------------------------------
+
+def reset_vuln_token_accumulator() -> None:
+    """Reset per-vulnerability token counters. Call at the start of each vulnerability loop."""
+    global _vuln_input_tokens, _vuln_output_tokens
+    _vuln_input_tokens = 0
+    _vuln_output_tokens = 0
+
+
+def get_vuln_token_totals() -> tuple:
+    """Return (total_input_tokens, total_output_tokens) accumulated for the current vulnerability."""
+    return _vuln_input_tokens, _vuln_output_tokens
+
+
+# ---------------------------------------------------------------------------
 # Public recording helpers
 # ---------------------------------------------------------------------------
 
@@ -184,6 +205,7 @@ def record_llm_call_tokens(
         cache_write_tokens: Prompt-cache write (creation) tokens.
         model: LiteLLM model string (e.g. "contrast/claude-sonnet-4-5").
     """
+    global _vuln_input_tokens, _vuln_output_tokens
     try:
         total_counter = _get_tokens_total_counter()
         total_input = input_tokens + cache_read_tokens + cache_write_tokens
@@ -196,6 +218,9 @@ def record_llm_call_tokens(
                 cache_counter.add(cache_read_tokens, {"gen_ai.token.type": "read", "gen_ai.request.model": model})
             if cache_write_tokens:
                 cache_counter.add(cache_write_tokens, {"gen_ai.token.type": "write", "gen_ai.request.model": model})
+
+        _vuln_input_tokens += total_input
+        _vuln_output_tokens += output_tokens
     except Exception:
         pass
 

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -36,6 +36,15 @@ Per-LLM-call (emitted from smartfix_litellm.py):
 Per-vulnerability (emitted from main.py):
   smartfix.vulnerability.duration  histogram(s)  end-to-end fix latency
   smartfix.pr.count                counter       PR creation attempts
+
+Per-vulnerability token accumulator
+------------------------------------
+Module-level integers (_vuln_input_tokens, _vuln_output_tokens) that are
+reset via reset_vuln_token_accumulator() at the start of each vulnerability
+loop iteration, and incremented by record_llm_call_tokens() on every LLM call.
+Call get_vuln_token_totals() in the fix-vulnerability span's finally block to
+attach total token usage as span attributes.  Accumulation happens outside the
+OTel try/except so a failed counter write never silently zeroes the totals.
 """
 
 from typing import Optional
@@ -139,7 +148,7 @@ def reset_vuln_token_accumulator() -> None:
     _vuln_output_tokens = 0
 
 
-def get_vuln_token_totals() -> tuple:
+def get_vuln_token_totals() -> tuple[int, int]:
     """Return (total_input_tokens, total_output_tokens) accumulated for the current vulnerability."""
     return _vuln_input_tokens, _vuln_output_tokens
 
@@ -206,9 +215,13 @@ def record_llm_call_tokens(
         model: LiteLLM model string (e.g. "contrast/claude-sonnet-4-5").
     """
     global _vuln_input_tokens, _vuln_output_tokens
+    total_input = input_tokens + cache_read_tokens + cache_write_tokens
+    # Accumulate outside the try block so that a failure in the OTel counter
+    # (e.g. meter not yet initialised) never silently zeroes the per-vulnerability totals.
+    _vuln_input_tokens += total_input
+    _vuln_output_tokens += output_tokens
     try:
         total_counter = _get_tokens_total_counter()
-        total_input = input_tokens + cache_read_tokens + cache_write_tokens
         total_counter.add(total_input, {"gen_ai.token.type": "input", "gen_ai.request.model": model})
         total_counter.add(output_tokens, {"gen_ai.token.type": "output", "gen_ai.request.model": model})
 
@@ -218,9 +231,6 @@ def record_llm_call_tokens(
                 cache_counter.add(cache_read_tokens, {"gen_ai.token.type": "read", "gen_ai.request.model": model})
             if cache_write_tokens:
                 cache_counter.add(cache_write_tokens, {"gen_ai.token.type": "write", "gen_ai.request.model": model})
-
-        _vuln_input_tokens += total_input
-        _vuln_output_tokens += output_tokens
     except Exception:
         pass
 

--- a/test/test_otel_spans.py
+++ b/test/test_otel_spans.py
@@ -92,11 +92,12 @@ class TestSmartFixRunSpan(unittest.TestCase):
     def tearDown(self):
         self.patch_ctx.__exit__(None, None, None)
 
-    def _emit_run_span(self, session_id="run-99999", vuln_count=2):
+    def _emit_run_span(self, session_id="run-99999", vuln_count=2, prs_created_total=0):
         import src.smartfix.domains.telemetry.otel_provider as otel_provider
         with otel_provider.start_span("smartfix-run") as span:
             span.set_attribute("session.id", session_id)
             span.set_attribute("contrast.smartfix.vulnerabilities_total", vuln_count)
+            span.set_attribute("contrast.smartfix.prs_created_total", prs_created_total)
 
     def test_smartfix_run_span_has_session_id(self):
         self._emit_run_span(session_id="run-12345")
@@ -127,6 +128,16 @@ class TestSmartFixRunSpan(unittest.TestCase):
         spans = _spans_named(self.exporter, "smartfix-run")
         self.assertNotIn("contrast.smartfix.pr_url", spans[0].attributes)
 
+    def test_smartfix_run_span_has_prs_created_total(self):
+        self._emit_run_span(prs_created_total=3)
+        spans = _spans_named(self.exporter, "smartfix-run")
+        self.assertEqual(spans[0].attributes["contrast.smartfix.prs_created_total"], 3)
+
+    def test_smartfix_run_span_prs_created_total_zero_when_no_prs(self):
+        self._emit_run_span(prs_created_total=0)
+        spans = _spans_named(self.exporter, "smartfix-run")
+        self.assertEqual(spans[0].attributes["contrast.smartfix.prs_created_total"], 0)
+
 
 # ---------------------------------------------------------------------------
 # TestFixVulnerabilitySpan — operation span attributes
@@ -150,10 +161,13 @@ class TestFixVulnerabilitySpan(unittest.TestCase):
             rule_id="sql-injection",
             coding_agent="smartfix",
             language="java",
+            severity="HIGH",
             fix_applied=True,
             files_modified=2,
             pr_created=True,
             pr_url="https://github.com/org/repo/pull/42",
+            total_input_tokens=0,
+            total_output_tokens=0,
         )
         attrs.update(overrides)
         with otel_provider.start_span("fix-vulnerability") as span:
@@ -162,9 +176,12 @@ class TestFixVulnerabilitySpan(unittest.TestCase):
             span.set_attribute("contrast.finding.rule_id", attrs["rule_id"])
             span.set_attribute("contrast.smartfix.coding_agent", attrs["coding_agent"])
             span.set_attribute("contrast.finding.language", attrs["language"])
+            span.set_attribute("contrast.finding.severity", attrs["severity"])
             span.set_attribute("contrast.smartfix.fix_applied", attrs["fix_applied"])
             span.set_attribute("contrast.smartfix.files_modified", attrs["files_modified"])
             span.set_attribute("contrast.smartfix.pr_created", attrs["pr_created"])
+            span.set_attribute("contrast.smartfix.total_input_tokens", attrs["total_input_tokens"])
+            span.set_attribute("contrast.smartfix.total_output_tokens", attrs["total_output_tokens"])
             if attrs.get("pr_url"):
                 span.set_attribute("contrast.smartfix.pr_url", attrs["pr_url"])
 
@@ -214,6 +231,18 @@ class TestFixVulnerabilitySpan(unittest.TestCase):
         """pr_url should not be set when no PR was created."""
         self._emit(pr_url=None)
         self.assertNotIn("contrast.smartfix.pr_url", self._span().attributes)
+
+    def test_has_finding_severity(self):
+        self._emit(severity="CRITICAL")
+        self.assertEqual(self._span().attributes["contrast.finding.severity"], "CRITICAL")
+
+    def test_has_total_input_tokens(self):
+        self._emit(total_input_tokens=1500)
+        self.assertEqual(self._span().attributes["contrast.smartfix.total_input_tokens"], 1500)
+
+    def test_has_total_output_tokens(self):
+        self._emit(total_output_tokens=320)
+        self.assertEqual(self._span().attributes["contrast.smartfix.total_output_tokens"], 320)
 
 
 # ---------------------------------------------------------------------------
@@ -388,6 +417,48 @@ class TestLlmCallSpan(unittest.TestCase):
         self.assertEqual(len(llm_spans), 1)
         self.assertEqual(llm_spans[0].attributes["gen_ai.usage.input_tokens"], 200)
         self.assertEqual(llm_spans[0].attributes["gen_ai.usage.output_tokens"], 80)
+
+
+# ---------------------------------------------------------------------------
+# TestSmartFixMergeSpan — merge event span attributes
+# ---------------------------------------------------------------------------
+
+class TestSmartFixMergeSpan(unittest.TestCase):
+    """Verify the smartfix-merge span emitted by merge_handler."""
+
+    def setUp(self):
+        self.exporter, self.patch_ctx = _make_span_recorder()
+        self.patch_ctx.__enter__()
+
+    def tearDown(self):
+        self.patch_ctx.__exit__(None, None, None)
+
+    def _emit_merge_span(self, remediation_id="rem-abc", vuln_uuid="vuln-xyz"):
+        import src.smartfix.domains.telemetry.otel_provider as otel_provider
+        with otel_provider.start_span("smartfix-merge") as span:
+            span.set_attribute("contrast.smartfix.pr_merged", True)
+            span.set_attribute("contrast.smartfix.remediation_id", remediation_id)
+            span.set_attribute("contrast.finding.fingerprint", vuln_uuid)
+
+    def test_merge_span_emitted(self):
+        self._emit_merge_span()
+        spans = _spans_named(self.exporter, "smartfix-merge")
+        self.assertEqual(len(spans), 1)
+
+    def test_merge_span_has_pr_merged_true(self):
+        self._emit_merge_span()
+        spans = _spans_named(self.exporter, "smartfix-merge")
+        self.assertTrue(spans[0].attributes["contrast.smartfix.pr_merged"])
+
+    def test_merge_span_has_remediation_id(self):
+        self._emit_merge_span(remediation_id="rem-12345")
+        spans = _spans_named(self.exporter, "smartfix-merge")
+        self.assertEqual(spans[0].attributes["contrast.smartfix.remediation_id"], "rem-12345")
+
+    def test_merge_span_has_finding_fingerprint(self):
+        self._emit_merge_span(vuln_uuid="vuln-abc123")
+        spans = _spans_named(self.exporter, "smartfix-merge")
+        self.assertEqual(spans[0].attributes["contrast.finding.fingerprint"], "vuln-abc123")
 
 
 if __name__ == "__main__":

--- a/test/test_otel_spans.py
+++ b/test/test_otel_spans.py
@@ -460,6 +460,27 @@ class TestSmartFixMergeSpan(unittest.TestCase):
         spans = _spans_named(self.exporter, "smartfix-merge")
         self.assertEqual(spans[0].attributes["contrast.finding.fingerprint"], "vuln-abc123")
 
+    @patch('src.merge_handler.otel_provider.shutdown_otel')
+    @patch('src.merge_handler.atexit.register')
+    @patch('src.merge_handler.otel_provider.initialize_otel')
+    @patch('src.smartfix.domains.telemetry.telemetry_handler.initialize_telemetry')
+    @patch('src.merge_handler._validate_pr_event')
+    @patch('src.merge_handler._load_github_event')
+    @patch('src.merge_handler._extract_remediation_info', side_effect=SystemExit(1))
+    def test_no_merge_span_when_extraction_fails(
+        self, _mock_extract, mock_load, mock_validate,
+        _mock_init_tel, _mock_init_otel, _mock_atexit, _mock_shutdown
+    ):
+        """Extraction failure before start_span must produce zero smartfix-merge spans."""
+        mock_load.return_value = {}
+        mock_validate.return_value = {"merged": True}
+
+        with self.assertRaises(SystemExit):
+            import src.merge_handler as merge_handler
+            merge_handler.handle_merged_pr()
+
+        self.assertEqual(len(_spans_named(self.exporter, "smartfix-merge")), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -278,11 +278,15 @@ class TestVulnTokenAccumulator(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
+        self._m = m
+        self._orig_total = m._tokens_total_counter
+        self._orig_cache = m._cache_tokens_counter
         m.reset_vuln_token_accumulator()
 
     def tearDown(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.reset_vuln_token_accumulator()
+        self._m._tokens_total_counter = self._orig_total
+        self._m._cache_tokens_counter = self._orig_cache
+        self._m.reset_vuln_token_accumulator()
 
     def test_reset_clears_counts(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -273,5 +273,75 @@ class TestRecordLlmRetry(unittest.TestCase):
         m.record_llm_retry("contrast/claude-sonnet-4-5", "RateLimitError")
 
 
+class TestVulnTokenAccumulator(unittest.TestCase):
+    """Tests for the per-vulnerability token accumulator."""
+
+    def setUp(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.reset_vuln_token_accumulator()
+
+    def tearDown(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.reset_vuln_token_accumulator()
+
+    def test_reset_clears_counts(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m._vuln_input_tokens = 500
+        m._vuln_output_tokens = 200
+        m.reset_vuln_token_accumulator()
+        self.assertEqual(m._vuln_input_tokens, 0)
+        self.assertEqual(m._vuln_output_tokens, 0)
+
+    def test_get_totals_returns_zero_after_reset(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        input_t, output_t = m.get_vuln_token_totals()
+        self.assertEqual(input_t, 0)
+        self.assertEqual(output_t, 0)
+
+    def test_accumulates_across_multiple_calls(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        mock_total = MagicMock()
+        mock_cache = MagicMock()
+        m._tokens_total_counter = mock_total
+        m._cache_tokens_counter = mock_cache
+
+        m.record_llm_call_tokens(100, 50, 0, 0, "model-a")
+        m.record_llm_call_tokens(200, 80, 0, 0, "model-a")
+        m.record_llm_call_tokens(300, 120, 0, 0, "model-a")
+
+        input_t, output_t = m.get_vuln_token_totals()
+        self.assertEqual(input_t, 600)
+        self.assertEqual(output_t, 250)
+
+    def test_accumulator_includes_cache_tokens_in_input(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        mock_total = MagicMock()
+        mock_cache = MagicMock()
+        m._tokens_total_counter = mock_total
+        m._cache_tokens_counter = mock_cache
+
+        # 50 new input + 30 cache_read + 20 cache_write = 100 total input
+        m.record_llm_call_tokens(50, 40, 30, 20, "model-b")
+
+        input_t, output_t = m.get_vuln_token_totals()
+        self.assertEqual(input_t, 100)
+        self.assertEqual(output_t, 40)
+
+    def test_reset_between_vulnerabilities(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        mock_total = MagicMock()
+        mock_cache = MagicMock()
+        m._tokens_total_counter = mock_total
+        m._cache_tokens_counter = mock_cache
+
+        m.record_llm_call_tokens(100, 50, 0, 0, "model-a")
+        m.reset_vuln_token_accumulator()
+        m.record_llm_call_tokens(200, 80, 0, 0, "model-a")
+
+        input_t, output_t = m.get_vuln_token_totals()
+        self.assertEqual(input_t, 200)
+        self.assertEqual(output_t, 80)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Jira: [AIML-655](https://contrast.atlassian.net/browse/AIML-655)

Expands OpenTelemetry instrumentation in the SmartFix GitHub Action to emit the full set of attributes needed for analytics.

**New span attributes:**

| Attribute | Span | Source |
|---|---|---|
| `contrast.finding.severity` | `fix-vulnerability` | `Vulnerability.severity.value` |
| `contrast.smartfix.total_input_tokens` | `fix-vulnerability` | Accumulated across all LLM calls per vulnerability |
| `contrast.smartfix.total_output_tokens` | `fix-vulnerability` | Accumulated across all LLM calls per vulnerability |
| `contrast.smartfix.prs_created_total` | `smartfix-run` (root) | Count of PRs successfully created during the run |
| `contrast.smartfix.pr_merged` | `smartfix-merge` (new) | Always `true` -- only emitted on merge events |
| `contrast.smartfix.remediation_id` | `smartfix-merge` (new) | Remediation ID extracted from PR labels/branch |
| `contrast.finding.fingerprint` | `smartfix-merge` (new) | Vulnerability UUID extracted from PR labels |

Note: the following attributes were already emitted on `fix-vulnerability` spans before this PR and required no changes: `contrast.finding.language`, `contrast.finding.fingerprint`, `contrast.smartfix.pr_created`. These are per-vulnerability attributes and are not present on the `smartfix-run` root span (which aggregates across all vulnerabilities in a run).

**Changes:**

- `src/smartfix/domains/telemetry/smartfix_metrics.py`: Add per-vulnerability token accumulator (`reset_vuln_token_accumulator()`, `get_vuln_token_totals()`). Update `record_llm_call_tokens()` to accumulate into module-level counters alongside the existing OTel metric recording.
- `src/main.py`: Emit `contrast.finding.severity`, token totals on `fix-vulnerability` span; emit `prs_created_total` on `smartfix-run` span; reset token accumulator at start of each vulnerability iteration.
- `src/merge_handler.py`: Initialize OTel and wrap merge logic in a `smartfix-merge` span with `pr_merged`, `remediation_id`, and `fingerprint` attributes.

## Test plan

- [x] 14 new unit tests added (span schema tests in `test_otel_spans.py`, accumulator behavior tests in `test_smartfix_metrics.py`)
- [x] All 947 tests pass locally (`make test`)
- [x] Pre-push linting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIML-655]: https://contrast.atlassian.net/browse/AIML-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ