### PR TITLE
AIML-771 unmockify smartfix

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -268,6 +268,7 @@ def _main_impl(vuln_count):  # noqa: C901
             vuln_title = vulnerability_data['vulnerabilityTitle']
             remediation_id = vulnerability_data['remediationId']
             session_id = vulnerability_data.get('sessionId')
+            vuln_language = vulnerability_data.get('language')
 
             # Validate and create prompt configuration for SmartFix agent
             try:
@@ -310,6 +311,7 @@ def _main_impl(vuln_count):  # noqa: C901
             vuln_title = vulnerability_data['vulnerabilityTitle']
             remediation_id = vulnerability_data['remediationId']
             session_id = None  # External agents don't use Contrast LLM sessions
+            vuln_language = vulnerability_data.get('language')
 
             # No prompts required for external agents
             prompts = PromptConfiguration()
@@ -373,6 +375,7 @@ def _main_impl(vuln_count):  # noqa: C901
                     repo_config=repo_config,
                     skip_writing_security_test=config.SKIP_WRITING_SECURITY_TEST,
                     session_id=session_id,
+                    language=vuln_language,
                 )
 
                 # Propagate a build command discovered by a previous agent run so the next

--- a/src/smartfix/domains/agents/smartfix_agent.py
+++ b/src/smartfix/domains/agents/smartfix_agent.py
@@ -251,6 +251,9 @@ class SmartFixAgent(CodingAgentStrategy):
             context.remediation_id,
             context.session_id,
             additional_tools=[build_tool],
+            vuln_uuid=context.vulnerability.uuid,
+            repo_slug=get_config().GITHUB_REPOSITORY,
+            language=context.language or "",
         )
 
         log("--- AI Agent Fix Attempt Completed ---")

--- a/src/smartfix/domains/agents/smartfix_agent.py
+++ b/src/smartfix/domains/agents/smartfix_agent.py
@@ -232,7 +232,8 @@ class SmartFixAgent(CodingAgentStrategy):
                 "5. Do NOT skip the build step or mark the task complete without a recorded successful build."
             )
 
-        custom_instructions = load_custom_instructions(repo_path, get_config()) or ""
+        config = get_config()
+        custom_instructions = load_custom_instructions(repo_path, config) or ""
         debug_log(
             f"Custom instructions appended ({len(custom_instructions)} chars)"
             if custom_instructions
@@ -252,7 +253,7 @@ class SmartFixAgent(CodingAgentStrategy):
             context.session_id,
             additional_tools=[build_tool],
             vuln_uuid=context.vulnerability.uuid,
-            repo_slug=get_config().GITHUB_REPOSITORY,
+            repo_slug=config.GITHUB_REPOSITORY,
             language=context.language or "",
         )
 

--- a/src/smartfix/domains/agents/sub_agent_executor.py
+++ b/src/smartfix/domains/agents/sub_agent_executor.py
@@ -84,7 +84,10 @@ class SubAgentExecutor:
         system_prompt: str,
         remediation_id: str,
         session_id: str = None,
-        additional_tools: list = None
+        additional_tools: list = None,
+        vuln_uuid: str = "",
+        repo_slug: str = "",
+        language: str = "",
     ) -> str:
         """
         Run the agent end-to-end: create session, create agent, execute, return summary.
@@ -96,6 +99,9 @@ class SubAgentExecutor:
             remediation_id: Remediation ID for error tracking
             session_id: ADK session ID for agent execution tracking
             additional_tools: Optional list of extra tools to add to the agent
+            vuln_uuid: Vulnerability UUID for LLM usage attribution
+            repo_slug: GitHub repository slug for LLM usage attribution
+            language: Source language for LLM usage attribution
 
         Returns:
             str: Summary from the agent execution
@@ -121,7 +127,8 @@ class SubAgentExecutor:
 
         agent = await self.create_agent(
             repo_root, remediation_id, session_id, system_prompt=system_prompt,
-            additional_tools=additional_tools
+            additional_tools=additional_tools,
+            vuln_uuid=vuln_uuid, repo_slug=repo_slug, language=language,
         )
         if not agent:
             log(
@@ -146,7 +153,10 @@ class SubAgentExecutor:
         remediation_id: str,
         session_id: str,
         system_prompt: Optional[str] = None,
-        additional_tools: list = None
+        additional_tools: list = None,
+        vuln_uuid: str = "",
+        repo_slug: str = "",
+        language: str = "",
     ) -> Optional[Agent]:
         """
         Create an ADK Agent.
@@ -157,6 +167,9 @@ class SubAgentExecutor:
             session_id: ADK session ID for agent execution tracking
             system_prompt: System prompt for agent instructions
             additional_tools: Optional list of extra tools (e.g., BuildTool) to include
+            vuln_uuid: Vulnerability UUID for LLM usage attribution
+            repo_slug: GitHub repository slug for LLM usage attribution
+            language: Source language for LLM usage attribution
 
         Returns:
             Agent: Configured ADK agent instance
@@ -184,15 +197,25 @@ class SubAgentExecutor:
             # Check if we should use Contrast LLM with custom headers
             if hasattr(self.config, 'USE_CONTRAST_LLM') and self.config.USE_CONTRAST_LLM:
                 setup_contrast_provider()
+                headers = {
+                    "Api-Key": f"{self.config.CONTRAST_API_KEY}",
+                    "Authorization": f"{self.config.CONTRAST_AUTHORIZATION_KEY}",
+                    "x-contrast-llm-feature": "SMARTFIX",
+                }
+                if vuln_uuid:
+                    headers["x-contrast-llm-fingerprint"] = vuln_uuid
+                if remediation_id:
+                    headers["x-contrast-llm-session-id"] = remediation_id
+                if repo_slug:
+                    headers["x-contrast-llm-repo"] = repo_slug
+                if language:
+                    headers["x-contrast-llm-source-language"] = language
                 model_instance = SmartFixLiteLlm(
                     model=self.config.AGENT_MODEL,
                     temperature=0.2,
                     stream_options={"include_usage": True},
-                    system=system_prompt,  # Use standard system parameter
-                    extra_headers={
-                        "Api-Key": f"{self.config.CONTRAST_API_KEY}",
-                        "Authorization": f"{self.config.CONTRAST_AUTHORIZATION_KEY}",
-                    }
+                    system=system_prompt,
+                    extra_headers=headers,
                 )
                 debug_log(f"Creating fix agent ({agent_name}) with model contrast_llm")
             else:

--- a/src/smartfix/domains/agents/sub_agent_executor.py
+++ b/src/smartfix/domains/agents/sub_agent_executor.py
@@ -205,6 +205,8 @@ class SubAgentExecutor:
                 if vuln_uuid:
                     headers["x-contrast-llm-fingerprint"] = vuln_uuid
                 if remediation_id:
+                    # session-id is the remediation_id, not the ADK session_id.
+                    # It groups all LLM calls for a single SmartFix PR attempt.
                     headers["x-contrast-llm-session-id"] = remediation_id
                 if repo_slug:
                     headers["x-contrast-llm-repo"] = repo_slug

--- a/src/smartfix/domains/vulnerability/context.py
+++ b/src/smartfix/domains/vulnerability/context.py
@@ -239,3 +239,4 @@ class RemediationContext:
     skip_writing_security_test: bool = False
     session_id: Optional[str] = None
     issue_body: Optional[str] = None
+    language: Optional[str] = None

--- a/test/contrast_api/test_contrast_api_credit_tracking.py
+++ b/test/contrast_api/test_contrast_api_credit_tracking.py
@@ -19,25 +19,11 @@
 #
 
 import unittest
-import json
 from unittest.mock import patch
-import requests
 
+from setup_test_env import make_sample_response
 from src import contrast_api
 from src.smartfix.domains.workflow.credit_tracking import CreditTrackingResponse
-
-
-def _make_response(status_code, body=None, text=None):
-    """Create a real requests.Response with the given status code and content."""
-    resp = requests.Response()
-    resp.status_code = status_code
-    if body is not None:
-        resp._content = json.dumps(body).encode()
-    elif text is not None:
-        resp._content = text.encode()
-    else:
-        resp._content = b''
-    return resp
 
 
 class TestContrastApiCreditTrackingOrg(unittest.TestCase):
@@ -56,7 +42,7 @@ class TestContrastApiCreditTrackingOrg(unittest.TestCase):
     @patch('src.contrast_api.requests.get')
     def test_get_credit_tracking_org_returns_valid_response(self, mock_get):
         """Test that org-level endpoint returns properly structured CreditTrackingResponse."""
-        mock_get.return_value = _make_response(200, body=self.sample_api_response)
+        mock_get.return_value = make_sample_response(200, body=self.sample_api_response)
 
         result = contrast_api.get_credit_tracking_org(
             contrast_host="test.contrastsecurity.com",
@@ -71,7 +57,7 @@ class TestContrastApiCreditTrackingOrg(unittest.TestCase):
     @patch('src.contrast_api.requests.get')
     def test_get_credit_tracking_org_url_has_no_app_id(self, mock_get):
         """Test that the org-level endpoint URL does not include an application ID."""
-        mock_get.return_value = _make_response(200, body=self.sample_api_response)
+        mock_get.return_value = make_sample_response(200, body=self.sample_api_response)
 
         contrast_api.get_credit_tracking_org(
             contrast_host="test.contrastsecurity.com",
@@ -87,7 +73,7 @@ class TestContrastApiCreditTrackingOrg(unittest.TestCase):
     @patch('src.contrast_api.requests.get')
     def test_get_credit_tracking_org_returns_none_on_http_error(self, mock_get):
         """Test that org-level endpoint returns None on HTTP errors."""
-        mock_get.return_value = _make_response(404, text="Not Found")
+        mock_get.return_value = make_sample_response(404, text="Not Found")
 
         result = contrast_api.get_credit_tracking_org(
             contrast_host="test.contrastsecurity.com",

--- a/test/contrast_api/test_contrast_api_credit_tracking.py
+++ b/test/contrast_api/test_contrast_api_credit_tracking.py
@@ -20,11 +20,24 @@
 
 import unittest
 import json
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 import requests
 
 from src import contrast_api
 from src.smartfix.domains.workflow.credit_tracking import CreditTrackingResponse
+
+
+def _make_response(status_code, body=None, text=None):
+    """Create a real requests.Response with the given status code and content."""
+    resp = requests.Response()
+    resp.status_code = status_code
+    if body is not None:
+        resp._content = json.dumps(body).encode()
+    elif text is not None:
+        resp._content = text.encode()
+    else:
+        resp._content = b''
+    return resp
 
 
 class TestContrastApiCreditTrackingOrg(unittest.TestCase):
@@ -43,11 +56,7 @@ class TestContrastApiCreditTrackingOrg(unittest.TestCase):
     @patch('src.contrast_api.requests.get')
     def test_get_credit_tracking_org_returns_valid_response(self, mock_get):
         """Test that org-level endpoint returns properly structured CreditTrackingResponse."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.text = json.dumps(self.sample_api_response)
-        mock_response.json.return_value = self.sample_api_response
-        mock_get.return_value = mock_response
+        mock_get.return_value = _make_response(200, body=self.sample_api_response)
 
         result = contrast_api.get_credit_tracking_org(
             contrast_host="test.contrastsecurity.com",
@@ -62,11 +71,7 @@ class TestContrastApiCreditTrackingOrg(unittest.TestCase):
     @patch('src.contrast_api.requests.get')
     def test_get_credit_tracking_org_url_has_no_app_id(self, mock_get):
         """Test that the org-level endpoint URL does not include an application ID."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.text = json.dumps(self.sample_api_response)
-        mock_response.json.return_value = self.sample_api_response
-        mock_get.return_value = mock_response
+        mock_get.return_value = _make_response(200, body=self.sample_api_response)
 
         contrast_api.get_credit_tracking_org(
             contrast_host="test.contrastsecurity.com",
@@ -82,13 +87,7 @@ class TestContrastApiCreditTrackingOrg(unittest.TestCase):
     @patch('src.contrast_api.requests.get')
     def test_get_credit_tracking_org_returns_none_on_http_error(self, mock_get):
         """Test that org-level endpoint returns None on HTTP errors."""
-        mock_response = Mock()
-        mock_response.status_code = 404
-        mock_response.text = "Not Found"
-        mock_get.return_value = mock_response
-        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            response=mock_response
-        )
+        mock_get.return_value = _make_response(404, text="Not Found")
 
         result = contrast_api.get_credit_tracking_org(
             contrast_host="test.contrastsecurity.com",

--- a/test/contrast_api/test_contrast_api_credit_tracking.py
+++ b/test/contrast_api/test_contrast_api_credit_tracking.py
@@ -20,7 +20,7 @@
 
 import unittest
 import json
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 import requests
 
 from src import contrast_api
@@ -43,7 +43,7 @@ class TestContrastApiCreditTrackingOrg(unittest.TestCase):
     @patch('src.contrast_api.requests.get')
     def test_get_credit_tracking_org_returns_valid_response(self, mock_get):
         """Test that org-level endpoint returns properly structured CreditTrackingResponse."""
-        mock_response = MagicMock()
+        mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = json.dumps(self.sample_api_response)
         mock_response.json.return_value = self.sample_api_response
@@ -62,7 +62,7 @@ class TestContrastApiCreditTrackingOrg(unittest.TestCase):
     @patch('src.contrast_api.requests.get')
     def test_get_credit_tracking_org_url_has_no_app_id(self, mock_get):
         """Test that the org-level endpoint URL does not include an application ID."""
-        mock_response = MagicMock()
+        mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = json.dumps(self.sample_api_response)
         mock_response.json.return_value = self.sample_api_response
@@ -82,7 +82,7 @@ class TestContrastApiCreditTrackingOrg(unittest.TestCase):
     @patch('src.contrast_api.requests.get')
     def test_get_credit_tracking_org_returns_none_on_http_error(self, mock_get):
         """Test that org-level endpoint returns None on HTTP errors."""
-        mock_response = MagicMock()
+        mock_response = Mock()
         mock_response.status_code = 404
         mock_response.text = "Not Found"
         mock_get.return_value = mock_response

--- a/test/contrast_api/test_contrast_api_org_endpoints.py
+++ b/test/contrast_api/test_contrast_api_org_endpoints.py
@@ -32,12 +32,12 @@ Covers:
   - send_telemetry_data_org
 """
 
-import json
 import unittest
 from unittest.mock import patch
 
 import requests
 
+from setup_test_env import make_sample_response
 from src import contrast_api
 
 
@@ -47,19 +47,6 @@ ORG_ID = 'test-org-id'
 AUTH_KEY = 'test-auth-key'
 API_KEY = 'test-api-key'
 REMEDIATION_ID = 'rem-123'
-
-
-def _make_response(status_code, body=None, text=None):
-    """Build a real requests.Response for tests."""
-    resp = requests.Response()
-    resp.status_code = status_code
-    if body is not None:
-        resp._content = json.dumps(body).encode()
-    elif text is not None:
-        resp._content = text.encode()
-    else:
-        resp._content = b''
-    return resp
 
 
 # =============================================================================
@@ -80,7 +67,7 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_list_on_200(self, mock_post):
-        mock_post.return_value = _make_response(
+        mock_post.return_value = make_sample_response(
             200, body=[{'remediationId': REMEDIATION_ID, 'vulnerabilityId': 'v1'}]
         )
         result = self._call()
@@ -89,7 +76,7 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_posts_to_org_url_without_app_id(self, mock_post):
-        mock_post.return_value = _make_response(200, body=[])
+        mock_post.return_value = make_sample_response(200, body=[])
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/open', url)
@@ -97,14 +84,14 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_sends_app_ids_in_body(self, mock_post):
-        mock_post.return_value = _make_response(200, body=[])
+        mock_post.return_value = make_sample_response(200, body=[])
         self._call()
         payload = mock_post.call_args[1]['json']
         self.assertEqual(payload['appIds'], APP_IDS)
 
     @patch('src.contrast_api.requests.post')
     def test_returns_empty_list_on_non_200(self, mock_post):
-        mock_post.return_value = _make_response(500)
+        mock_post.return_value = make_sample_response(500)
         self.assertEqual(self._call(), [])
 
     @patch('src.contrast_api.requests.post')
@@ -114,16 +101,13 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_empty_list_on_json_error(self, mock_post):
-        bad_response = requests.Response()
-        bad_response.status_code = 200
-        bad_response._content = b'not valid json'
-        mock_post.return_value = bad_response
+        mock_post.return_value = make_sample_response(200, text='not valid json')
         self.assertEqual(self._call(), [])
 
     @patch('src.contrast_api.requests.post')
     def test_strips_protocol_from_host_in_url(self, mock_post):
         """normalize_host is applied — passing host with https:// prefix still builds a valid URL."""
-        mock_post.return_value = _make_response(200, body=[])
+        mock_post.return_value = make_sample_response(200, body=[])
         self._call(contrast_host=f'https://{HOST}')
         url = mock_post.call_args[0][0]
         self.assertNotIn('https://https://', url)
@@ -160,7 +144,7 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
             'applicationId': 'app-id-1',
             'skippedAppIds': ['app-id-2'],
         }
-        mock_post.return_value = _make_response(200, body=payload)
+        mock_post.return_value = make_sample_response(200, body=payload)
         result = self._call()
         self.assertEqual(result['remediationId'], REMEDIATION_ID)
         self.assertEqual(result['applicationId'], 'app-id-1')
@@ -169,7 +153,7 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_posts_to_org_url_without_app_id(self, mock_post):
-        mock_post.return_value = _make_response(204)
+        mock_post.return_value = make_sample_response(204)
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediation-details', url)
@@ -177,14 +161,14 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_sends_app_ids_in_body(self, mock_post):
-        mock_post.return_value = _make_response(204)
+        mock_post.return_value = make_sample_response(204)
         self._call()
         body = mock_post.call_args[1]['json']
         self.assertEqual(body['appIds'], APP_IDS)
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_204(self, mock_post):
-        mock_post.return_value = _make_response(204)
+        mock_post.return_value = make_sample_response(204)
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
@@ -194,18 +178,18 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_unexpected_status(self, mock_post):
-        mock_post.return_value = _make_response(500, text='error')
+        mock_post.return_value = make_sample_response(500, text='error')
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_503(self, mock_post):
-        mock_post.return_value = _make_response(503, text='all apps inaccessible')
+        mock_post.return_value = make_sample_response(503, text='all apps inaccessible')
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_exits_on_409_is_error(self, mock_post, mock_409):
-        mock_post.return_value = _make_response(409, text='credits exhausted')
+        mock_post.return_value = make_sample_response(409, text='credits exhausted')
         mock_409.return_value = ('Credits exhausted', True)
         with self.assertRaises(SystemExit):
             self._call()
@@ -213,7 +197,7 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_409_not_error(self, mock_post, mock_409):
-        mock_post.return_value = _make_response(409, text='pr limit reached')
+        mock_post.return_value = make_sample_response(409, text='pr limit reached')
         mock_409.return_value = ('PR limit reached', False)
         self.assertIsNone(self._call())
 
@@ -246,7 +230,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
             'fixSystemPrompt': 'sys', 'fixUserPrompt': 'usr',
             'applicationId': 'app-id-1', 'skippedAppIds': ['app-id-2'],
         }
-        mock_post.return_value = _make_response(200, body=payload)
+        mock_post.return_value = make_sample_response(200, body=payload)
         result = self._call()
         self.assertEqual(result['remediationId'], REMEDIATION_ID)
         self.assertEqual(result['applicationId'], 'app-id-1')
@@ -254,7 +238,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_posts_to_org_url_without_app_id(self, mock_post):
-        mock_post.return_value = _make_response(204)
+        mock_post.return_value = make_sample_response(204)
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/prompt-details', url)
@@ -262,19 +246,19 @@ class TestGetOrgPromptDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_sends_app_ids_in_body(self, mock_post):
-        mock_post.return_value = _make_response(204)
+        mock_post.return_value = make_sample_response(204)
         self._call()
         body = mock_post.call_args[1]['json']
         self.assertEqual(body['appIds'], APP_IDS)
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_204(self, mock_post):
-        mock_post.return_value = _make_response(204)
+        mock_post.return_value = make_sample_response(204)
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_503(self, mock_post):
-        mock_post.return_value = _make_response(503, text='all apps inaccessible')
+        mock_post.return_value = make_sample_response(503, text='all apps inaccessible')
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
@@ -286,7 +270,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_exits_on_409_is_error(self, mock_post, mock_409):
-        mock_post.return_value = _make_response(409, text='credits exhausted')
+        mock_post.return_value = make_sample_response(409, text='credits exhausted')
         mock_409.return_value = ('Credits exhausted', True)
         with self.assertRaises(SystemExit):
             self._call()
@@ -294,7 +278,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_409_not_error(self, mock_post, mock_409):
-        mock_post.return_value = _make_response(409, text='pr limit reached')
+        mock_post.return_value = make_sample_response(409, text='pr limit reached')
         mock_409.return_value = ('PR limit reached', False)
         self.assertIsNone(self._call())
 
@@ -304,7 +288,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
             'remediationId': REMEDIATION_ID,
             # missing vulnerabilityUuid, vulnerabilityTitle, etc.
         }
-        mock_post.return_value = _make_response(200, body=incomplete_payload)
+        mock_post.return_value = make_sample_response(200, body=incomplete_payload)
         with self.assertRaises(SystemExit):
             self._call()
 
@@ -327,13 +311,13 @@ class TestNotifyRemediationPrOpenedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = _make_response(204)
+        mock_put.return_value = make_sample_response(204)
 
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = _make_response(204)
+        mock_put.return_value = make_sample_response(204)
 
         self._call()
         url = mock_put.call_args[0][0]
@@ -342,7 +326,7 @@ class TestNotifyRemediationPrOpenedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_false_on_http_error(self, mock_put):
-        mock_put.return_value = _make_response(500, text='error')
+        mock_put.return_value = make_sample_response(500, text='error')
         self.assertFalse(self._call())
 
     @patch('src.contrast_api.requests.put')
@@ -367,13 +351,13 @@ class TestNotifyRemediationPrClosedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = _make_response(204)
+        mock_put.return_value = make_sample_response(204)
 
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = _make_response(204)
+        mock_put.return_value = make_sample_response(204)
 
         self._call()
         url = mock_put.call_args[0][0]
@@ -402,13 +386,13 @@ class TestNotifyRemediationPrMergedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = _make_response(204)
+        mock_put.return_value = make_sample_response(204)
 
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = _make_response(204)
+        mock_put.return_value = make_sample_response(204)
 
         self._call()
         url = mock_put.call_args[0][0]
@@ -438,13 +422,13 @@ class TestNotifyRemediationFailedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = _make_response(204)
+        mock_put.return_value = make_sample_response(204)
 
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = _make_response(204)
+        mock_put.return_value = make_sample_response(204)
 
         self._call()
         url = mock_put.call_args[0][0]
@@ -453,7 +437,7 @@ class TestNotifyRemediationFailedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_sends_failure_category_in_body(self, mock_put):
-        mock_put.return_value = _make_response(204)
+        mock_put.return_value = make_sample_response(204)
 
         self._call(failure_category='AGENT_FAILURE')
         body = mock_put.call_args[1]['json']
@@ -484,12 +468,12 @@ class TestSendTelemetryDataOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_true_on_201(self, mock_post):
-        mock_post.return_value = _make_response(201)
+        mock_post.return_value = make_sample_response(201)
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.post')
     def test_url_has_no_app_id_segment(self, mock_post):
-        mock_post.return_value = _make_response(201)
+        mock_post.return_value = make_sample_response(201)
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/telemetry', url)
@@ -497,7 +481,7 @@ class TestSendTelemetryDataOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_false_on_error_status(self, mock_post):
-        mock_post.return_value = _make_response(500, text='error')
+        mock_post.return_value = make_sample_response(500, text='error')
         self.assertFalse(self._call())
 
     @patch('src.contrast_api.requests.post')

--- a/test/contrast_api/test_contrast_api_org_endpoints.py
+++ b/test/contrast_api/test_contrast_api_org_endpoints.py
@@ -34,7 +34,7 @@ Covers:
 
 import json
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 import requests
 
@@ -47,6 +47,19 @@ ORG_ID = 'test-org-id'
 AUTH_KEY = 'test-auth-key'
 API_KEY = 'test-api-key'
 REMEDIATION_ID = 'rem-123'
+
+
+def _make_response(status_code, body=None, text=None):
+    """Build a real requests.Response for tests."""
+    resp = requests.Response()
+    resp.status_code = status_code
+    if body is not None:
+        resp._content = json.dumps(body).encode()
+    elif text is not None:
+        resp._content = text.encode()
+    else:
+        resp._content = b''
+    return resp
 
 
 # =============================================================================
@@ -67,9 +80,8 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_list_on_200(self, mock_post):
-        mock_post.return_value = Mock(
-            status_code=200,
-            json=lambda: [{'remediationId': REMEDIATION_ID, 'vulnerabilityId': 'v1'}]
+        mock_post.return_value = _make_response(
+            200, body=[{'remediationId': REMEDIATION_ID, 'vulnerabilityId': 'v1'}]
         )
         result = self._call()
         self.assertEqual(len(result), 1)
@@ -77,7 +89,7 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_posts_to_org_url_without_app_id(self, mock_post):
-        mock_post.return_value = Mock(status_code=200, json=lambda: [])
+        mock_post.return_value = _make_response(200, body=[])
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/open', url)
@@ -85,14 +97,14 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_sends_app_ids_in_body(self, mock_post):
-        mock_post.return_value = Mock(status_code=200, json=lambda: [])
+        mock_post.return_value = _make_response(200, body=[])
         self._call()
         payload = mock_post.call_args[1]['json']
         self.assertEqual(payload['appIds'], APP_IDS)
 
     @patch('src.contrast_api.requests.post')
     def test_returns_empty_list_on_non_200(self, mock_post):
-        mock_post.return_value = Mock(status_code=500)
+        mock_post.return_value = _make_response(500)
         self.assertEqual(self._call(), [])
 
     @patch('src.contrast_api.requests.post')
@@ -102,13 +114,16 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_empty_list_on_json_error(self, mock_post):
-        mock_post.return_value = Mock(status_code=200, json=Mock(side_effect=json.JSONDecodeError('', '', 0)))
+        bad_response = requests.Response()
+        bad_response.status_code = 200
+        bad_response._content = b'not valid json'
+        mock_post.return_value = bad_response
         self.assertEqual(self._call(), [])
 
     @patch('src.contrast_api.requests.post')
     def test_strips_protocol_from_host_in_url(self, mock_post):
         """normalize_host is applied — passing host with https:// prefix still builds a valid URL."""
-        mock_post.return_value = Mock(status_code=200, json=lambda: [])
+        mock_post.return_value = _make_response(200, body=[])
         self._call(contrast_host=f'https://{HOST}')
         url = mock_post.call_args[0][0]
         self.assertNotIn('https://https://', url)
@@ -145,7 +160,7 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
             'applicationId': 'app-id-1',
             'skippedAppIds': ['app-id-2'],
         }
-        mock_post.return_value = Mock(status_code=200, json=lambda: payload)
+        mock_post.return_value = _make_response(200, body=payload)
         result = self._call()
         self.assertEqual(result['remediationId'], REMEDIATION_ID)
         self.assertEqual(result['applicationId'], 'app-id-1')
@@ -154,7 +169,7 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_posts_to_org_url_without_app_id(self, mock_post):
-        mock_post.return_value = Mock(status_code=204)
+        mock_post.return_value = _make_response(204)
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediation-details', url)
@@ -162,14 +177,14 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_sends_app_ids_in_body(self, mock_post):
-        mock_post.return_value = Mock(status_code=204)
+        mock_post.return_value = _make_response(204)
         self._call()
         body = mock_post.call_args[1]['json']
         self.assertEqual(body['appIds'], APP_IDS)
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_204(self, mock_post):
-        mock_post.return_value = Mock(status_code=204)
+        mock_post.return_value = _make_response(204)
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
@@ -179,18 +194,18 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_unexpected_status(self, mock_post):
-        mock_post.return_value = Mock(status_code=500, text='error')
+        mock_post.return_value = _make_response(500, text='error')
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_503(self, mock_post):
-        mock_post.return_value = Mock(status_code=503, text='all apps inaccessible')
+        mock_post.return_value = _make_response(503, text='all apps inaccessible')
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_exits_on_409_is_error(self, mock_post, mock_409):
-        mock_post.return_value = Mock(status_code=409, text='credits exhausted')
+        mock_post.return_value = _make_response(409, text='credits exhausted')
         mock_409.return_value = ('Credits exhausted', True)
         with self.assertRaises(SystemExit):
             self._call()
@@ -198,7 +213,7 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_409_not_error(self, mock_post, mock_409):
-        mock_post.return_value = Mock(status_code=409, text='pr limit reached')
+        mock_post.return_value = _make_response(409, text='pr limit reached')
         mock_409.return_value = ('PR limit reached', False)
         self.assertIsNone(self._call())
 
@@ -231,7 +246,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
             'fixSystemPrompt': 'sys', 'fixUserPrompt': 'usr',
             'applicationId': 'app-id-1', 'skippedAppIds': ['app-id-2'],
         }
-        mock_post.return_value = Mock(status_code=200, json=lambda: payload)
+        mock_post.return_value = _make_response(200, body=payload)
         result = self._call()
         self.assertEqual(result['remediationId'], REMEDIATION_ID)
         self.assertEqual(result['applicationId'], 'app-id-1')
@@ -239,7 +254,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_posts_to_org_url_without_app_id(self, mock_post):
-        mock_post.return_value = Mock(status_code=204)
+        mock_post.return_value = _make_response(204)
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/prompt-details', url)
@@ -247,19 +262,19 @@ class TestGetOrgPromptDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_sends_app_ids_in_body(self, mock_post):
-        mock_post.return_value = Mock(status_code=204)
+        mock_post.return_value = _make_response(204)
         self._call()
         body = mock_post.call_args[1]['json']
         self.assertEqual(body['appIds'], APP_IDS)
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_204(self, mock_post):
-        mock_post.return_value = Mock(status_code=204)
+        mock_post.return_value = _make_response(204)
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_503(self, mock_post):
-        mock_post.return_value = Mock(status_code=503, text='all apps inaccessible')
+        mock_post.return_value = _make_response(503, text='all apps inaccessible')
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
@@ -271,7 +286,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_exits_on_409_is_error(self, mock_post, mock_409):
-        mock_post.return_value = Mock(status_code=409, text='credits exhausted')
+        mock_post.return_value = _make_response(409, text='credits exhausted')
         mock_409.return_value = ('Credits exhausted', True)
         with self.assertRaises(SystemExit):
             self._call()
@@ -279,7 +294,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_409_not_error(self, mock_post, mock_409):
-        mock_post.return_value = Mock(status_code=409, text='pr limit reached')
+        mock_post.return_value = _make_response(409, text='pr limit reached')
         mock_409.return_value = ('PR limit reached', False)
         self.assertIsNone(self._call())
 
@@ -289,7 +304,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
             'remediationId': REMEDIATION_ID,
             # missing vulnerabilityUuid, vulnerabilityTitle, etc.
         }
-        mock_post.return_value = Mock(status_code=200, json=lambda: incomplete_payload)
+        mock_post.return_value = _make_response(200, body=incomplete_payload)
         with self.assertRaises(SystemExit):
             self._call()
 
@@ -312,14 +327,14 @@ class TestNotifyRemediationPrOpenedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = Mock(status_code=204)
-        mock_put.return_value.raise_for_status = Mock()
+        mock_put.return_value = _make_response(204)
+
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = Mock(status_code=204)
-        mock_put.return_value.raise_for_status = Mock()
+        mock_put.return_value = _make_response(204)
+
         self._call()
         url = mock_put.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/open', url)
@@ -327,10 +342,7 @@ class TestNotifyRemediationPrOpenedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_false_on_http_error(self, mock_put):
-        mock_response = Mock(status_code=500, text='error')
-        mock_put.return_value = mock_response
-        mock_put.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            response=mock_response)
+        mock_put.return_value = _make_response(500, text='error')
         self.assertFalse(self._call())
 
     @patch('src.contrast_api.requests.put')
@@ -355,14 +367,14 @@ class TestNotifyRemediationPrClosedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = Mock(status_code=204)
-        mock_put.return_value.raise_for_status = Mock()
+        mock_put.return_value = _make_response(204)
+
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = Mock(status_code=204)
-        mock_put.return_value.raise_for_status = Mock()
+        mock_put.return_value = _make_response(204)
+
         self._call()
         url = mock_put.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/closed', url)
@@ -390,14 +402,14 @@ class TestNotifyRemediationPrMergedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = Mock(status_code=204)
-        mock_put.return_value.raise_for_status = Mock()
+        mock_put.return_value = _make_response(204)
+
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = Mock(status_code=204)
-        mock_put.return_value.raise_for_status = Mock()
+        mock_put.return_value = _make_response(204)
+
         self._call()
         url = mock_put.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/merged', url)
@@ -426,14 +438,14 @@ class TestNotifyRemediationFailedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = Mock(status_code=204)
-        mock_put.return_value.raise_for_status = Mock()
+        mock_put.return_value = _make_response(204)
+
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = Mock(status_code=204)
-        mock_put.return_value.raise_for_status = Mock()
+        mock_put.return_value = _make_response(204)
+
         self._call()
         url = mock_put.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/failed', url)
@@ -441,8 +453,8 @@ class TestNotifyRemediationFailedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_sends_failure_category_in_body(self, mock_put):
-        mock_put.return_value = Mock(status_code=204)
-        mock_put.return_value.raise_for_status = Mock()
+        mock_put.return_value = _make_response(204)
+
         self._call(failure_category='AGENT_FAILURE')
         body = mock_put.call_args[1]['json']
         self.assertEqual(body['failureCategory'], 'AGENT_FAILURE')
@@ -472,12 +484,12 @@ class TestSendTelemetryDataOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_true_on_201(self, mock_post):
-        mock_post.return_value = Mock(status_code=201)
+        mock_post.return_value = _make_response(201)
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.post')
     def test_url_has_no_app_id_segment(self, mock_post):
-        mock_post.return_value = Mock(status_code=201)
+        mock_post.return_value = _make_response(201)
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/telemetry', url)
@@ -485,7 +497,7 @@ class TestSendTelemetryDataOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_false_on_error_status(self, mock_post):
-        mock_post.return_value = Mock(status_code=500, text='error')
+        mock_post.return_value = _make_response(500, text='error')
         self.assertFalse(self._call())
 
     @patch('src.contrast_api.requests.post')

--- a/test/contrast_api/test_contrast_api_org_endpoints.py
+++ b/test/contrast_api/test_contrast_api_org_endpoints.py
@@ -34,7 +34,7 @@ Covers:
 
 import json
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 import requests
 
@@ -67,7 +67,7 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_list_on_200(self, mock_post):
-        mock_post.return_value = MagicMock(
+        mock_post.return_value = Mock(
             status_code=200,
             json=lambda: [{'remediationId': REMEDIATION_ID, 'vulnerabilityId': 'v1'}]
         )
@@ -77,7 +77,7 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_posts_to_org_url_without_app_id(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=200, json=lambda: [])
+        mock_post.return_value = Mock(status_code=200, json=lambda: [])
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/open', url)
@@ -85,14 +85,14 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_sends_app_ids_in_body(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=200, json=lambda: [])
+        mock_post.return_value = Mock(status_code=200, json=lambda: [])
         self._call()
         payload = mock_post.call_args[1]['json']
         self.assertEqual(payload['appIds'], APP_IDS)
 
     @patch('src.contrast_api.requests.post')
     def test_returns_empty_list_on_non_200(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=500)
+        mock_post.return_value = Mock(status_code=500)
         self.assertEqual(self._call(), [])
 
     @patch('src.contrast_api.requests.post')
@@ -102,13 +102,13 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_empty_list_on_json_error(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=200, json=MagicMock(side_effect=json.JSONDecodeError('', '', 0)))
+        mock_post.return_value = Mock(status_code=200, json=Mock(side_effect=json.JSONDecodeError('', '', 0)))
         self.assertEqual(self._call(), [])
 
     @patch('src.contrast_api.requests.post')
     def test_strips_protocol_from_host_in_url(self, mock_post):
         """normalize_host is applied — passing host with https:// prefix still builds a valid URL."""
-        mock_post.return_value = MagicMock(status_code=200, json=lambda: [])
+        mock_post.return_value = Mock(status_code=200, json=lambda: [])
         self._call(contrast_host=f'https://{HOST}')
         url = mock_post.call_args[0][0]
         self.assertNotIn('https://https://', url)
@@ -145,7 +145,7 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
             'applicationId': 'app-id-1',
             'skippedAppIds': ['app-id-2'],
         }
-        mock_post.return_value = MagicMock(status_code=200, json=lambda: payload)
+        mock_post.return_value = Mock(status_code=200, json=lambda: payload)
         result = self._call()
         self.assertEqual(result['remediationId'], REMEDIATION_ID)
         self.assertEqual(result['applicationId'], 'app-id-1')
@@ -154,7 +154,7 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_posts_to_org_url_without_app_id(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=204)
+        mock_post.return_value = Mock(status_code=204)
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediation-details', url)
@@ -162,14 +162,14 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_sends_app_ids_in_body(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=204)
+        mock_post.return_value = Mock(status_code=204)
         self._call()
         body = mock_post.call_args[1]['json']
         self.assertEqual(body['appIds'], APP_IDS)
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_204(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=204)
+        mock_post.return_value = Mock(status_code=204)
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
@@ -179,18 +179,18 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_unexpected_status(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=500, text='error')
+        mock_post.return_value = Mock(status_code=500, text='error')
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_503(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=503, text='all apps inaccessible')
+        mock_post.return_value = Mock(status_code=503, text='all apps inaccessible')
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_exits_on_409_is_error(self, mock_post, mock_409):
-        mock_post.return_value = MagicMock(status_code=409, text='credits exhausted')
+        mock_post.return_value = Mock(status_code=409, text='credits exhausted')
         mock_409.return_value = ('Credits exhausted', True)
         with self.assertRaises(SystemExit):
             self._call()
@@ -198,7 +198,7 @@ class TestGetOrgRemediationDetails(unittest.TestCase):
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_409_not_error(self, mock_post, mock_409):
-        mock_post.return_value = MagicMock(status_code=409, text='pr limit reached')
+        mock_post.return_value = Mock(status_code=409, text='pr limit reached')
         mock_409.return_value = ('PR limit reached', False)
         self.assertIsNone(self._call())
 
@@ -231,7 +231,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
             'fixSystemPrompt': 'sys', 'fixUserPrompt': 'usr',
             'applicationId': 'app-id-1', 'skippedAppIds': ['app-id-2'],
         }
-        mock_post.return_value = MagicMock(status_code=200, json=lambda: payload)
+        mock_post.return_value = Mock(status_code=200, json=lambda: payload)
         result = self._call()
         self.assertEqual(result['remediationId'], REMEDIATION_ID)
         self.assertEqual(result['applicationId'], 'app-id-1')
@@ -239,7 +239,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_posts_to_org_url_without_app_id(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=204)
+        mock_post.return_value = Mock(status_code=204)
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/prompt-details', url)
@@ -247,19 +247,19 @@ class TestGetOrgPromptDetails(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_sends_app_ids_in_body(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=204)
+        mock_post.return_value = Mock(status_code=204)
         self._call()
         body = mock_post.call_args[1]['json']
         self.assertEqual(body['appIds'], APP_IDS)
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_204(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=204)
+        mock_post.return_value = Mock(status_code=204)
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_503(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=503, text='all apps inaccessible')
+        mock_post.return_value = Mock(status_code=503, text='all apps inaccessible')
         self.assertIsNone(self._call())
 
     @patch('src.contrast_api.requests.post')
@@ -271,7 +271,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_exits_on_409_is_error(self, mock_post, mock_409):
-        mock_post.return_value = MagicMock(status_code=409, text='credits exhausted')
+        mock_post.return_value = Mock(status_code=409, text='credits exhausted')
         mock_409.return_value = ('Credits exhausted', True)
         with self.assertRaises(SystemExit):
             self._call()
@@ -279,7 +279,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
     @patch('src.contrast_api.get_sanitized_409_message')
     @patch('src.contrast_api.requests.post')
     def test_returns_none_on_409_not_error(self, mock_post, mock_409):
-        mock_post.return_value = MagicMock(status_code=409, text='pr limit reached')
+        mock_post.return_value = Mock(status_code=409, text='pr limit reached')
         mock_409.return_value = ('PR limit reached', False)
         self.assertIsNone(self._call())
 
@@ -289,7 +289,7 @@ class TestGetOrgPromptDetails(unittest.TestCase):
             'remediationId': REMEDIATION_ID,
             # missing vulnerabilityUuid, vulnerabilityTitle, etc.
         }
-        mock_post.return_value = MagicMock(status_code=200, json=lambda: incomplete_payload)
+        mock_post.return_value = Mock(status_code=200, json=lambda: incomplete_payload)
         with self.assertRaises(SystemExit):
             self._call()
 
@@ -312,14 +312,14 @@ class TestNotifyRemediationPrOpenedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = MagicMock(status_code=204)
-        mock_put.return_value.raise_for_status = MagicMock()
+        mock_put.return_value = Mock(status_code=204)
+        mock_put.return_value.raise_for_status = Mock()
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = MagicMock(status_code=204)
-        mock_put.return_value.raise_for_status = MagicMock()
+        mock_put.return_value = Mock(status_code=204)
+        mock_put.return_value.raise_for_status = Mock()
         self._call()
         url = mock_put.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/open', url)
@@ -327,7 +327,7 @@ class TestNotifyRemediationPrOpenedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_false_on_http_error(self, mock_put):
-        mock_response = MagicMock(status_code=500, text='error')
+        mock_response = Mock(status_code=500, text='error')
         mock_put.return_value = mock_response
         mock_put.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError(
             response=mock_response)
@@ -355,14 +355,14 @@ class TestNotifyRemediationPrClosedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = MagicMock(status_code=204)
-        mock_put.return_value.raise_for_status = MagicMock()
+        mock_put.return_value = Mock(status_code=204)
+        mock_put.return_value.raise_for_status = Mock()
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = MagicMock(status_code=204)
-        mock_put.return_value.raise_for_status = MagicMock()
+        mock_put.return_value = Mock(status_code=204)
+        mock_put.return_value.raise_for_status = Mock()
         self._call()
         url = mock_put.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/closed', url)
@@ -390,14 +390,14 @@ class TestNotifyRemediationPrMergedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = MagicMock(status_code=204)
-        mock_put.return_value.raise_for_status = MagicMock()
+        mock_put.return_value = Mock(status_code=204)
+        mock_put.return_value.raise_for_status = Mock()
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = MagicMock(status_code=204)
-        mock_put.return_value.raise_for_status = MagicMock()
+        mock_put.return_value = Mock(status_code=204)
+        mock_put.return_value.raise_for_status = Mock()
         self._call()
         url = mock_put.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/merged', url)
@@ -426,14 +426,14 @@ class TestNotifyRemediationFailedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_returns_true_on_204(self, mock_put):
-        mock_put.return_value = MagicMock(status_code=204)
-        mock_put.return_value.raise_for_status = MagicMock()
+        mock_put.return_value = Mock(status_code=204)
+        mock_put.return_value.raise_for_status = Mock()
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.put')
     def test_url_has_no_app_id_segment(self, mock_put):
-        mock_put.return_value = MagicMock(status_code=204)
-        mock_put.return_value.raise_for_status = MagicMock()
+        mock_put.return_value = Mock(status_code=204)
+        mock_put.return_value.raise_for_status = Mock()
         self._call()
         url = mock_put.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/failed', url)
@@ -441,8 +441,8 @@ class TestNotifyRemediationFailedOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.put')
     def test_sends_failure_category_in_body(self, mock_put):
-        mock_put.return_value = MagicMock(status_code=204)
-        mock_put.return_value.raise_for_status = MagicMock()
+        mock_put.return_value = Mock(status_code=204)
+        mock_put.return_value.raise_for_status = Mock()
         self._call(failure_category='AGENT_FAILURE')
         body = mock_put.call_args[1]['json']
         self.assertEqual(body['failureCategory'], 'AGENT_FAILURE')
@@ -472,12 +472,12 @@ class TestSendTelemetryDataOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_true_on_201(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=201)
+        mock_post.return_value = Mock(status_code=201)
         self.assertTrue(self._call())
 
     @patch('src.contrast_api.requests.post')
     def test_url_has_no_app_id_segment(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=201)
+        mock_post.return_value = Mock(status_code=201)
         self._call()
         url = mock_post.call_args[0][0]
         self.assertIn(f'/organizations/{ORG_ID}/remediations/{REMEDIATION_ID}/telemetry', url)
@@ -485,7 +485,7 @@ class TestSendTelemetryDataOrg(unittest.TestCase):
 
     @patch('src.contrast_api.requests.post')
     def test_returns_false_on_error_status(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=500, text='error')
+        mock_post.return_value = Mock(status_code=500, text='error')
         self.assertFalse(self._call())
 
     @patch('src.contrast_api.requests.post')

--- a/test/contrast_api/test_sanitized_409_messages.py
+++ b/test/contrast_api/test_sanitized_409_messages.py
@@ -1,10 +1,22 @@
 """Tests for sanitized 409 error message handling."""
 
 import unittest
-from unittest.mock import Mock
 from datetime import datetime, timezone, timedelta
 
 from src.contrast_api import get_sanitized_409_message
+from src.smartfix.domains.workflow.credit_tracking import CreditTrackingResponse
+
+
+def _make_credit_info(end_date):
+    """Create a sample CreditTrackingResponse with a specific end_date."""
+    return CreditTrackingResponse(
+        organization_id="test-org",
+        enabled=True,
+        max_credits=100,
+        credits_used=100,
+        start_date="2025-01-01T00:00:00Z",
+        end_date=end_date,
+    )
 
 
 class TestSanitized409Messages(unittest.TestCase):
@@ -31,9 +43,9 @@ class TestSanitized409Messages(unittest.TestCase):
         """Credits exhausted with expired trial shows trial expired message and IS an error."""
         response = '{"message": "Credits have been exhausted. Contact your CSM to request additional credits."}'
 
-        # Mock credit info with expired end_date
-        credit_info = Mock()
-        credit_info.end_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        credit_info = _make_credit_info(
+            end_date=(datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        )
 
         message, is_error = get_sanitized_409_message(response, credit_info)
         self.assertEqual(
@@ -46,9 +58,9 @@ class TestSanitized409Messages(unittest.TestCase):
         """Credits exhausted with active trial shows credits exhausted message and IS an error."""
         response = '{"message": "Credits have been exhausted. Contact your CSM to request additional credits."}'
 
-        # Mock credit info with future end_date
-        credit_info = Mock()
-        credit_info.end_date = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+        credit_info = _make_credit_info(
+            end_date=(datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+        )
 
         message, is_error = get_sanitized_409_message(response, credit_info)
         self.assertEqual(
@@ -101,8 +113,7 @@ class TestSanitized409Messages(unittest.TestCase):
         """If end_date can't be parsed, fall through to credits exhausted message."""
         response = '{"message": "Credits have been exhausted. Contact your CSM to request additional credits."}'
 
-        credit_info = Mock()
-        credit_info.end_date = "not-a-valid-date"
+        credit_info = _make_credit_info(end_date="not-a-valid-date")
 
         message, is_error = get_sanitized_409_message(response, credit_info)
         self.assertEqual(

--- a/test/contrast_api/test_sanitized_409_messages.py
+++ b/test/contrast_api/test_sanitized_409_messages.py
@@ -1,7 +1,7 @@
 """Tests for sanitized 409 error message handling."""
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import Mock
 from datetime import datetime, timezone, timedelta
 
 from src.contrast_api import get_sanitized_409_message
@@ -32,7 +32,7 @@ class TestSanitized409Messages(unittest.TestCase):
         response = '{"message": "Credits have been exhausted. Contact your CSM to request additional credits."}'
 
         # Mock credit info with expired end_date
-        credit_info = MagicMock()
+        credit_info = Mock()
         credit_info.end_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
 
         message, is_error = get_sanitized_409_message(response, credit_info)
@@ -47,7 +47,7 @@ class TestSanitized409Messages(unittest.TestCase):
         response = '{"message": "Credits have been exhausted. Contact your CSM to request additional credits."}'
 
         # Mock credit info with future end_date
-        credit_info = MagicMock()
+        credit_info = Mock()
         credit_info.end_date = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         message, is_error = get_sanitized_409_message(response, credit_info)
@@ -101,7 +101,7 @@ class TestSanitized409Messages(unittest.TestCase):
         """If end_date can't be parsed, fall through to credits exhausted message."""
         response = '{"message": "Credits have been exhausted. Contact your CSM to request additional credits."}'
 
-        credit_info = MagicMock()
+        credit_info = Mock()
         credit_info.end_date = "not-a-valid-date"
 
         message, is_error = get_sanitized_409_message(response, credit_info)

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -63,8 +63,8 @@ if [[ $SKIP_INSTALL -eq 0 ]]; then
         fi
     fi
 
-    # Sync dependencies in virtual environment (matches CI's uv pip sync)
-    if ! uv pip sync "$REQUIREMENTS_LOCK"; then
+    # Install dependencies in virtual environment
+    if ! uv pip install -r "$REQUIREMENTS_LOCK"; then
         echo "Error installing dependencies" >&2
         exit 1
     fi

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -63,8 +63,8 @@ if [[ $SKIP_INSTALL -eq 0 ]]; then
         fi
     fi
 
-    # Install dependencies in virtual environment
-    if ! uv pip install -r "$REQUIREMENTS_LOCK"; then
+    # Sync dependencies in virtual environment (matches CI's uv pip sync)
+    if ! uv pip sync "$REQUIREMENTS_LOCK"; then
         echo "Error installing dependencies" >&2
         exit 1
     fi

--- a/test/setup_test_env.py
+++ b/test/setup_test_env.py
@@ -5,7 +5,6 @@ temporary directory management and sample object factories.
 """
 
 from pathlib import Path
-from typing import Optional
 
 from src.smartfix.domains.vulnerability import RemediationContext
 from src.smartfix.domains.vulnerability.context import (

--- a/test/setup_test_env.py
+++ b/test/setup_test_env.py
@@ -1,10 +1,73 @@
 """Test environment helper utilities.
 
 This module provides helper functions for test setup, including
-temporary directory management.
+temporary directory management and sample object factories.
 """
 
 from pathlib import Path
+from typing import Optional
+
+from src.smartfix.domains.vulnerability import RemediationContext
+from src.smartfix.domains.vulnerability.context import (
+    PromptConfiguration, BuildConfiguration, RepositoryConfiguration
+)
+from src.smartfix.domains.vulnerability.models import Vulnerability, VulnerabilitySeverity
+
+
+_SENTINEL = object()
+
+
+def make_sample_context(
+    remediation_id="sample-remediation",
+    session_id="sample-session",
+    fix_system_prompt="Fix system prompt",
+    fix_user_prompt="Fix user prompt",
+    build_config=_SENTINEL,
+    build_command=None,
+    user_build_command=None,
+    user_format_command=None,
+    repo_path="/tmp/test",
+    language=None,
+    vuln_uuid="sample-vuln-uuid",
+    vuln_title="Sample Vulnerability",
+    skip_writing_security_test=False,
+) -> RemediationContext:
+    """Build a real RemediationContext with sensible defaults for tests.
+
+    Pass build_config=None to explicitly set no build configuration.
+    Otherwise a BuildConfiguration is created from the build_command,
+    user_build_command, and user_format_command arguments.
+    """
+    vulnerability = Vulnerability(
+        uuid=vuln_uuid,
+        title=vuln_title,
+        rule_name="sample-rule",
+        severity=VulnerabilitySeverity.HIGH,
+    )
+    prompts = PromptConfiguration(
+        fix_system_prompt=fix_system_prompt,
+        fix_user_prompt=fix_user_prompt,
+    )
+    if build_config is _SENTINEL:
+        build_config = BuildConfiguration(
+            build_command=build_command,
+            user_build_command=user_build_command,
+            user_format_command=user_format_command,
+        )
+    repo_config = RepositoryConfiguration(
+        repo_path=repo_path,
+        base_branch="main",
+    )
+    return RemediationContext(
+        remediation_id=remediation_id,
+        vulnerability=vulnerability,
+        prompts=prompts,
+        build_config=build_config,
+        repo_config=repo_config,
+        skip_writing_security_test=skip_writing_security_test,
+        session_id=session_id,
+        language=language,
+    )
 
 
 def create_temp_repo_dir():

--- a/test/setup_test_env.py
+++ b/test/setup_test_env.py
@@ -4,7 +4,10 @@ This module provides helper functions for test setup, including
 temporary directory management and sample object factories.
 """
 
+import json
 from pathlib import Path
+
+import requests
 
 from src.smartfix.domains.vulnerability import RemediationContext
 from src.smartfix.domains.vulnerability.context import (
@@ -16,6 +19,19 @@ from src.smartfix.domains.vulnerability.models import Vulnerability, Vulnerabili
 _SENTINEL = object()
 
 
+def make_sample_response(status_code, body=None, text=None):
+    """Create a real requests.Response with the given status code and content."""
+    resp = requests.Response()
+    resp.status_code = status_code
+    if body is not None:
+        resp._content = json.dumps(body).encode()
+    elif text is not None:
+        resp._content = text.encode()
+    else:
+        resp._content = b''
+    return resp
+
+
 def make_sample_context(
     remediation_id="sample-remediation",
     session_id="sample-session",
@@ -25,7 +41,7 @@ def make_sample_context(
     build_command=None,
     user_build_command=None,
     user_format_command=None,
-    repo_path="/tmp/test",
+    repo_path=Path("/tmp/test"),
     language=None,
     vuln_uuid="sample-vuln-uuid",
     vuln_title="Sample Vulnerability",

--- a/test/test.py
+++ b/test/test.py
@@ -3,7 +3,7 @@ import os
 import contextlib
 import unittest
 import tempfile
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 # Test setup imports (path is set up by conftest.py)
 from src.config import reset_config
@@ -39,7 +39,7 @@ class TestSmartFixAction(unittest.TestCase):
         # Mock subprocess to prevent actual command execution
         self.subprocess_patcher = patch('subprocess.run')
         self.mock_subprocess_run = self.subprocess_patcher.start()
-        mock_process = MagicMock()
+        mock_process = Mock()
         mock_process.returncode = 0
         mock_process.stdout = "Mock process output"
         mock_process.stderr = ""
@@ -58,14 +58,14 @@ class TestSmartFixAction(unittest.TestCase):
         # Mock all HTTP requests
         self.requests_patcher = patch('requests.post')
         self.mock_requests_post = self.requests_patcher.start()
-        mock_post_response = MagicMock()
+        mock_post_response = Mock()
         mock_post_response.status_code = 404  # Not found, to avoid further processing
         self.mock_requests_post.return_value = mock_post_response
 
         # Mock version check requests
         self.version_requests_patcher = patch('src.version_check.requests.get')
         self.mock_requests_get = self.version_requests_patcher.start()
-        mock_response = MagicMock()
+        mock_response = Mock()
         mock_response.json.return_value = [{'name': 'v1.0.0'}]
         mock_response.raise_for_status.return_value = None
         self.mock_requests_get.return_value = mock_response

--- a/test/test.py
+++ b/test/test.py
@@ -64,7 +64,7 @@ class TestSmartFixAction(unittest.TestCase):
         # Mock version check requests
         self.version_requests_patcher = patch('src.version_check.requests.get')
         self.mock_requests_get = self.version_requests_patcher.start()
-        mock_response = Mock()
+        mock_response = Mock(spec=requests.Response)
         mock_response.json.return_value = [{'name': 'v1.0.0'}]
         mock_response.raise_for_status.return_value = None
         self.mock_requests_get.return_value = mock_response

--- a/test/test.py
+++ b/test/test.py
@@ -1,8 +1,10 @@
 import io
 import os
 import contextlib
+import subprocess
 import unittest
 import tempfile
+import requests
 from unittest.mock import patch, Mock
 
 # Test setup imports (path is set up by conftest.py)
@@ -39,12 +41,9 @@ class TestSmartFixAction(unittest.TestCase):
         # Mock subprocess to prevent actual command execution
         self.subprocess_patcher = patch('subprocess.run')
         self.mock_subprocess_run = self.subprocess_patcher.start()
-        mock_process = Mock()
-        mock_process.returncode = 0
-        mock_process.stdout = "Mock process output"
-        mock_process.stderr = ""
-        mock_process.communicate.return_value = (b"Mock stdout", b"Mock stderr")
-        self.mock_subprocess_run.return_value = mock_process
+        self.mock_subprocess_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Mock process output", stderr=""
+        )
 
         # Mock GitOperations.configure_git_user to prevent git config errors
         self.git_config_patcher = patch('src.smartfix.domains.scm.git_operations.GitOperations.configure_git_user')
@@ -58,9 +57,9 @@ class TestSmartFixAction(unittest.TestCase):
         # Mock all HTTP requests
         self.requests_patcher = patch('requests.post')
         self.mock_requests_post = self.requests_patcher.start()
-        mock_post_response = Mock()
-        mock_post_response.status_code = 404  # Not found, to avoid further processing
-        self.mock_requests_post.return_value = mock_post_response
+        post_response = requests.Response()
+        post_response.status_code = 404  # Not found, to avoid further processing
+        self.mock_requests_post.return_value = post_response
 
         # Mock version check requests
         self.version_requests_patcher = patch('src.version_check.requests.get')

--- a/test/test.py
+++ b/test/test.py
@@ -8,6 +8,7 @@ import requests
 from unittest.mock import patch, Mock
 
 # Test setup imports (path is set up by conftest.py)
+from setup_test_env import make_sample_response
 from src.config import reset_config
 from src.main import main
 
@@ -57,9 +58,7 @@ class TestSmartFixAction(unittest.TestCase):
         # Mock all HTTP requests
         self.requests_patcher = patch('requests.post')
         self.mock_requests_post = self.requests_patcher.start()
-        post_response = requests.Response()
-        post_response.status_code = 404  # Not found, to avoid further processing
-        self.mock_requests_post.return_value = post_response
+        self.mock_requests_post.return_value = make_sample_response(404)
 
         # Mock version check requests
         self.version_requests_patcher = patch('src.version_check.requests.get')

--- a/test/test_agent_domain.py
+++ b/test/test_agent_domain.py
@@ -18,7 +18,7 @@
 #
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, patch
 from src.config import get_config, reset_config
 from src.smartfix.domains.agents import (
     SmartFixAgent,
@@ -83,15 +83,15 @@ class TestSmartFixAgent(unittest.TestCase):
         Tests that the remediate method is present on the SmartFixAgent and no longer raises NotImplementedError.
         """
         agent = SmartFixAgent()
-        mock_context = MagicMock(spec=RemediationContext)
+        mock_context = Mock(spec=RemediationContext)
 
         # Mock the required attributes and methods
-        mock_context.build_config = MagicMock()
+        mock_context.build_config = Mock()
         mock_context.build_config.has_build_command.return_value = False
-        mock_context.vulnerability = MagicMock()
+        mock_context.vulnerability = Mock()
         mock_context.vulnerability.title = "Test Vulnerability"
         mock_context.remediation_id = "test-123"
-        mock_context.repo_config = MagicMock()
+        mock_context.repo_config = Mock()
         mock_context.repo_config.repo_path = "/tmp/test-repo"
 
         # Mock function returns
@@ -111,13 +111,13 @@ class TestSmartFixAgent(unittest.TestCase):
         """
         agent = SmartFixAgent()
         session = AgentSession()
-        mock_context = MagicMock(spec=RemediationContext)
+        mock_context = Mock(spec=RemediationContext)
 
         # Setup mocks with proper attribute structure
-        mock_context.vulnerability = MagicMock()
+        mock_context.vulnerability = Mock()
         mock_context.vulnerability.title = "SQL Injection"
-        mock_context.prompts = MagicMock()  # Required by _run_fix_agent
-        mock_context.repo_config = MagicMock()  # Required by _run_fix_agent
+        mock_context.prompts = Mock()  # Required by _run_fix_agent
+        mock_context.repo_config = Mock()  # Required by _run_fix_agent
 
         mock_run_ai_fix.return_value = "Fix applied successfully"
 
@@ -134,10 +134,10 @@ class TestSmartFixAgent(unittest.TestCase):
         """
         agent = SmartFixAgent()
         session = AgentSession()
-        mock_context = MagicMock(spec=RemediationContext)
+        mock_context = Mock(spec=RemediationContext)
 
         # Setup mocks with proper attribute structure
-        mock_context.vulnerability = MagicMock()
+        mock_context.vulnerability = Mock()
         mock_context.vulnerability.title = "SQL Injection"
 
         mock_run_ai_fix.return_value = "Error during AI fix agent execution: Something went wrong"
@@ -154,9 +154,9 @@ class TestSmartFixAgent(unittest.TestCase):
         Tests the complete remediation workflow with all steps successful.
         """
         agent = SmartFixAgent()
-        mock_context = MagicMock(spec=RemediationContext)
+        mock_context = Mock(spec=RemediationContext)
 
-        mock_context.build_config = MagicMock()
+        mock_context.build_config = Mock()
         mock_context.build_config.has_build_command.return_value = True
         mock_context.build_config.user_build_command = None
 
@@ -178,8 +178,8 @@ class TestSmartFixAgent(unittest.TestCase):
         Tests the complete remediation workflow with BuildTool verification (PR gate).
         """
         agent = SmartFixAgent()
-        mock_context = MagicMock(spec=RemediationContext)
-        mock_context.build_config = MagicMock()
+        mock_context = Mock(spec=RemediationContext)
+        mock_context.build_config = Mock()
         mock_context.build_config.has_build_command.return_value = True
         mock_context.build_config.user_build_command = "mvn test"
 

--- a/test/test_agent_domain.py
+++ b/test/test_agent_domain.py
@@ -18,15 +18,16 @@
 #
 
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from src.config import get_config, reset_config
 from src.smartfix.domains.agents import (
     SmartFixAgent,
     CodingAgentStrategy,
     AgentSession,
 )
-from src.smartfix.shared.failure_categories import FailureCategory
 from src.smartfix.domains.vulnerability import RemediationContext
+from src.smartfix.shared.failure_categories import FailureCategory
+from setup_test_env import make_sample_context
 
 
 # Global patches to prevent git operations during tests
@@ -83,23 +84,17 @@ class TestSmartFixAgent(unittest.TestCase):
         Tests that the remediate method is present on the SmartFixAgent and no longer raises NotImplementedError.
         """
         agent = SmartFixAgent()
-        mock_context = Mock(spec=RemediationContext)
-
-        # Mock the required attributes and methods
-        mock_context.build_config = Mock()
-        mock_context.build_config.has_build_command.return_value = False
-        mock_context.vulnerability = Mock()
-        mock_context.vulnerability.title = "Test Vulnerability"
-        mock_context.remediation_id = "test-123"
-        mock_context.repo_config = Mock()
-        mock_context.repo_config.repo_path = "/tmp/test-repo"
+        context = make_sample_context(
+            remediation_id="test-123",
+            vuln_title="Test Vulnerability",
+        )
 
         # Mock function returns
         mock_run_build.return_value = (True, "Build success")
         mock_run_ai_fix.return_value = "Fix applied successfully"
 
         # Should not raise NotImplementedError anymore
-        result = agent.remediate(mock_context)
+        result = agent.remediate(context)
         self.assertIsInstance(result, AgentSession)
         # Just verify that the method returns a valid session object, don't check specific status
         # since the mock setup might result in different statuses
@@ -111,17 +106,11 @@ class TestSmartFixAgent(unittest.TestCase):
         """
         agent = SmartFixAgent()
         session = AgentSession()
-        mock_context = Mock(spec=RemediationContext)
-
-        # Setup mocks with proper attribute structure
-        mock_context.vulnerability = Mock()
-        mock_context.vulnerability.title = "SQL Injection"
-        mock_context.prompts = Mock()  # Required by _run_fix_agent
-        mock_context.repo_config = Mock()  # Required by _run_fix_agent
+        context = make_sample_context(vuln_title="SQL Injection")
 
         mock_run_ai_fix.return_value = "Fix applied successfully"
 
-        result = agent._run_fix_agent(session, mock_context)
+        result = agent._run_fix_agent(session, context)
 
         self.assertIsNotNone(result)
         self.assertEqual(result, "Fix applied successfully")
@@ -134,15 +123,11 @@ class TestSmartFixAgent(unittest.TestCase):
         """
         agent = SmartFixAgent()
         session = AgentSession()
-        mock_context = Mock(spec=RemediationContext)
-
-        # Setup mocks with proper attribute structure
-        mock_context.vulnerability = Mock()
-        mock_context.vulnerability.title = "SQL Injection"
+        context = make_sample_context(vuln_title="SQL Injection")
 
         mock_run_ai_fix.return_value = "Error during AI fix agent execution: Something went wrong"
 
-        result = agent._run_fix_agent(session, mock_context)
+        result = agent._run_fix_agent(session, context)
 
         self.assertIsNone(result)
         # Verify failure reason is set
@@ -154,18 +139,14 @@ class TestSmartFixAgent(unittest.TestCase):
         Tests the complete remediation workflow with all steps successful.
         """
         agent = SmartFixAgent()
-        mock_context = Mock(spec=RemediationContext)
-
-        mock_context.build_config = Mock()
-        mock_context.build_config.has_build_command.return_value = True
-        mock_context.build_config.user_build_command = None
+        context = make_sample_context(build_command="mvn test")
 
         def fix_agent_side_effect(session, context):
             agent._build_state = {"build_cmd": "mvn test", "format_cmd": None}
             return "success"
 
         with patch.object(agent, '_run_fix_agent', side_effect=fix_agent_side_effect) as mock_fix:
-            result = agent.remediate(mock_context)
+            result = agent.remediate(context)
 
             self.assertIsInstance(result, AgentSession)
             self.assertTrue(result.success)
@@ -178,10 +159,10 @@ class TestSmartFixAgent(unittest.TestCase):
         Tests the complete remediation workflow with BuildTool verification (PR gate).
         """
         agent = SmartFixAgent()
-        mock_context = Mock(spec=RemediationContext)
-        mock_context.build_config = Mock()
-        mock_context.build_config.has_build_command.return_value = True
-        mock_context.build_config.user_build_command = "mvn test"
+        context = make_sample_context(
+            build_command="mvn test",
+            user_build_command="mvn test",
+        )
 
         def fake_fix_agent(session, context):
             # Simulate BuildTool recording a successful build
@@ -189,7 +170,7 @@ class TestSmartFixAgent(unittest.TestCase):
             return "success"
 
         with patch.object(agent, '_run_fix_agent', side_effect=fake_fix_agent) as mock_fix:
-            result = agent.remediate(mock_context)
+            result = agent.remediate(context)
 
             self.assertTrue(result.success)
             self.assertIsNone(result.failure_category)

--- a/test/test_agent_infrastructure.py
+++ b/test/test_agent_infrastructure.py
@@ -258,7 +258,8 @@ class TestSubAgentExecutor(unittest.TestCase):
         headers = call_kwargs['extra_headers']
         self.assertEqual(headers['Api-Key'], 'test-api-key')
         self.assertEqual(headers['Authorization'], 'test-auth-key')
-        self.assertNotIn('x-contrast-llm-session-id', headers)
+        self.assertEqual(headers['x-contrast-llm-feature'], 'SMARTFIX')
+        self.assertEqual(headers['x-contrast-llm-session-id'], 'test-123')
 
     @patch('src.smartfix.domains.agents.sub_agent_executor.error_exit')
     @patch('src.config.get_config')

--- a/test/test_agent_infrastructure.py
+++ b/test/test_agent_infrastructure.py
@@ -7,7 +7,7 @@ This module tests the low-level agent infrastructure including:
 """
 
 import unittest
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import Mock, patch, AsyncMock
 from pathlib import Path
 import asyncio
 import os
@@ -111,8 +111,8 @@ class TestMCPToolsetManager(unittest.TestCase):
     def test_get_tools_success(self, mock_toolset_class):
         """Test successful get_tools call."""
         # Create mock toolset with async get_tools
-        mock_toolset = MagicMock()
-        mock_tool = MagicMock()
+        mock_toolset = Mock()
+        mock_tool = Mock()
         mock_tool.name = 'test_tool'
         mock_toolset.get_tools = AsyncMock(return_value=[mock_tool])
         mock_toolset_class.return_value = mock_toolset
@@ -129,7 +129,7 @@ class TestMCPToolsetManager(unittest.TestCase):
     def test_get_tools_failure(self, mock_toolset_class, mock_error_exit):
         """Test get_tools failure handling."""
         # Make get_tools raise an exception
-        mock_toolset = MagicMock()
+        mock_toolset = Mock()
         mock_toolset.get_tools = AsyncMock(side_effect=Exception('Connection failed'))
         mock_toolset_class.return_value = mock_toolset
 
@@ -170,7 +170,7 @@ class TestSubAgentExecutor(unittest.TestCase):
     def test_initialization_default_max_events(self):
         """Test SubAgentExecutor initialization with default max_events."""
         with patch('src.config.get_config') as mock_config:
-            config_mock = MagicMock()
+            config_mock = Mock()
             config_mock.MAX_EVENTS_PER_AGENT = 100
             mock_config.return_value = config_mock
 
@@ -193,19 +193,19 @@ class TestSubAgentExecutor(unittest.TestCase):
     def test_create_agent_success(self, mock_get_config, mock_litellm, mock_agent):
         """Test successful agent creation."""
         # Mock config
-        config_mock = MagicMock()
+        config_mock = Mock()
         config_mock.AGENT_MODEL = 'test-model'
         config_mock.USE_CONTRAST_LLM = False
         mock_get_config.return_value = config_mock
 
         # Mock MCP manager
-        mock_mcp_tools = MagicMock()
+        mock_mcp_tools = Mock()
 
         executor = SubAgentExecutor()
         executor.mcp_manager.get_tools = AsyncMock(return_value=mock_mcp_tools)
 
         # Mock agent creation
-        mock_agent_instance = MagicMock()
+        mock_agent_instance = Mock()
         mock_agent.return_value = mock_agent_instance
 
         result = asyncio.run(executor.create_agent(
@@ -224,7 +224,7 @@ class TestSubAgentExecutor(unittest.TestCase):
     def test_create_agent_with_contrast_llm(self, mock_get_config, mock_litellm, mock_agent):
         """Test agent creation with Contrast LLM configuration."""
         # Mock config with Contrast LLM enabled
-        config_mock = MagicMock()
+        config_mock = Mock()
         config_mock.AGENT_MODEL = 'test-model'
         config_mock.USE_CONTRAST_LLM = True
         config_mock.CONTRAST_API_KEY = 'test-api-key'
@@ -232,13 +232,13 @@ class TestSubAgentExecutor(unittest.TestCase):
         mock_get_config.return_value = config_mock
 
         # Mock MCP manager
-        mock_mcp_tools = MagicMock()
+        mock_mcp_tools = Mock()
 
         executor = SubAgentExecutor()
         executor.mcp_manager.get_tools = AsyncMock(return_value=mock_mcp_tools)
 
         # Mock agent creation
-        mock_agent_instance = MagicMock()
+        mock_agent_instance = Mock()
         mock_agent.return_value = mock_agent_instance
 
         result = asyncio.run(executor.create_agent(
@@ -266,7 +266,7 @@ class TestSubAgentExecutor(unittest.TestCase):
     def test_create_agent_no_mcp_tools(self, mock_get_config, mock_error_exit):
         """Test agent creation fails when no MCP tools available."""
         # Mock config
-        config_mock = MagicMock()
+        config_mock = Mock()
         mock_get_config.return_value = config_mock
 
         executor = SubAgentExecutor()
@@ -286,11 +286,11 @@ class TestSubAgentExecutor(unittest.TestCase):
     def test_create_agent_no_system_prompt(self, mock_get_config, mock_error_exit):
         """Test agent creation fails when no system prompt provided."""
         # Mock config
-        config_mock = MagicMock()
+        config_mock = Mock()
         mock_get_config.return_value = config_mock
 
         executor = SubAgentExecutor()
-        executor.mcp_manager.get_tools = AsyncMock(return_value=MagicMock())
+        executor.mcp_manager.get_tools = AsyncMock(return_value=Mock())
 
         asyncio.run(executor.create_agent(
             target_folder=Path('/test'),
@@ -306,7 +306,7 @@ class TestSubAgentExecutor(unittest.TestCase):
         executor = SubAgentExecutor()
 
         # Mock agent with stats
-        mock_agent = MagicMock()
+        mock_agent = Mock()
         mock_agent.gather_accumulated_stats_dict.return_value = {
             'token_usage': {'total_tokens': 1000},
             'cost_analysis': {'total_cost': 0.05}
@@ -322,7 +322,7 @@ class TestSubAgentExecutor(unittest.TestCase):
         executor = SubAgentExecutor()
 
         # Mock agent with stats including $ sign
-        mock_agent = MagicMock()
+        mock_agent = Mock()
         mock_agent.gather_accumulated_stats_dict.return_value = {
             'token_usage': {'total_tokens': 1000},
             'cost_analysis': {'total_cost': '$0.05'}
@@ -338,7 +338,7 @@ class TestSubAgentExecutor(unittest.TestCase):
         executor = SubAgentExecutor()
 
         # Mock agent that raises AttributeError (one of the caught exceptions)
-        mock_agent = MagicMock()
+        mock_agent = Mock()
         mock_agent.gather_accumulated_stats_dict.side_effect = AttributeError('Stats error')
 
         total_tokens, total_cost = executor._collect_statistics(mock_agent)
@@ -352,7 +352,7 @@ class TestSubAgentExecutor(unittest.TestCase):
         executor = SubAgentExecutor()
 
         # Mock event with text content
-        mock_event = MagicMock()
+        mock_event = Mock()
         mock_event.content.text = 'Agent response text'
 
         result = executor._process_content(mock_event)
@@ -364,10 +364,10 @@ class TestSubAgentExecutor(unittest.TestCase):
         executor = SubAgentExecutor()
 
         # Mock event with parts (no text attribute)
-        mock_event = MagicMock()
+        mock_event = Mock()
         # Remove the text attribute so hasattr returns False
         del mock_event.content.text
-        mock_part = MagicMock()
+        mock_part = Mock()
         mock_part.text = 'Part text'
         mock_event.content.parts = [mock_part]
 
@@ -380,7 +380,7 @@ class TestSubAgentExecutor(unittest.TestCase):
         executor = SubAgentExecutor()
 
         # Mock event with no content
-        mock_event = MagicMock()
+        mock_event = Mock()
         mock_event.content = None
 
         result = executor._process_content(mock_event)
@@ -393,8 +393,8 @@ class TestSubAgentExecutor(unittest.TestCase):
         telemetry = []
 
         # Mock event with function calls
-        mock_event = MagicMock()
-        mock_call = MagicMock()
+        mock_event = Mock()
+        mock_call = Mock()
         mock_call.name = 'read_file'
         mock_call.args = {'path': '/test/file.py'}
         mock_event.get_function_calls.return_value = [mock_call]
@@ -411,8 +411,8 @@ class TestSubAgentExecutor(unittest.TestCase):
         telemetry = []
 
         # Mock event with function response
-        mock_event = MagicMock()
-        mock_response = MagicMock()
+        mock_event = Mock()
+        mock_response = Mock()
         mock_response.name = 'read_file'
         mock_response.response = 'isError = False, content = file contents'
         mock_event.get_function_responses.return_value = [mock_response]
@@ -429,8 +429,8 @@ class TestSubAgentExecutor(unittest.TestCase):
         telemetry = []
 
         # Mock event with error response
-        mock_event = MagicMock()
-        mock_response = MagicMock()
+        mock_event = Mock()
+        mock_response = Mock()
         mock_response.name = 'write_file'
         mock_response.response = 'isError = True, error = permission denied'
         mock_event.get_function_responses.return_value = [mock_response]

--- a/test/test_agent_infrastructure.py
+++ b/test/test_agent_infrastructure.py
@@ -195,7 +195,7 @@ class TestSubAgentExecutor(unittest.TestCase):
         # Mock config
         config_mock = MagicMock()
         config_mock.AGENT_MODEL = 'test-model'
-        config_mock.USE_CONTRAST_LLM = 'false'
+        config_mock.USE_CONTRAST_LLM = False
         mock_get_config.return_value = config_mock
 
         # Mock MCP manager
@@ -226,7 +226,7 @@ class TestSubAgentExecutor(unittest.TestCase):
         # Mock config with Contrast LLM enabled
         config_mock = MagicMock()
         config_mock.AGENT_MODEL = 'test-model'
-        config_mock.USE_CONTRAST_LLM = 'true'
+        config_mock.USE_CONTRAST_LLM = True
         config_mock.CONTRAST_API_KEY = 'test-api-key'
         config_mock.CONTRAST_AUTHORIZATION_KEY = 'test-auth-key'
         mock_get_config.return_value = config_mock

--- a/test/test_build_command_detection_integration.py
+++ b/test/test_build_command_detection_integration.py
@@ -21,6 +21,7 @@ Detection is store-only: it does NOT run actual builds.
 The Fix agent's BuildTool handles build execution and verification.
 """
 
+import subprocess
 import unittest
 import tempfile
 import shutil
@@ -56,7 +57,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         self._create_file('src/main/java/App.java', 'public class App {}')
 
         # Mock mvn --version check (tool exists)
-        mock_subprocess.return_value = Mock(returncode=0, stdout='Maven 3.8.1')
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout='Maven 3.8.1')
 
         result = detect_build_command(repo_root=self.repo_root)
 
@@ -92,7 +93,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         self._create_file('build.gradle', 'plugins { id "java" }')
         self._create_file('settings.gradle', 'rootProject.name = "test"')
 
-        mock_subprocess.return_value = Mock(returncode=0, stdout='Gradle 7.4')
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout='Gradle 7.4')
 
         result = detect_build_command(repo_root=self.repo_root)
 
@@ -107,7 +108,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         """npm project: detects npm command from package.json marker."""
         self._create_file('package.json', '{"name": "test", "scripts": {"test": "jest"}}')
 
-        mock_subprocess.return_value = Mock(returncode=0, stdout='8.19.2')
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout='8.19.2')
 
         result = detect_build_command(repo_root=self.repo_root)
 
@@ -119,7 +120,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         """Makefile project: detects make command from Makefile marker."""
         self._create_file('Makefile', 'test:\n\t@python -m pytest\n\n.PHONY: test\n')
 
-        mock_subprocess.return_value = Mock(returncode=0, stdout='GNU Make 4.3')
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout='GNU Make 4.3')
 
         result = detect_build_command(repo_root=self.repo_root)
 
@@ -144,7 +145,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         backend_dir.mkdir(parents=True)
         (backend_dir / 'pom.xml').write_text('<project></project>')
 
-        mock_subprocess.return_value = Mock(returncode=0, stdout='Maven 3.8.1')
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout='Maven 3.8.1')
 
         result = detect_build_command(
             repo_root=self.repo_root,
@@ -159,7 +160,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         """Detection must NOT run actual builds (store-only)."""
         self._create_file('pom.xml', '<project></project>')
 
-        mock_subprocess.return_value = Mock(returncode=0, stdout='Maven 3.8.1')
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout='Maven 3.8.1')
 
         detect_build_command(repo_root=self.repo_root)
 

--- a/test/test_build_command_detection_integration.py
+++ b/test/test_build_command_detection_integration.py
@@ -25,7 +25,7 @@ import unittest
 import tempfile
 import shutil
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 from src.smartfix.config.command_detector import detect_build_command
 
@@ -56,7 +56,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         self._create_file('src/main/java/App.java', 'public class App {}')
 
         # Mock mvn --version check (tool exists)
-        mock_subprocess.return_value = MagicMock(returncode=0, stdout='Maven 3.8.1')
+        mock_subprocess.return_value = Mock(returncode=0, stdout='Maven 3.8.1')
 
         result = detect_build_command(repo_root=self.repo_root)
 
@@ -92,7 +92,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         self._create_file('build.gradle', 'plugins { id "java" }')
         self._create_file('settings.gradle', 'rootProject.name = "test"')
 
-        mock_subprocess.return_value = MagicMock(returncode=0, stdout='Gradle 7.4')
+        mock_subprocess.return_value = Mock(returncode=0, stdout='Gradle 7.4')
 
         result = detect_build_command(repo_root=self.repo_root)
 
@@ -107,7 +107,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         """npm project: detects npm command from package.json marker."""
         self._create_file('package.json', '{"name": "test", "scripts": {"test": "jest"}}')
 
-        mock_subprocess.return_value = MagicMock(returncode=0, stdout='8.19.2')
+        mock_subprocess.return_value = Mock(returncode=0, stdout='8.19.2')
 
         result = detect_build_command(repo_root=self.repo_root)
 
@@ -119,7 +119,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         """Makefile project: detects make command from Makefile marker."""
         self._create_file('Makefile', 'test:\n\t@python -m pytest\n\n.PHONY: test\n')
 
-        mock_subprocess.return_value = MagicMock(returncode=0, stdout='GNU Make 4.3')
+        mock_subprocess.return_value = Mock(returncode=0, stdout='GNU Make 4.3')
 
         result = detect_build_command(repo_root=self.repo_root)
 
@@ -144,7 +144,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         backend_dir.mkdir(parents=True)
         (backend_dir / 'pom.xml').write_text('<project></project>')
 
-        mock_subprocess.return_value = MagicMock(returncode=0, stdout='Maven 3.8.1')
+        mock_subprocess.return_value = Mock(returncode=0, stdout='Maven 3.8.1')
 
         result = detect_build_command(
             repo_root=self.repo_root,
@@ -159,7 +159,7 @@ class TestBuildCommandDetectionIntegration(unittest.TestCase):
         """Detection must NOT run actual builds (store-only)."""
         self._create_file('pom.xml', '<project></project>')
 
-        mock_subprocess.return_value = MagicMock(returncode=0, stdout='Maven 3.8.1')
+        mock_subprocess.return_value = Mock(returncode=0, stdout='Maven 3.8.1')
 
         detect_build_command(repo_root=self.repo_root)
 

--- a/test/test_build_command_detection_integration.py
+++ b/test/test_build_command_detection_integration.py
@@ -26,7 +26,7 @@ import unittest
 import tempfile
 import shutil
 from pathlib import Path
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 from src.smartfix.config.command_detector import detect_build_command
 

--- a/test/test_build_runner.py
+++ b/test/test_build_runner.py
@@ -4,9 +4,10 @@ Tests for build_runner.py module.
 Tests build execution, output capture, exit code handling, and telemetry integration.
 """
 
+import subprocess
 import unittest
 from pathlib import Path
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 from src.smartfix.domains.workflow.build_runner import run_build_command
 
@@ -31,12 +32,9 @@ class TestBuildRunner(unittest.TestCase):
 
     def test_build_succeeds_exit_code_0(self):
         """Test successful build with exit code 0."""
-        # Setup mock
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "BUILD SUCCESS\n"
-        mock_result.stderr = ""
-        self.mock_subprocess.return_value = mock_result
+        self.mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="BUILD SUCCESS\n", stderr=""
+        )
 
         # Execute
         success, output = run_build_command(
@@ -53,12 +51,9 @@ class TestBuildRunner(unittest.TestCase):
 
     def test_build_fails_exit_code_1(self):
         """Test failed build with exit code 1."""
-        # Setup mock
-        mock_result = Mock()
-        mock_result.returncode = 1
-        mock_result.stdout = ""
-        mock_result.stderr = "COMPILATION FAILED\n"
-        self.mock_subprocess.return_value = mock_result
+        self.mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="COMPILATION FAILED\n"
+        )
 
         # Execute
         success, output = run_build_command(
@@ -82,12 +77,9 @@ class TestBuildRunner(unittest.TestCase):
 
         for exit_code, error_msg in test_cases:
             with self.subTest(exit_code=exit_code):
-                # Setup mock
-                mock_result = Mock()
-                mock_result.returncode = exit_code
-                mock_result.stdout = ""
-                mock_result.stderr = error_msg
-                self.mock_subprocess.return_value = mock_result
+                self.mock_subprocess.return_value = subprocess.CompletedProcess(
+                    args=[], returncode=exit_code, stdout="", stderr=error_msg
+                )
 
                 # Execute
                 success, output = run_build_command(
@@ -102,12 +94,9 @@ class TestBuildRunner(unittest.TestCase):
 
     def test_build_output_parsing_stdout_and_stderr(self):
         """Test that both stdout and stderr are captured and combined."""
-        # Setup mock
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "Standard output\n"
-        mock_result.stderr = "Warning messages\n"
-        self.mock_subprocess.return_value = mock_result
+        self.mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Standard output\n", stderr="Warning messages\n"
+        )
 
         # Execute
         success, output = run_build_command(
@@ -156,12 +145,9 @@ class TestBuildRunner(unittest.TestCase):
 
     def test_build_subprocess_call_parameters(self):
         """Test that subprocess.run is called with correct parameters."""
-        # Setup mock
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "Success"
-        mock_result.stderr = ""
-        self.mock_subprocess.return_value = mock_result
+        self.mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Success", stderr=""
+        )
 
         # Execute
         command = "npm run build"
@@ -183,11 +169,9 @@ class TestBuildRunner(unittest.TestCase):
     def test_build_telemetry_always_recorded(self):
         """Test that telemetry is recorded regardless of build outcome."""
         # Test successful build
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "Success"
-        mock_result.stderr = ""
-        self.mock_subprocess.return_value = mock_result
+        self.mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Success", stderr=""
+        )
 
         run_build_command("npm test", Path("/tmp/repo"), "test-remediation-id")
         self.mock_telemetry.assert_called_with("configInfo.buildCommandRunTestsIncluded", True)
@@ -196,21 +180,20 @@ class TestBuildRunner(unittest.TestCase):
         self.mock_telemetry.reset_mock()
 
         # Test failed build
-        mock_result.returncode = 1
-        mock_result.stdout = ""
-        mock_result.stderr = "Failed"
+        self.mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="Failed"
+        )
 
         run_build_command("npm test", Path("/tmp/repo"), "test-remediation-id")
         self.mock_telemetry.assert_called_with("configInfo.buildCommandRunTestsIncluded", True)
 
     def test_build_encoding_handling(self):
         """Test that encoding errors are handled gracefully."""
-        # Setup mock with unicode characters
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "Test output with unicode: \u2713\n"
-        mock_result.stderr = "Warning with emoji: \U0001F4A9\n"
-        self.mock_subprocess.return_value = mock_result
+        self.mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0,
+            stdout="Test output with unicode: \u2713\n",
+            stderr="Warning with emoji: \U0001F4A9\n"
+        )
 
         # Execute
         success, output = run_build_command(

--- a/test/test_build_runner.py
+++ b/test/test_build_runner.py
@@ -6,7 +6,7 @@ Tests build execution, output capture, exit code handling, and telemetry integra
 
 import unittest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 from src.smartfix.domains.workflow.build_runner import run_build_command
 
@@ -32,7 +32,7 @@ class TestBuildRunner(unittest.TestCase):
     def test_build_succeeds_exit_code_0(self):
         """Test successful build with exit code 0."""
         # Setup mock
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = "BUILD SUCCESS\n"
         mock_result.stderr = ""
@@ -54,7 +54,7 @@ class TestBuildRunner(unittest.TestCase):
     def test_build_fails_exit_code_1(self):
         """Test failed build with exit code 1."""
         # Setup mock
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 1
         mock_result.stdout = ""
         mock_result.stderr = "COMPILATION FAILED\n"
@@ -83,7 +83,7 @@ class TestBuildRunner(unittest.TestCase):
         for exit_code, error_msg in test_cases:
             with self.subTest(exit_code=exit_code):
                 # Setup mock
-                mock_result = MagicMock()
+                mock_result = Mock()
                 mock_result.returncode = exit_code
                 mock_result.stdout = ""
                 mock_result.stderr = error_msg
@@ -103,7 +103,7 @@ class TestBuildRunner(unittest.TestCase):
     def test_build_output_parsing_stdout_and_stderr(self):
         """Test that both stdout and stderr are captured and combined."""
         # Setup mock
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = "Standard output\n"
         mock_result.stderr = "Warning messages\n"
@@ -157,7 +157,7 @@ class TestBuildRunner(unittest.TestCase):
     def test_build_subprocess_call_parameters(self):
         """Test that subprocess.run is called with correct parameters."""
         # Setup mock
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = "Success"
         mock_result.stderr = ""
@@ -183,7 +183,7 @@ class TestBuildRunner(unittest.TestCase):
     def test_build_telemetry_always_recorded(self):
         """Test that telemetry is recorded regardless of build outcome."""
         # Test successful build
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = "Success"
         mock_result.stderr = ""
@@ -206,7 +206,7 @@ class TestBuildRunner(unittest.TestCase):
     def test_build_encoding_handling(self):
         """Test that encoding errors are handled gracefully."""
         # Setup mock with unicode characters
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = "Test output with unicode: \u2713\n"
         mock_result.stderr = "Warning with emoji: \U0001F4A9\n"

--- a/test/test_buildtool_integration.py
+++ b/test/test_buildtool_integration.py
@@ -9,6 +9,7 @@ Tests the end-to-end flow:
 - Non-recordable commands don't satisfy PR gate
 """
 
+import subprocess
 import unittest
 from pathlib import Path
 from unittest.mock import patch, Mock
@@ -27,7 +28,7 @@ class TestBuildToolPRGateIntegration(unittest.TestCase):
     @patch('subprocess.run')
     def test_successful_build_records_command_and_pr_gate_passes(self, mock_subprocess):
         """Full flow: BuildTool records success → PR gate passes."""
-        mock_subprocess.return_value = Mock(returncode=0, stdout="BUILD SUCCESS", stderr="")
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="BUILD SUCCESS", stderr="")
 
         tool, state = create_build_tool(
             repo_root=Path("/tmp/test"),
@@ -88,7 +89,7 @@ class TestBuildToolPRGateIntegration(unittest.TestCase):
     @patch('subprocess.run')
     def test_non_recordable_command_does_not_satisfy_gate(self, mock_subprocess):
         """Non-recordable commands (--version, echo) don't satisfy PR gate."""
-        mock_subprocess.return_value = Mock(returncode=0, stdout="Maven 3.8.1", stderr="")
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="Maven 3.8.1", stderr="")
 
         tool, state = create_build_tool(
             repo_root=Path("/tmp/test"),
@@ -117,7 +118,7 @@ class TestBuildCommandEnforcement(unittest.TestCase):
     @patch('subprocess.run')
     def test_scoped_command_not_recorded_when_configured_exists(self, mock_subprocess):
         """Agent runs scoped command (e.g. mvn test -Dtest=Foo) but configured is 'mvn test' → not recorded."""
-        mock_subprocess.return_value = Mock(returncode=0, stdout="BUILD SUCCESS", stderr="")
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="BUILD SUCCESS", stderr="")
 
         tool, state = create_build_tool(
             repo_root=Path("/tmp/test"),
@@ -135,7 +136,7 @@ class TestBuildCommandEnforcement(unittest.TestCase):
     @patch('subprocess.run')
     def test_exact_configured_command_is_recorded(self, mock_subprocess):
         """Agent runs exact configured command → recorded."""
-        mock_subprocess.return_value = Mock(returncode=0, stdout="BUILD SUCCESS", stderr="")
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="BUILD SUCCESS", stderr="")
 
         tool, state = create_build_tool(
             repo_root=Path("/tmp/test"),
@@ -152,7 +153,7 @@ class TestBuildCommandEnforcement(unittest.TestCase):
     @patch('subprocess.run')
     def test_pr_gate_rejects_mismatched_recorded_command(self, mock_subprocess):
         """PR gate fails if recorded command doesn't match configured command."""
-        mock_subprocess.return_value = Mock(returncode=0, stdout="BUILD SUCCESS", stderr="")
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="BUILD SUCCESS", stderr="")
 
         # Simulate: no user_build_command so any recordable command gets recorded
         tool, state = create_build_tool(
@@ -179,7 +180,7 @@ class TestBuildToolConfiguredVsDetermined(unittest.TestCase):
     @patch('subprocess.run')
     def test_configured_command_skips_allowlist(self, mock_subprocess):
         """User-configured command skips allowlist validation."""
-        mock_subprocess.return_value = Mock(returncode=0, stdout="OK", stderr="")
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="OK", stderr="")
 
         tool, state = create_build_tool(
             repo_root=Path("/tmp/test"),
@@ -197,7 +198,7 @@ class TestBuildToolConfiguredVsDetermined(unittest.TestCase):
     @patch('subprocess.run')
     def test_agent_discovered_command_must_pass_allowlist(self, mock_subprocess):
         """Agent-discovered command must pass allowlist validation."""
-        mock_subprocess.return_value = Mock(returncode=0, stdout="OK", stderr="")
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="OK", stderr="")
 
         tool, state = create_build_tool(
             repo_root=Path("/tmp/test"),
@@ -215,7 +216,7 @@ class TestBuildToolConfiguredVsDetermined(unittest.TestCase):
     @patch('subprocess.run')
     def test_configured_format_command_skips_allowlist(self, mock_subprocess, mock_format):
         """User-configured format command skips allowlist validation."""
-        mock_subprocess.return_value = Mock(returncode=0, stdout="Formatted", stderr="")
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="Formatted", stderr="")
 
         tool, state = create_build_tool(
             repo_root=Path("/tmp/test"),
@@ -265,7 +266,7 @@ class TestCrossRunPersistence(unittest.TestCase):
     @patch('subprocess.run')
     def test_cross_run_build_config_passes_user_command_to_tool(self, mock_subprocess):
         """BuildConfiguration.user_build_command flows through to BuildTool for exact-match."""
-        mock_subprocess.return_value = Mock(returncode=0, stdout="OK", stderr="")
+        mock_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="OK", stderr="")
 
         config = Mock()
         config.BUILD_COMMAND = "custom-tool verify"

--- a/test/test_buildtool_integration.py
+++ b/test/test_buildtool_integration.py
@@ -13,10 +13,12 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch, Mock
 
+from src.smartfix.domains.agents.agent_session import AgentSession
 from src.smartfix.domains.agents.build_tool import create_build_tool
 from src.smartfix.domains.agents.smartfix_agent import SmartFixAgent
 from src.smartfix.domains.vulnerability.context import BuildConfiguration
 from src.smartfix.shared.failure_categories import FailureCategory
+from setup_test_env import make_sample_context
 
 
 class TestBuildToolPRGateIntegration(unittest.TestCase):
@@ -42,11 +44,8 @@ class TestBuildToolPRGateIntegration(unittest.TestCase):
         # PR gate should pass
         agent = SmartFixAgent()
         agent._build_state = state
-        session = Mock()
-        context = Mock()
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = True
-        context.build_config.user_build_command = "mvn test"
+        session = AgentSession()
+        context = make_sample_context(build_command="mvn test", user_build_command="mvn test")
 
         gate_result = agent._check_pr_gate(session, context)
         self.assertTrue(gate_result)
@@ -55,45 +54,36 @@ class TestBuildToolPRGateIntegration(unittest.TestCase):
         """No successful build recorded → PR gate fails with BUILD_VERIFICATION_FAILED."""
         agent = SmartFixAgent()
         agent._build_state = {"build_cmd": None, "format_cmd": None}
-        session = Mock()
-        session.complete_session = Mock()
-        context = Mock()
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = True
+        session = AgentSession()
+        context = make_sample_context(build_command="mvn test")
 
         gate_result = agent._check_pr_gate(session, context)
 
         self.assertFalse(gate_result)
-        session.complete_session.assert_called_once()
-        call_kwargs = session.complete_session.call_args[1]
-        self.assertEqual(call_kwargs["failure_category"], FailureCategory.BUILD_VERIFICATION_FAILED)
+        self.assertTrue(session.is_complete)
+        self.assertEqual(session.failure_category, FailureCategory.BUILD_VERIFICATION_FAILED)
 
     def test_no_build_config_pr_gate_fails(self):
         """No build command configured → PR gate fails."""
         agent = SmartFixAgent()
-        session = Mock()
-        context = Mock()
-        context.build_config = None
+        session = AgentSession()
+        context = make_sample_context(build_config=None)
 
         gate_result = agent._check_pr_gate(session, context)
         self.assertFalse(gate_result)
-        session.complete_session.assert_called_once()
-        call_kwargs = session.complete_session.call_args[1]
-        self.assertEqual(call_kwargs["failure_category"], FailureCategory.BUILD_VERIFICATION_FAILED)
+        self.assertTrue(session.is_complete)
+        self.assertEqual(session.failure_category, FailureCategory.BUILD_VERIFICATION_FAILED)
 
     def test_empty_build_command_pr_gate_fails(self):
         """Build config exists but has_build_command is False → gate fails."""
         agent = SmartFixAgent()
-        session = Mock()
-        context = Mock()
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = False
+        session = AgentSession()
+        context = make_sample_context()  # no build_command = empty
 
         gate_result = agent._check_pr_gate(session, context)
         self.assertFalse(gate_result)
-        session.complete_session.assert_called_once()
-        call_kwargs = session.complete_session.call_args[1]
-        self.assertEqual(call_kwargs["failure_category"], FailureCategory.BUILD_VERIFICATION_FAILED)
+        self.assertTrue(session.is_complete)
+        self.assertEqual(session.failure_category, FailureCategory.BUILD_VERIFICATION_FAILED)
 
     @patch('subprocess.run')
     def test_non_recordable_command_does_not_satisfy_gate(self, mock_subprocess):
@@ -114,11 +104,8 @@ class TestBuildToolPRGateIntegration(unittest.TestCase):
         # PR gate should fail since nothing was recorded
         agent = SmartFixAgent()
         agent._build_state = state
-        session = Mock()
-        session.complete_session = Mock()
-        context = Mock()
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = True
+        session = AgentSession()
+        context = make_sample_context(build_command="mvn --version")
 
         gate_result = agent._check_pr_gate(session, context)
         self.assertFalse(gate_result)
@@ -177,18 +164,13 @@ class TestBuildCommandEnforcement(unittest.TestCase):
         # Now check PR gate with a configured command that doesn't match
         agent = SmartFixAgent()
         agent._build_state = state
-        session = Mock()
-        session.complete_session = Mock()
-        context = Mock()
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = True
-        context.build_config.user_build_command = "mvn test"
+        session = AgentSession()
+        context = make_sample_context(build_command="mvn test", user_build_command="mvn test")
 
         gate_result = agent._check_pr_gate(session, context)
         self.assertFalse(gate_result)
-        session.complete_session.assert_called_once()
-        call_kwargs = session.complete_session.call_args[1]
-        self.assertEqual(call_kwargs["failure_category"], FailureCategory.BUILD_VERIFICATION_FAILED)
+        self.assertTrue(session.is_complete)
+        self.assertEqual(session.failure_category, FailureCategory.BUILD_VERIFICATION_FAILED)
 
 
 class TestBuildToolConfiguredVsDetermined(unittest.TestCase):
@@ -327,10 +309,7 @@ class TestSmartFixAgentRemediation(unittest.TestCase):
         agent = SmartFixAgent()
         agent._build_state = {"build_cmd": "leftover", "format_cmd": None}
 
-        context = Mock()
-        context.build_config = None
-        context.prompts = Mock()
-        context.repo_config = Mock()
+        context = make_sample_context(build_config=None)
 
         with patch.object(agent, '_run_ai_fix_agent', return_value="<pr_body>Fixed</pr_body>"):
             agent.remediate(context)
@@ -346,19 +325,13 @@ class TestSmartFixAgentRemediation(unittest.TestCase):
         mock_event_loop.return_value = "<pr_body>Fix applied</pr_body>"
 
         agent = SmartFixAgent()
-        context = Mock()
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = False
-        context.build_config.user_build_command = "mvn test"
-        context.build_config.user_format_command = None
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix"
-        context.prompts.fix_user_prompt = "Fix"
-        context.remediation_id = "int-010"
-        context.session_id = "sess-010"
-        context.skip_writing_security_test = False
+        context = make_sample_context(
+            remediation_id="int-010",
+            session_id="sess-010",
+            fix_system_prompt="Fix",
+            fix_user_prompt="Fix",
+            user_build_command="mvn test",
+        )
 
         with patch.object(agent, '_extract_analytics_data'):
             agent.remediate(context)

--- a/test/test_closed_handler.py
+++ b/test/test_closed_handler.py
@@ -24,6 +24,7 @@ import os
 import json
 
 from src.config import reset_config, get_config  # noqa: E402
+from src.github.github_operations import GitHubOperations  # noqa: E402
 from src import closed_handler  # noqa: E402
 
 
@@ -282,7 +283,7 @@ class TestClosedHandler(unittest.TestCase):
         """Test _extract_remediation_info with Copilot branch"""
         # Mock objects
         mock_extract_remediation_id = Mock(return_value="REM-456")
-        github_ops_mock = Mock()
+        github_ops_mock = Mock(spec=GitHubOperations)
         github_ops_mock.extract_issue_number_from_branch.return_value = 42
         telemetry_mock = Mock()
         # Test data
@@ -307,7 +308,7 @@ class TestClosedHandler(unittest.TestCase):
         """Test _extract_remediation_info with Claude Code branch"""
         # Mock objects
         mock_extract_remediation_id = Mock(return_value="REM-789")
-        github_ops_mock = Mock()
+        github_ops_mock = Mock(spec=GitHubOperations)
         github_ops_mock.extract_issue_number_from_branch.return_value = 75
         telemetry_mock = Mock()
         # Test data
@@ -332,7 +333,7 @@ class TestClosedHandler(unittest.TestCase):
         """Test _extract_remediation_info with Claude Code branch without extractable issue number"""
         # Mock objects
         mock_extract_remediation_id = Mock(return_value="REM-789")
-        github_ops_mock = Mock()
+        github_ops_mock = Mock(spec=GitHubOperations)
         github_ops_mock.extract_issue_number_from_branch.return_value = None
         telemetry_mock = Mock()
         # Test data

--- a/test/test_closed_handler.py
+++ b/test/test_closed_handler.py
@@ -424,7 +424,7 @@ class TestCleanupSmartfixLabels(unittest.TestCase):
 
     def _build_mock_ops(self, smartfix_label_names, issue_number=None,
                         remove_pr_ok=True, remove_issue_ok=True):
-        ops = Mock()
+        ops = Mock(spec=GitHubOperations)
         ops.filter_smartfix_labels.return_value = smartfix_label_names
         ops.extract_issue_number_from_branch.return_value = issue_number
         ops.remove_labels_from_pr.return_value = remove_pr_ok

--- a/test/test_closed_handler.py
+++ b/test/test_closed_handler.py
@@ -19,7 +19,7 @@
 #
 
 import unittest
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open, Mock
 import os
 import json
 
@@ -168,7 +168,7 @@ class TestClosedHandler(unittest.TestCase):
             "head": {"ref": "smartfix/remediation-REM-555"},
             "labels": [{"name": "smartfix-id:REM-555"}]
         }
-        telemetry_mock = MagicMock()
+        telemetry_mock = Mock()
         with patch('src.smartfix.domains.telemetry.telemetry_handler.update_telemetry', telemetry_mock):
             result = closed_handler._extract_remediation_info(pull_request)
         self.assertEqual(result, ("REM-555", [{"name": "smartfix-id:REM-555"}]))
@@ -179,7 +179,7 @@ class TestClosedHandler(unittest.TestCase):
             "head": {"ref": "smartfix/remediation-REM-999"},
             "labels": []
         }
-        telemetry_mock = MagicMock()
+        telemetry_mock = Mock()
         with patch('src.smartfix.domains.telemetry.telemetry_handler.update_telemetry', telemetry_mock):
             result = closed_handler._extract_remediation_info(pull_request)
         self.assertEqual(result[0], "REM-999")
@@ -281,10 +281,10 @@ class TestClosedHandler(unittest.TestCase):
     def test_extract_remediation_info_copilot_branch(self):
         """Test _extract_remediation_info with Copilot branch"""
         # Mock objects
-        mock_extract_remediation_id = MagicMock(return_value="REM-456")
-        github_ops_mock = MagicMock()
+        mock_extract_remediation_id = Mock(return_value="REM-456")
+        github_ops_mock = Mock()
         github_ops_mock.extract_issue_number_from_branch.return_value = 42
-        telemetry_mock = MagicMock()
+        telemetry_mock = Mock()
         # Test data
         pull_request = {
             "head": {"ref": "copilot/fix-42"},
@@ -306,10 +306,10 @@ class TestClosedHandler(unittest.TestCase):
     def test_extract_remediation_info_claude_branch(self):
         """Test _extract_remediation_info with Claude Code branch"""
         # Mock objects
-        mock_extract_remediation_id = MagicMock(return_value="REM-789")
-        github_ops_mock = MagicMock()
+        mock_extract_remediation_id = Mock(return_value="REM-789")
+        github_ops_mock = Mock()
         github_ops_mock.extract_issue_number_from_branch.return_value = 75
-        telemetry_mock = MagicMock()
+        telemetry_mock = Mock()
         # Test data
         pull_request = {
             "head": {"ref": "claude/issue-75-20250908-1723"},
@@ -331,10 +331,10 @@ class TestClosedHandler(unittest.TestCase):
     def test_extract_remediation_info_claude_branch_no_issue_number(self):
         """Test _extract_remediation_info with Claude Code branch without extractable issue number"""
         # Mock objects
-        mock_extract_remediation_id = MagicMock(return_value="REM-789")
-        github_ops_mock = MagicMock()
+        mock_extract_remediation_id = Mock(return_value="REM-789")
+        github_ops_mock = Mock()
         github_ops_mock.extract_issue_number_from_branch.return_value = None
-        telemetry_mock = MagicMock()
+        telemetry_mock = Mock()
         # Test data
         pull_request = {
             "head": {"ref": "claude/issue-75-20250908-1723"},
@@ -423,7 +423,7 @@ class TestCleanupSmartfixLabels(unittest.TestCase):
 
     def _build_mock_ops(self, smartfix_label_names, issue_number=None,
                         remove_pr_ok=True, remove_issue_ok=True):
-        ops = MagicMock()
+        ops = Mock()
         ops.filter_smartfix_labels.return_value = smartfix_label_names
         ops.extract_issue_number_from_branch.return_value = issue_number
         ops.remove_labels_from_pr.return_value = remove_pr_ok

--- a/test/test_contrast_message_handling.py
+++ b/test/test_contrast_message_handling.py
@@ -19,7 +19,7 @@
 #
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import Mock
 
 # Import just the function we need to test, avoiding full class initialization
 import sys
@@ -184,7 +184,7 @@ class TestContrastMessageHandling(unittest.TestCase):
     def test_message_object_handling(self):
         """Test handling of message objects (not just dicts)"""
         # Create mock message objects
-        user_message = MagicMock()
+        user_message = Mock()
         user_message.role = 'user'
         messages = [user_message]
 

--- a/test/test_contrast_message_handling.py
+++ b/test/test_contrast_message_handling.py
@@ -19,7 +19,7 @@
 #
 
 import unittest
-from types import SimpleNamespace
+from litellm.types.utils import Message
 
 # Import just the function we need to test, avoiding full class initialization
 import sys
@@ -183,8 +183,8 @@ class TestContrastMessageHandling(unittest.TestCase):
 
     def test_message_object_handling(self):
         """Test handling of message objects (not just dicts)"""
-        # Use a non-dict message object to verify the function handles arbitrary objects
-        user_message = SimpleNamespace(role='user')
+        # Use the real litellm Message type to verify the function handles non-dict objects
+        user_message = Message(role='user')
         messages = [user_message]
 
         result = self.model._ensure_system_message_for_contrast(messages)

--- a/test/test_contrast_message_handling.py
+++ b/test/test_contrast_message_handling.py
@@ -19,7 +19,7 @@
 #
 
 import unittest
-from unittest.mock import Mock
+from types import SimpleNamespace
 
 # Import just the function we need to test, avoiding full class initialization
 import sys
@@ -183,9 +183,8 @@ class TestContrastMessageHandling(unittest.TestCase):
 
     def test_message_object_handling(self):
         """Test handling of message objects (not just dicts)"""
-        # Create mock message objects
-        user_message = Mock()
-        user_message.role = 'user'
+        # Use a non-dict message object to verify the function handles arbitrary objects
+        user_message = SimpleNamespace(role='user')
         messages = [user_message]
 
         result = self.model._ensure_system_message_for_contrast(messages)

--- a/test/test_custom_instructions.py
+++ b/test/test_custom_instructions.py
@@ -22,7 +22,7 @@ import subprocess
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 from src.smartfix.domains.agents.custom_instructions import load_custom_instructions, HEADER, SOURCE_B_FRAMING
 
@@ -36,15 +36,17 @@ def _config(use_smartfix=True, use_repo=True, base_branch="main"):
 
 
 def _git_show_result(content=None, returncode=0, stderr=""):
-    """Return a mock subprocess.CompletedProcess for git show."""
-    result = Mock()
-    result.returncode = returncode
+    """Return a subprocess.CompletedProcess for git show."""
     if content is not None:
-        result.stdout = content if isinstance(content, bytes) else content.encode("utf-8")
+        stdout = content if isinstance(content, bytes) else content.encode("utf-8")
     else:
-        result.stdout = b""
-    result.stderr = stderr.encode("utf-8") if isinstance(stderr, str) else stderr
-    return result
+        stdout = b""
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr.encode("utf-8") if isinstance(stderr, str) else stderr,
+    )
 
 
 class TestLoadCustomInstructions(unittest.TestCase):
@@ -193,10 +195,9 @@ class TestLoadCustomInstructions(unittest.TestCase):
     def test_non_utf8_content_decoded_with_replacement(self, mock_run):
         """Non-UTF-8 bytes are decoded with replacement chars, not a crash."""
         bad_bytes = b"Good prefix \xff\xfe bad bytes then more text."
-        result_mock = Mock()
-        result_mock.returncode = 0
-        result_mock.stdout = bad_bytes
-        mock_run.return_value = result_mock
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=bad_bytes, stderr=b""
+        )
         # Should not raise; result should contain something
         result = load_custom_instructions(self.repo_path, self.config)
         self.assertIsNotNone(result)

--- a/test/test_custom_instructions.py
+++ b/test/test_custom_instructions.py
@@ -22,7 +22,7 @@ import subprocess
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 from src.smartfix.domains.agents.custom_instructions import load_custom_instructions, HEADER, SOURCE_B_FRAMING
 
@@ -37,7 +37,7 @@ def _config(use_smartfix=True, use_repo=True, base_branch="main"):
 
 def _git_show_result(content=None, returncode=0, stderr=""):
     """Return a mock subprocess.CompletedProcess for git show."""
-    result = MagicMock()
+    result = Mock()
     result.returncode = returncode
     if content is not None:
         result.stdout = content if isinstance(content, bytes) else content.encode("utf-8")
@@ -193,7 +193,7 @@ class TestLoadCustomInstructions(unittest.TestCase):
     def test_non_utf8_content_decoded_with_replacement(self, mock_run):
         """Non-UTF-8 bytes are decoded with replacement chars, not a crash."""
         bad_bytes = b"Good prefix \xff\xfe bad bytes then more text."
-        result_mock = MagicMock()
+        result_mock = Mock()
         result_mock.returncode = 0
         result_mock.stdout = bad_bytes
         mock_run.return_value = result_mock

--- a/test/test_directory_tree_utils.py
+++ b/test/test_directory_tree_utils.py
@@ -31,7 +31,7 @@ import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock  # Mock kept for RemediationContext in _make_context
 
 from src.smartfix.domains.agents.directory_tree_utils import (
     get_directory_tree,
@@ -45,25 +45,22 @@ class TestGetDirectoryTree(unittest.TestCase):
 
     def test_uses_tree_cli_when_available(self):
         """When tree CLI succeeds (returncode=0), returns its stdout."""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = ".\n├── src\n└── test\n\n2 directories"
+        tree_output = ".\n├── src\n└── test\n\n2 directories"
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=tree_output)
 
-        with patch('subprocess.run', return_value=mock_result) as mock_run:
+        with patch('subprocess.run', return_value=completed) as mock_run:
             result = get_directory_tree(Path('/some/repo'), max_depth=3)
 
-        self.assertEqual(result, mock_result.stdout)
+        self.assertEqual(result, tree_output)
         mock_run.assert_called_once()
         call_args = mock_run.call_args
         self.assertIn('tree', call_args[0][0])
 
     def test_tree_cli_excludes_dotfiles_and_build_dirs(self):
         """The tree -I pattern uses .* to exclude all dotfiles/dotdirs and common build directories."""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "tree output"
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="tree output")
 
-        with patch('subprocess.run', return_value=mock_result) as mock_run:
+        with patch('subprocess.run', return_value=completed) as mock_run:
             get_directory_tree(Path('/some/repo'), max_depth=3)
 
         cmd = mock_run.call_args[0][0]
@@ -74,11 +71,9 @@ class TestGetDirectoryTree(unittest.TestCase):
 
     def test_tree_cli_passes_gitignore_flag(self):
         """The tree CLI call includes --gitignore so .gitignore files are respected natively."""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "tree output"
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="tree output")
 
-        with patch('subprocess.run', return_value=mock_result) as mock_run:
+        with patch('subprocess.run', return_value=completed) as mock_run:
             get_directory_tree(Path('/some/repo'), max_depth=3)
 
         cmd = mock_run.call_args[0][0]
@@ -86,13 +81,11 @@ class TestGetDirectoryTree(unittest.TestCase):
 
     def test_tree_cli_nonzero_returncode_falls_back_to_python(self):
         """When tree CLI returns non-zero, falls back to generate_simple_tree."""
-        mock_result = Mock()
-        mock_result.returncode = 1
-        mock_result.stdout = ""
+        completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="")
 
         with TemporaryDirectory() as tmpdir:
             (Path(tmpdir) / "src").mkdir()
-            with patch('subprocess.run', return_value=mock_result):
+            with patch('subprocess.run', return_value=completed):
                 result = get_directory_tree(Path(tmpdir), max_depth=2)
 
         self.assertIn("src", result)
@@ -118,11 +111,9 @@ class TestGetDirectoryTree(unittest.TestCase):
     def test_truncates_when_output_exceeds_max_chars(self):
         """Output longer than max_chars is truncated with a suffix message."""
         long_output = "x" * 200
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = long_output
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=long_output)
 
-        with patch('subprocess.run', return_value=mock_result):
+        with patch('subprocess.run', return_value=completed):
             result = get_directory_tree(Path('/repo'), max_depth=3, max_chars=100)
 
         self.assertEqual(len(result), 100 + len("\n... [truncated, 100 chars omitted]"))
@@ -132,11 +123,9 @@ class TestGetDirectoryTree(unittest.TestCase):
     def test_no_truncation_when_output_within_max_chars(self):
         """Output shorter than max_chars is returned unchanged."""
         short_output = ".\n└── src\n"
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = short_output
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=short_output)
 
-        with patch('subprocess.run', return_value=mock_result):
+        with patch('subprocess.run', return_value=completed):
             result = get_directory_tree(Path('/repo'), max_depth=3, max_chars=8000)
 
         self.assertEqual(result, short_output)
@@ -299,13 +288,13 @@ class TestGenerateSimpleTree(unittest.TestCase):
             (root / "README.md").touch()
 
             # Mock git check-ignore to report secret.log as ignored
-            mock_result = Mock()
-            mock_result.returncode = 0
-            mock_result.stdout = "secret.log\n"
+            check_ignore_result = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="secret.log\n"
+            )
 
             with patch(
                 'src.smartfix.domains.agents.directory_tree_utils.subprocess.run',
-                return_value=mock_result,
+                return_value=check_ignore_result,
             ):
                 result = generate_simple_tree(root, max_depth=2, repo_root=root)
 
@@ -320,13 +309,13 @@ class TestGenerateSimpleTree(unittest.TestCase):
             (root / "src").mkdir()
             (root / "main.py").touch()
 
-            mock_result = Mock()
-            mock_result.returncode = 1  # nothing ignored
-            mock_result.stdout = ""
+            check_ignore_result = subprocess.CompletedProcess(
+                args=[], returncode=1, stdout=""  # nothing ignored
+            )
 
             with patch(
                 'src.smartfix.domains.agents.directory_tree_utils.subprocess.run',
-                return_value=mock_result,
+                return_value=check_ignore_result,
             ):
                 result = generate_simple_tree(root, max_depth=2, repo_root=root)
 

--- a/test/test_directory_tree_utils.py
+++ b/test/test_directory_tree_utils.py
@@ -31,8 +31,9 @@ import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import patch, Mock  # Mock kept for RemediationContext in _make_context
+from unittest.mock import patch
 
+from setup_test_env import make_sample_context
 from src.smartfix.domains.agents.directory_tree_utils import (
     get_directory_tree,
     generate_simple_tree,
@@ -375,15 +376,14 @@ class TestSmartfixAgentDirectoryTreeIntegration(unittest.TestCase):
     """
 
     def _make_context(self, repo_path=None):
-        """Build a minimal RemediationContext mock for testing."""
-        context = Mock()
-        context.repo_config.repo_path = repo_path or Path('/tmp/test-repo')
-        context.remediation_id = "rem-123"
-        context.session_id = "sess-456"
-        context.prompts.fix_user_prompt = "Fix this vulnerability."
-        context.prompts.fix_system_prompt = "You are a security expert."
-        context.build_config.has_build_command.return_value = False
-        return context
+        """Build a RemediationContext for testing."""
+        return make_sample_context(
+            remediation_id="rem-123",
+            session_id="sess-456",
+            fix_user_prompt="Fix this vulnerability.",
+            fix_system_prompt="You are a security expert.",
+            repo_path=repo_path or Path('/tmp/test-repo'),
+        )
 
     def test_fix_agent_appends_directory_tree_to_user_prompt(self):
         """

--- a/test/test_directory_tree_utils.py
+++ b/test/test_directory_tree_utils.py
@@ -31,7 +31,7 @@ import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 from src.smartfix.domains.agents.directory_tree_utils import (
     get_directory_tree,
@@ -45,7 +45,7 @@ class TestGetDirectoryTree(unittest.TestCase):
 
     def test_uses_tree_cli_when_available(self):
         """When tree CLI succeeds (returncode=0), returns its stdout."""
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = ".\n├── src\n└── test\n\n2 directories"
 
@@ -59,7 +59,7 @@ class TestGetDirectoryTree(unittest.TestCase):
 
     def test_tree_cli_excludes_dotfiles_and_build_dirs(self):
         """The tree -I pattern uses .* to exclude all dotfiles/dotdirs and common build directories."""
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = "tree output"
 
@@ -74,7 +74,7 @@ class TestGetDirectoryTree(unittest.TestCase):
 
     def test_tree_cli_passes_gitignore_flag(self):
         """The tree CLI call includes --gitignore so .gitignore files are respected natively."""
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = "tree output"
 
@@ -86,7 +86,7 @@ class TestGetDirectoryTree(unittest.TestCase):
 
     def test_tree_cli_nonzero_returncode_falls_back_to_python(self):
         """When tree CLI returns non-zero, falls back to generate_simple_tree."""
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 1
         mock_result.stdout = ""
 
@@ -118,7 +118,7 @@ class TestGetDirectoryTree(unittest.TestCase):
     def test_truncates_when_output_exceeds_max_chars(self):
         """Output longer than max_chars is truncated with a suffix message."""
         long_output = "x" * 200
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = long_output
 
@@ -132,7 +132,7 @@ class TestGetDirectoryTree(unittest.TestCase):
     def test_no_truncation_when_output_within_max_chars(self):
         """Output shorter than max_chars is returned unchanged."""
         short_output = ".\n└── src\n"
-        mock_result = MagicMock()
+        mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = short_output
 
@@ -299,7 +299,7 @@ class TestGenerateSimpleTree(unittest.TestCase):
             (root / "README.md").touch()
 
             # Mock git check-ignore to report secret.log as ignored
-            mock_result = MagicMock()
+            mock_result = Mock()
             mock_result.returncode = 0
             mock_result.stdout = "secret.log\n"
 
@@ -320,7 +320,7 @@ class TestGenerateSimpleTree(unittest.TestCase):
             (root / "src").mkdir()
             (root / "main.py").touch()
 
-            mock_result = MagicMock()
+            mock_result = Mock()
             mock_result.returncode = 1  # nothing ignored
             mock_result.stdout = ""
 
@@ -387,7 +387,7 @@ class TestSmartfixAgentDirectoryTreeIntegration(unittest.TestCase):
 
     def _make_context(self, repo_path=None):
         """Build a minimal RemediationContext mock for testing."""
-        context = MagicMock()
+        context = Mock()
         context.repo_config.repo_path = repo_path or Path('/tmp/test-repo')
         context.remediation_id = "rem-123"
         context.session_id = "sess-456"

--- a/test/test_event_loop_utils.py
+++ b/test/test_event_loop_utils.py
@@ -29,7 +29,7 @@ import sys
 import unittest
 import os
 from pathlib import Path
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, Mock, AsyncMock
 
 # Add project root to path for imports
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -114,7 +114,7 @@ class TestEventLoopUtils(unittest.TestCase):
             return "windows_success"
 
         # Mock WindowsProactorEventLoopPolicy - patch at asyncio level
-        mock_policy_class = MagicMock()
+        mock_policy_class = Mock()
         with patch('asyncio.WindowsProactorEventLoopPolicy', mock_policy_class, create=True):
             result = event_loop_utils._run_agent_in_event_loop(simple_async_func)
             self.assertEqual(result, "windows_success")
@@ -169,7 +169,7 @@ class TestEventLoopUtils(unittest.TestCase):
         """Test SubAgentExecutor.run() with session creation error"""
         mock_error_exit.side_effect = SystemExit(1)
 
-        mock_service_instance = MagicMock()
+        mock_service_instance = Mock()
         mock_service_instance.create_session = AsyncMock(side_effect=Exception("Session error"))
         mock_session_service.return_value = mock_service_instance
 
@@ -196,8 +196,8 @@ class TestEventLoopUtils(unittest.TestCase):
         """Test SubAgentExecutor.run() when agent creation fails"""
         mock_error_exit.side_effect = SystemExit(1)
 
-        mock_service_instance = MagicMock()
-        mock_service_instance.create_session = AsyncMock(return_value=MagicMock())
+        mock_service_instance = Mock()
+        mock_service_instance.create_session = AsyncMock(return_value=Mock())
         mock_session_service.return_value = mock_service_instance
 
         executor = SubAgentExecutor()
@@ -222,13 +222,13 @@ class TestEventLoopUtils(unittest.TestCase):
         self, mock_runner_class, mock_artifact_service, mock_session_service
     ):
         """Test SubAgentExecutor.run() with successful execution"""
-        mock_session = MagicMock()
-        mock_service_instance = MagicMock()
+        mock_session = Mock()
+        mock_service_instance = Mock()
         mock_service_instance.create_session = AsyncMock(return_value=mock_session)
         mock_session_service.return_value = mock_service_instance
 
         executor = SubAgentExecutor()
-        mock_agent = MagicMock()
+        mock_agent = Mock()
         with patch.object(executor, 'create_agent', AsyncMock(return_value=mock_agent)) as mock_create, \
              patch.object(executor, 'execute_agent', AsyncMock(return_value="Fix applied successfully")) as mock_execute:
             result = asyncio.run(executor.run(
@@ -251,13 +251,13 @@ class TestEventLoopUtils(unittest.TestCase):
         self, mock_runner_class, mock_artifact_service, mock_session_service
     ):
         """Test SubAgentExecutor.run() passes session_id through to create_agent"""
-        mock_session = MagicMock()
-        mock_service_instance = MagicMock()
+        mock_session = Mock()
+        mock_service_instance = Mock()
         mock_service_instance.create_session = AsyncMock(return_value=mock_session)
         mock_session_service.return_value = mock_service_instance
 
         executor = SubAgentExecutor()
-        mock_agent = MagicMock()
+        mock_agent = Mock()
         with patch.object(executor, 'create_agent', AsyncMock(return_value=mock_agent)) as mock_create, \
              patch.object(executor, 'execute_agent', AsyncMock(return_value="Windows fix success")):
             result = asyncio.run(executor.run(

--- a/test/test_external_coding_agent.py
+++ b/test/test_external_coding_agent.py
@@ -20,7 +20,7 @@
 
 import re
 import unittest
-from unittest.mock import patch, MagicMock, ANY
+from unittest.mock import patch, Mock, ANY
 
 # Test setup imports (path is set up by conftest.py)
 from src.config import get_config, reset_config
@@ -170,7 +170,7 @@ class TestExternalCodingAgent(unittest.TestCase):
         agent = ExternalCodingAgent(self.config)
 
         # Mock _poll_for_pr instead of patching it
-        mock_poll_for_pr = MagicMock(return_value=None)
+        mock_poll_for_pr = Mock(return_value=None)
         original_poll_for_pr = agent._process_external_coding_agent_run
         agent._process_external_coding_agent_run = mock_poll_for_pr
 
@@ -235,7 +235,7 @@ class TestExternalCodingAgent(unittest.TestCase):
         agent = ExternalCodingAgent(self.config)
 
         # Mock _poll_for_pr instead of patching it
-        mock_poll_for_pr = MagicMock(return_value=pr_info)
+        mock_poll_for_pr = Mock(return_value=pr_info)
         original_poll_for_pr = agent._process_external_coding_agent_run
         agent._process_external_coding_agent_run = mock_poll_for_pr
 

--- a/test/test_get_pr_actual_state.py
+++ b/test/test_get_pr_actual_state.py
@@ -2,7 +2,7 @@
 
 import unittest
 import json
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 from src.github.github_operations import GitHubOperations
 
@@ -13,7 +13,7 @@ class TestGetPrActualState(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         with patch('src.github.github_operations.get_config') as mock_config:
-            mock_config.return_value = MagicMock(
+            mock_config.return_value = Mock(
                 GITHUB_TOKEN="test-token",
                 GITHUB_REPOSITORY="test-owner/test-repo",
                 testing=True,

--- a/test/test_git_operations.py
+++ b/test/test_git_operations.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 from src.smartfix.domains.scm.git_operations import GitOperations
 
 
@@ -13,7 +13,7 @@ class TestGitOperations(unittest.TestCase):
         # Mock the config to avoid requiring environment variables in tests
         patcher = patch('src.utils.get_config')
         self.mock_config = patcher.start()
-        self.mock_config.return_value = MagicMock(
+        self.mock_config.return_value = Mock(
             BASE_BRANCH="main",
             testing=True
         )
@@ -83,7 +83,7 @@ class TestGitOperations(unittest.TestCase):
     def test_push_branch(self, mock_run_command):
         """Test pushing branch."""
         with patch('src.smartfix.domains.scm.git_operations.get_config') as mock_config:
-            mock_config.return_value = MagicMock(
+            mock_config.return_value = Mock(
                 GITHUB_TOKEN="mock-token",
                 GITHUB_SERVER_URL="https://mockhub.com",
                 GITHUB_REPOSITORY="mock/repo",

--- a/test/test_github_operations.py
+++ b/test/test_github_operations.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 import json
 from src.github.github_operations import GitHubOperations
 from src.smartfix.shared.failure_categories import FailureCategory
@@ -14,7 +14,7 @@ class TestGitHubOperations(unittest.TestCase):
         """Set up test fixtures."""
         # Mock the config to avoid import issues
         with patch('src.github.github_operations.get_config') as mock_config:
-            mock_config.return_value = MagicMock(
+            mock_config.return_value = Mock(
                 GITHUB_TOKEN="test-token",
                 GITHUB_REPOSITORY="test-owner/test-repo",
                 testing=True,
@@ -94,7 +94,7 @@ class TestGitHubOperations(unittest.TestCase):
         # First call returns empty list (no existing labels)
         mock_run_command.return_value = json.dumps([])
         # subprocess.run for label creation succeeds
-        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_subprocess_run.return_value = Mock(returncode=0)
 
         result = self.github_ops.ensure_label("new-label", "New description", "ff0000")
         self.assertTrue(result)
@@ -408,7 +408,7 @@ class TestGitHubOperations(unittest.TestCase):
             "Created",       # Create label2
             "Success"        # Final add labels command
         ]
-        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_subprocess_run.return_value = Mock(returncode=0)
 
         result = self.github_ops.add_labels_to_pr(123, ["label1", "label2"])
         self.assertTrue(result)
@@ -423,7 +423,7 @@ class TestGitHubOperations(unittest.TestCase):
             "Created",       # Create label1
             Exception("Failed to add labels")  # Final add labels command fails
         ]
-        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_subprocess_run.return_value = Mock(returncode=0)
 
         result = self.github_ops.add_labels_to_pr(123, ["label1"])
         self.assertFalse(result)
@@ -810,8 +810,8 @@ class TestGitHubOperations(unittest.TestCase):
         # Mock temp file
         mock_temp = MagicMock()
         mock_temp.name = "/tmp/test_pr_body.md"
-        mock_temp.__enter__ = MagicMock(return_value=mock_temp)
-        mock_temp.__exit__ = MagicMock(return_value=False)
+        mock_temp.__enter__ = Mock(return_value=mock_temp)
+        mock_temp.__exit__ = Mock(return_value=False)
         mock_tempfile.return_value = mock_temp
 
         # Mock file operations
@@ -842,13 +842,13 @@ class TestGitHubOperations(unittest.TestCase):
         # Mock temp file
         mock_temp = MagicMock()
         mock_temp.name = "/tmp/test_pr_body.md"
-        mock_temp.__enter__ = MagicMock(return_value=mock_temp)
-        mock_temp.__exit__ = MagicMock(return_value=False)
+        mock_temp.__enter__ = Mock(return_value=mock_temp)
+        mock_temp.__exit__ = Mock(return_value=False)
         mock_tempfile.return_value = mock_temp
 
         mock_exists.return_value = True
         mock_getsize.return_value = 1000
-        mock_subprocess_run.return_value = MagicMock(returncode=0, stdout="gh version 2.0.0")
+        mock_subprocess_run.return_value = Mock(returncode=0, stdout="gh version 2.0.0")
         mock_run_command.return_value = "https://github.com/test/repo/pull/456"
 
         # Create body larger than 32000 chars
@@ -885,7 +885,7 @@ class TestGitHubOperations(unittest.TestCase):
 
         # Set up config for CLAUDE_CODE mode
         with patch('src.github.github_operations.get_config') as mock_config:
-            mock_config.return_value = MagicMock(
+            mock_config.return_value = Mock(
                 GITHUB_TOKEN="test-token",
                 GITHUB_REPOSITORY="test-owner/test-repo",
                 testing=True,
@@ -904,7 +904,7 @@ class TestGitHubOperations(unittest.TestCase):
             "Created",       # ensure_label for remediation (create)
             "https://github.com/test/repo/issues/789"  # create issue
         ]
-        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_subprocess_run.return_value = Mock(returncode=0)
 
         result = github_ops.create_issue(
             "Test Issue",
@@ -987,7 +987,7 @@ class TestGitHubOperations(unittest.TestCase):
 
         # Set up config for CLAUDE_CODE mode
         with patch('src.github.github_operations.get_config') as mock_config:
-            mock_config.return_value = MagicMock(
+            mock_config.return_value = Mock(
                 GITHUB_TOKEN="test-token",
                 GITHUB_REPOSITORY="test-owner/test-repo",
                 testing=True,
@@ -1013,7 +1013,7 @@ class TestGitHubOperations(unittest.TestCase):
             "Success",  # add new label
             "Comment added"  # add comment
         ]
-        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_subprocess_run.return_value = Mock(returncode=0)
 
         # Mock find_open_pr_for_issue to return None (no open PR)
         with patch.object(github_ops, 'find_open_pr_for_issue') as mock_find_pr:
@@ -1034,8 +1034,8 @@ class TestGitHubOperations(unittest.TestCase):
         # Mock temp file
         mock_temp = MagicMock()
         mock_temp.name = "/tmp/test_pr_body.md"
-        mock_temp.__enter__ = MagicMock(return_value=mock_temp)
-        mock_temp.__exit__ = MagicMock(return_value=False)
+        mock_temp.__enter__ = Mock(return_value=mock_temp)
+        mock_temp.__exit__ = Mock(return_value=False)
         mock_tempfile.return_value = mock_temp
 
         # Mock file operations
@@ -1043,7 +1043,7 @@ class TestGitHubOperations(unittest.TestCase):
         mock_getsize.return_value = 1000
 
         # Mock version check, PR creation
-        mock_subprocess_run.return_value = MagicMock(returncode=0, stdout="gh version 2.0.0")
+        mock_subprocess_run.return_value = Mock(returncode=0, stdout="gh version 2.0.0")
         mock_run_command.return_value = "https://github.com/test/repo/pull/123"
 
         # Mock git_ops.get_branch_name
@@ -1070,13 +1070,13 @@ class TestGitHubOperations(unittest.TestCase):
         # Mock temp file
         mock_temp = MagicMock()
         mock_temp.name = "/tmp/test_pr_body.md"
-        mock_temp.__enter__ = MagicMock(return_value=mock_temp)
-        mock_temp.__exit__ = MagicMock(return_value=False)
+        mock_temp.__enter__ = Mock(return_value=mock_temp)
+        mock_temp.__exit__ = Mock(return_value=False)
         mock_tempfile.return_value = mock_temp
 
         mock_exists.return_value = True
         mock_getsize.return_value = 1000
-        mock_subprocess_run.return_value = MagicMock(returncode=0, stdout="gh version 2.0.0")
+        mock_subprocess_run.return_value = Mock(returncode=0, stdout="gh version 2.0.0")
         mock_run_command.return_value = "https://github.com/test/repo/pull/456"
 
         # Mock git_ops.get_branch_name
@@ -1113,13 +1113,13 @@ class TestGitHubOperations(unittest.TestCase):
         # Mock temp file
         mock_temp = MagicMock()
         mock_temp.name = "/tmp/test_pr_body.md"
-        mock_temp.__enter__ = MagicMock(return_value=mock_temp)
-        mock_temp.__exit__ = MagicMock(return_value=False)
+        mock_temp.__enter__ = Mock(return_value=mock_temp)
+        mock_temp.__exit__ = Mock(return_value=False)
         mock_tempfile.return_value = mock_temp
 
         mock_exists.return_value = True
         mock_getsize.return_value = 1000
-        mock_subprocess_run.return_value = MagicMock(
+        mock_subprocess_run.return_value = Mock(
             returncode=0, stdout="gh version 2.0.0"
         )
 
@@ -1177,13 +1177,13 @@ class TestGitHubOperations(unittest.TestCase):
         # Mock temp file
         mock_temp = MagicMock()
         mock_temp.name = "/tmp/test_pr_body.md"
-        mock_temp.__enter__ = MagicMock(return_value=mock_temp)
-        mock_temp.__exit__ = MagicMock(return_value=False)
+        mock_temp.__enter__ = Mock(return_value=mock_temp)
+        mock_temp.__exit__ = Mock(return_value=False)
         mock_tempfile.return_value = mock_temp
 
         mock_exists.return_value = True
         mock_getsize.return_value = 1000
-        mock_subprocess_run.return_value = MagicMock(
+        mock_subprocess_run.return_value = Mock(
             returncode=0, stdout="gh version 2.0.0"
         )
 
@@ -1258,13 +1258,13 @@ class TestGitHubOperations(unittest.TestCase):
         # Mock temp file
         mock_temp = MagicMock()
         mock_temp.name = "/tmp/test_pr_body.md"
-        mock_temp.__enter__ = MagicMock(return_value=mock_temp)
-        mock_temp.__exit__ = MagicMock(return_value=False)
+        mock_temp.__enter__ = Mock(return_value=mock_temp)
+        mock_temp.__exit__ = Mock(return_value=False)
         mock_tempfile.return_value = mock_temp
 
         mock_exists.return_value = True
         mock_getsize.return_value = 1000
-        mock_subprocess_run.return_value = MagicMock(
+        mock_subprocess_run.return_value = Mock(
             returncode=0, stdout="gh version 2.0.0"
         )
 
@@ -1554,7 +1554,7 @@ class TestGetPrChangedFiles(unittest.TestCase):
 
     def setUp(self):
         with patch('src.github.github_operations.get_config') as mock_config:
-            mock_config.return_value = MagicMock(
+            mock_config.return_value = Mock(
                 GITHUB_TOKEN="test-token",
                 GITHUB_REPOSITORY="test-owner/test-repo",
                 testing=True,
@@ -1617,7 +1617,7 @@ class TestAddReviewersToPr(unittest.TestCase):
 
     def setUp(self):
         with patch('src.github.github_operations.get_config') as mock_config:
-            mock_config.return_value = MagicMock(
+            mock_config.return_value = Mock(
                 GITHUB_TOKEN="test-token",
                 GITHUB_REPOSITORY="test-owner/test-repo",
                 testing=True,

--- a/test/test_github_operations.py
+++ b/test/test_github_operations.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import subprocess
 import unittest
 from unittest.mock import patch, Mock, MagicMock
 import json
@@ -94,7 +95,7 @@ class TestGitHubOperations(unittest.TestCase):
         # First call returns empty list (no existing labels)
         mock_run_command.return_value = json.dumps([])
         # subprocess.run for label creation succeeds
-        mock_subprocess_run.return_value = Mock(returncode=0)
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
 
         result = self.github_ops.ensure_label("new-label", "New description", "ff0000")
         self.assertTrue(result)
@@ -408,7 +409,7 @@ class TestGitHubOperations(unittest.TestCase):
             "Created",       # Create label2
             "Success"        # Final add labels command
         ]
-        mock_subprocess_run.return_value = Mock(returncode=0)
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
 
         result = self.github_ops.add_labels_to_pr(123, ["label1", "label2"])
         self.assertTrue(result)
@@ -423,7 +424,7 @@ class TestGitHubOperations(unittest.TestCase):
             "Created",       # Create label1
             Exception("Failed to add labels")  # Final add labels command fails
         ]
-        mock_subprocess_run.return_value = Mock(returncode=0)
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
 
         result = self.github_ops.add_labels_to_pr(123, ["label1"])
         self.assertFalse(result)
@@ -848,7 +849,7 @@ class TestGitHubOperations(unittest.TestCase):
 
         mock_exists.return_value = True
         mock_getsize.return_value = 1000
-        mock_subprocess_run.return_value = Mock(returncode=0, stdout="gh version 2.0.0")
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="gh version 2.0.0")
         mock_run_command.return_value = "https://github.com/test/repo/pull/456"
 
         # Create body larger than 32000 chars
@@ -904,7 +905,7 @@ class TestGitHubOperations(unittest.TestCase):
             "Created",       # ensure_label for remediation (create)
             "https://github.com/test/repo/issues/789"  # create issue
         ]
-        mock_subprocess_run.return_value = Mock(returncode=0)
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
 
         result = github_ops.create_issue(
             "Test Issue",
@@ -1013,7 +1014,7 @@ class TestGitHubOperations(unittest.TestCase):
             "Success",  # add new label
             "Comment added"  # add comment
         ]
-        mock_subprocess_run.return_value = Mock(returncode=0)
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
 
         # Mock find_open_pr_for_issue to return None (no open PR)
         with patch.object(github_ops, 'find_open_pr_for_issue') as mock_find_pr:
@@ -1043,7 +1044,7 @@ class TestGitHubOperations(unittest.TestCase):
         mock_getsize.return_value = 1000
 
         # Mock version check, PR creation
-        mock_subprocess_run.return_value = Mock(returncode=0, stdout="gh version 2.0.0")
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="gh version 2.0.0")
         mock_run_command.return_value = "https://github.com/test/repo/pull/123"
 
         # Mock git_ops.get_branch_name
@@ -1076,7 +1077,7 @@ class TestGitHubOperations(unittest.TestCase):
 
         mock_exists.return_value = True
         mock_getsize.return_value = 1000
-        mock_subprocess_run.return_value = Mock(returncode=0, stdout="gh version 2.0.0")
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="gh version 2.0.0")
         mock_run_command.return_value = "https://github.com/test/repo/pull/456"
 
         # Mock git_ops.get_branch_name

--- a/test/test_github_operations.py
+++ b/test/test_github_operations.py
@@ -1120,8 +1120,8 @@ class TestGitHubOperations(unittest.TestCase):
 
         mock_exists.return_value = True
         mock_getsize.return_value = 1000
-        mock_subprocess_run.return_value = Mock(
-            returncode=0, stdout="gh version 2.0.0"
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="gh version 2.0.0"
         )
 
         # Simulate the exact error GitHub returns when setting is disabled
@@ -1184,8 +1184,8 @@ class TestGitHubOperations(unittest.TestCase):
 
         mock_exists.return_value = True
         mock_getsize.return_value = 1000
-        mock_subprocess_run.return_value = Mock(
-            returncode=0, stdout="gh version 2.0.0"
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="gh version 2.0.0"
         )
 
         # Simulate a different command error (not permission-related)
@@ -1265,8 +1265,8 @@ class TestGitHubOperations(unittest.TestCase):
 
         mock_exists.return_value = True
         mock_getsize.return_value = 1000
-        mock_subprocess_run.return_value = Mock(
-            returncode=0, stdout="gh version 2.0.0"
+        mock_subprocess_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="gh version 2.0.0"
         )
 
         # Simulate a command error with no stderr

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -94,6 +94,10 @@ class TestMain(unittest.TestCase):
         self.notify_patcher = patch('src.contrast_api.notify_remediation_failed_org', return_value=False)
         self.mock_notify = self.notify_patcher.start()
 
+        # Mock get_credit_tracking_org to prevent real HTTP calls during main() flow
+        self.credit_patcher = patch('src.contrast_api.get_credit_tracking_org', return_value=None)
+        self.mock_credit = self.credit_patcher.start()
+
     def tearDown(self):
         """Clean up after each test."""
         # Stop all patches
@@ -105,6 +109,7 @@ class TestMain(unittest.TestCase):
         self.exit_patcher.stop()
         self.pr_count_patcher.stop()
         self.notify_patcher.stop()
+        self.credit_patcher.stop()
         reset_config()
 
         # Clean up temp directory

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 import unittest
 import os
@@ -52,12 +53,9 @@ class TestMain(unittest.TestCase):
         # Mock subprocess calls
         self.subproc_patcher = patch('subprocess.run')
         self.mock_subprocess = self.subproc_patcher.start()
-        mock_process = Mock()
-        mock_process.returncode = 0
-        mock_process.stdout = "Mock output"
-        mock_process.stderr = ""
-        mock_process.communicate.return_value = (b"Mock stdout", b"Mock stderr")
-        self.mock_subprocess.return_value = mock_process
+        self.mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Mock output", stderr=""
+        )
 
         # Mock git configuration
         self.git_patcher = patch('src.smartfix.domains.scm.git_operations.GitOperations.configure_git_user')

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -55,6 +55,7 @@ class TestMain(unittest.TestCase):
         mock_process = Mock()
         mock_process.returncode = 0
         mock_process.stdout = "Mock output"
+        mock_process.stderr = ""
         mock_process.communicate.return_value = (b"Mock stdout", b"Mock stderr")
         self.mock_subprocess.return_value = mock_process
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,3 +1,4 @@
+import requests
 import subprocess
 import sys
 import unittest
@@ -73,7 +74,7 @@ class TestMain(unittest.TestCase):
         # Mock requests for version checking
         self.requests_patcher = patch('src.version_check.requests.get')
         self.mock_requests_get = self.requests_patcher.start()
-        mock_response = Mock()
+        mock_response = Mock(spec=requests.Response)
         mock_response.json.return_value = [{'name': 'v1.0.0'}]
         mock_response.raise_for_status.return_value = None
         self.mock_requests_get.return_value = mock_response

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -4,7 +4,7 @@ import os
 import io
 import contextlib
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 
 # Ensure test directory is on path (conftest.py only runs under pytest)
 sys.path.insert(0, str(Path(__file__).parent))
@@ -52,7 +52,7 @@ class TestMain(unittest.TestCase):
         # Mock subprocess calls
         self.subproc_patcher = patch('subprocess.run')
         self.mock_subprocess = self.subproc_patcher.start()
-        mock_process = MagicMock()
+        mock_process = Mock()
         mock_process.returncode = 0
         mock_process.stdout = "Mock output"
         mock_process.communicate.return_value = (b"Mock stdout", b"Mock stderr")
@@ -74,7 +74,7 @@ class TestMain(unittest.TestCase):
         # Mock requests for version checking
         self.requests_patcher = patch('src.version_check.requests.get')
         self.mock_requests_get = self.requests_patcher.start()
-        mock_response = MagicMock()
+        mock_response = Mock()
         mock_response.json.return_value = [{'name': 'v1.0.0'}]
         mock_response.raise_for_status.return_value = None
         self.mock_requests_get.return_value = mock_response
@@ -241,7 +241,7 @@ class TestMain(unittest.TestCase):
              patch('src.main.generate_qa_section', return_value=""), \
              patch('src.contrast_api.notify_remediation_failed_org') as mock_notify_failed:
 
-            mock_agent = MagicMock()
+            mock_agent = Mock()
             mock_agent_class.return_value = mock_agent
 
             with patch.dict('os.environ', test_env, clear=True):
@@ -286,7 +286,7 @@ class TestMain(unittest.TestCase):
         span_registry = {}
 
         def mock_start_span(name):
-            mock_span = MagicMock()
+            mock_span = Mock()
             mock_span_cm = MagicMock()
             mock_span_cm.__enter__ = MagicMock(return_value=mock_span)
             mock_span_cm.__exit__ = MagicMock(return_value=False)
@@ -305,7 +305,7 @@ class TestMain(unittest.TestCase):
              patch('src.smartfix.domains.telemetry.otel_provider.initialize_otel'), \
              patch('src.smartfix.domains.telemetry.otel_provider.shutdown_otel'):
 
-            mock_agent_class.return_value = MagicMock()
+            mock_agent_class.return_value = Mock()
 
             with patch.dict('os.environ', test_env, clear=True):
                 reset_config()
@@ -350,7 +350,7 @@ class TestMain(unittest.TestCase):
         span_registry = {}
 
         def mock_start_span(name):
-            mock_span = MagicMock()
+            mock_span = Mock()
             mock_span_cm = MagicMock()
             mock_span_cm.__enter__ = MagicMock(return_value=mock_span)
             mock_span_cm.__exit__ = MagicMock(return_value=False)
@@ -372,7 +372,7 @@ class TestMain(unittest.TestCase):
              patch('src.smartfix.domains.telemetry.otel_provider.initialize_otel'), \
              patch('src.smartfix.domains.telemetry.otel_provider.shutdown_otel'):
 
-            mock_agent_class.return_value = MagicMock()
+            mock_agent_class.return_value = Mock()
 
             with patch.dict('os.environ', test_env, clear=True):
                 reset_config()
@@ -388,7 +388,7 @@ class TestMain(unittest.TestCase):
 
     def test_main_initializes_and_shuts_down_otel(self):
         """main() calls initialize_otel, starts smartfix-run span, and calls shutdown_otel."""
-        mock_span = MagicMock()
+        mock_span = Mock()
         mock_span_cm = MagicMock()
         mock_span_cm.__enter__ = MagicMock(return_value=mock_span)
         mock_span_cm.__exit__ = MagicMock(return_value=False)

--- a/test/test_merge_handler.py
+++ b/test/test_merge_handler.py
@@ -20,7 +20,7 @@
 
 import sys
 import unittest
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open, Mock
 import os
 import json
 
@@ -147,10 +147,10 @@ class TestMergeHandler(unittest.TestCase):
     def test_extract_remediation_info_copilot_branch(self):
         """Test _extract_remediation_info with Copilot branch"""
         # Mock objects
-        mock_extract_remediation_id = MagicMock(return_value="REM-456")
-        github_ops_mock = MagicMock()
+        mock_extract_remediation_id = Mock(return_value="REM-456")
+        github_ops_mock = Mock()
         github_ops_mock.extract_issue_number_from_branch.return_value = 42
-        telemetry_mock = MagicMock()
+        telemetry_mock = Mock()
         # Test data
         pull_request = {
             "head": {"ref": "copilot/fix-42"},
@@ -172,10 +172,10 @@ class TestMergeHandler(unittest.TestCase):
     def test_extract_remediation_info_claude_branch(self):
         """Test _extract_remediation_info with Claude Code branch"""
         # Mock objects
-        mock_extract_remediation_id = MagicMock(return_value="REM-789")
-        github_ops_mock = MagicMock()
+        mock_extract_remediation_id = Mock(return_value="REM-789")
+        github_ops_mock = Mock()
         github_ops_mock.extract_issue_number_from_branch.return_value = 75
-        telemetry_mock = MagicMock()
+        telemetry_mock = Mock()
         # Test data
         pull_request = {
             "head": {"ref": "claude/issue-75-20250908-1723"},
@@ -197,10 +197,10 @@ class TestMergeHandler(unittest.TestCase):
     def test_extract_remediation_info_claude_branch_no_issue_number(self):
         """Test _extract_remediation_info with Claude Code branch without extractable issue number"""
         # Mock objects
-        mock_extract_remediation_id = MagicMock(return_value="REM-789")
-        github_ops_mock = MagicMock()
+        mock_extract_remediation_id = Mock(return_value="REM-789")
+        github_ops_mock = Mock()
         github_ops_mock.extract_issue_number_from_branch.return_value = None
-        telemetry_mock = MagicMock()
+        telemetry_mock = Mock()
         # Test data
         pull_request = {
             "head": {"ref": "claude/issue-75-20250908-1723"},
@@ -245,8 +245,8 @@ class TestMergeHandler(unittest.TestCase):
 
     def test_extract_remediation_info_smartfix_branch(self):
         """Test _extract_remediation_info with SmartFix branch"""
-        mock_extract_from_branch = MagicMock(return_value="REM-555")
-        telemetry_mock = MagicMock()
+        mock_extract_from_branch = Mock(return_value="REM-555")
+        telemetry_mock = Mock()
         pull_request = {
             "head": {"ref": "smartfix/REM-555-fix-sql-injection"},
             "labels": []
@@ -259,7 +259,7 @@ class TestMergeHandler(unittest.TestCase):
 
     def test_extract_remediation_info_no_remediation_id_external_agent(self):
         """Test _extract_remediation_info when remediation ID cannot be extracted from external agent branch"""
-        mock_extract_from_labels = MagicMock(return_value=None)
+        mock_extract_from_labels = Mock(return_value=None)
         pull_request = {
             "head": {"ref": "copilot/fix-123"},
             "labels": []
@@ -278,7 +278,7 @@ class TestMergeHandler(unittest.TestCase):
             "head": {"ref": "smartfix/remediation-REM-777"},
             "labels": [{"name": "smartfix-id:REM-777"}]
         }
-        telemetry_mock = MagicMock()
+        telemetry_mock = Mock()
         with patch('src.smartfix.domains.telemetry.telemetry_handler.update_telemetry', telemetry_mock):
             result = merge_handler._extract_remediation_info(pull_request)
         self.assertEqual(result, ("REM-777", [{"name": "smartfix-id:REM-777"}]))
@@ -300,7 +300,7 @@ class TestMergeHandler(unittest.TestCase):
 
     def test_extract_remediation_info_no_remediation_id_smartfix(self):
         """Test _extract_remediation_info when remediation ID cannot be extracted from SmartFix branch"""
-        mock_extract_from_branch = MagicMock(return_value=None)
+        mock_extract_from_branch = Mock(return_value=None)
         pull_request = {
             "head": {"ref": "smartfix/invalid-branch-name"},
             "labels": []
@@ -337,7 +337,7 @@ class TestMergeHandler(unittest.TestCase):
     @patch('src.merge_handler.contrast_api.notify_remediation_pr_merged_org')
     def test_notify_remediation_service_success(self, mock_notify, mock_get_config):
         """Test _notify_remediation_service when notification succeeds"""
-        mock_config = MagicMock()
+        mock_config = Mock()
         mock_config.CONTRAST_HOST = "test.contrastsecurity.com"
         mock_config.CONTRAST_ORG_ID = "test-org"
         mock_config.CONTRAST_AUTHORIZATION_KEY = "test-auth"
@@ -359,7 +359,7 @@ class TestMergeHandler(unittest.TestCase):
     @patch('src.merge_handler.contrast_api.notify_remediation_pr_merged_org')
     def test_notify_remediation_service_failure(self, mock_notify, mock_get_config):
         """Test _notify_remediation_service when notification fails"""
-        mock_config = MagicMock()
+        mock_config = Mock()
         mock_config.CONTRAST_HOST = "test.contrastsecurity.com"
         mock_config.CONTRAST_ORG_ID = "test-org"
         mock_config.CONTRAST_AUTHORIZATION_KEY = "test-auth"
@@ -392,7 +392,7 @@ class TestCleanupSmartfixLabels(unittest.TestCase):
 
     def _build_mock_ops(self, smartfix_label_names, issue_number=None,
                         remove_pr_ok=True, remove_issue_ok=True):
-        ops = MagicMock()
+        ops = Mock()
         ops.filter_smartfix_labels.return_value = smartfix_label_names
         ops.extract_issue_number_from_branch.return_value = issue_number
         ops.remove_labels_from_pr.return_value = remove_pr_ok

--- a/test/test_merge_handler.py
+++ b/test/test_merge_handler.py
@@ -48,7 +48,8 @@ TEST_ENV_VARS = {
 os.environ.update(TEST_ENV_VARS)
 
 # Now import project modules (after path modification)
-from src.config import reset_config, get_config  # noqa: E402
+from src.config import Config, reset_config, get_config  # noqa: E402
+from src.github.github_operations import GitHubOperations  # noqa: E402
 from src import merge_handler  # noqa: E402
 
 
@@ -148,7 +149,7 @@ class TestMergeHandler(unittest.TestCase):
         """Test _extract_remediation_info with Copilot branch"""
         # Mock objects
         mock_extract_remediation_id = Mock(return_value="REM-456")
-        github_ops_mock = Mock()
+        github_ops_mock = Mock(spec=GitHubOperations)
         github_ops_mock.extract_issue_number_from_branch.return_value = 42
         telemetry_mock = Mock()
         # Test data
@@ -173,7 +174,7 @@ class TestMergeHandler(unittest.TestCase):
         """Test _extract_remediation_info with Claude Code branch"""
         # Mock objects
         mock_extract_remediation_id = Mock(return_value="REM-789")
-        github_ops_mock = Mock()
+        github_ops_mock = Mock(spec=GitHubOperations)
         github_ops_mock.extract_issue_number_from_branch.return_value = 75
         telemetry_mock = Mock()
         # Test data
@@ -198,7 +199,7 @@ class TestMergeHandler(unittest.TestCase):
         """Test _extract_remediation_info with Claude Code branch without extractable issue number"""
         # Mock objects
         mock_extract_remediation_id = Mock(return_value="REM-789")
-        github_ops_mock = Mock()
+        github_ops_mock = Mock(spec=GitHubOperations)
         github_ops_mock.extract_issue_number_from_branch.return_value = None
         telemetry_mock = Mock()
         # Test data
@@ -337,7 +338,7 @@ class TestMergeHandler(unittest.TestCase):
     @patch('src.merge_handler.contrast_api.notify_remediation_pr_merged_org')
     def test_notify_remediation_service_success(self, mock_notify, mock_get_config):
         """Test _notify_remediation_service when notification succeeds"""
-        mock_config = Mock()
+        mock_config = Mock(spec=Config)
         mock_config.CONTRAST_HOST = "test.contrastsecurity.com"
         mock_config.CONTRAST_ORG_ID = "test-org"
         mock_config.CONTRAST_AUTHORIZATION_KEY = "test-auth"
@@ -359,7 +360,7 @@ class TestMergeHandler(unittest.TestCase):
     @patch('src.merge_handler.contrast_api.notify_remediation_pr_merged_org')
     def test_notify_remediation_service_failure(self, mock_notify, mock_get_config):
         """Test _notify_remediation_service when notification fails"""
-        mock_config = Mock()
+        mock_config = Mock(spec=Config)
         mock_config.CONTRAST_HOST = "test.contrastsecurity.com"
         mock_config.CONTRAST_ORG_ID = "test-org"
         mock_config.CONTRAST_AUTHORIZATION_KEY = "test-auth"

--- a/test/test_merge_handler.py
+++ b/test/test_merge_handler.py
@@ -393,7 +393,7 @@ class TestCleanupSmartfixLabels(unittest.TestCase):
 
     def _build_mock_ops(self, smartfix_label_names, issue_number=None,
                         remove_pr_ok=True, remove_issue_ok=True):
-        ops = Mock()
+        ops = Mock(spec=GitHubOperations)
         ops.filter_smartfix_labels.return_value = smartfix_label_names
         ops.extract_issue_number_from_branch.return_value = issue_number
         ops.remove_labels_from_pr.return_value = remove_pr_ok

--- a/test/test_otel_provider.py
+++ b/test/test_otel_provider.py
@@ -21,7 +21,7 @@
 import os
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -76,7 +76,7 @@ class TestOtelProvider(unittest.TestCase):
     def test_initialize_sets_tracer_provider_when_endpoint_present(self, mock_exporter_cls):
         """initialize_otel() creates a real TracerProvider when endpoint env var is set."""
         os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
-        mock_exporter_cls.return_value = MagicMock()
+        mock_exporter_cls.return_value = Mock()
 
         otel_provider.initialize_otel(_config())
 
@@ -86,7 +86,7 @@ class TestOtelProvider(unittest.TestCase):
     def test_initialize_sets_correct_resource_attributes(self, mock_exporter_cls):
         """Resource attributes on the TracerProvider match config values."""
         os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
-        mock_exporter_cls.return_value = MagicMock()
+        mock_exporter_cls.return_value = Mock()
         cfg = _config()
 
         otel_provider.initialize_otel(cfg)
@@ -106,7 +106,7 @@ class TestOtelProvider(unittest.TestCase):
     def test_initialize_also_accepts_traces_specific_endpoint_var(self, mock_exporter_cls):
         """OTEL_EXPORTER_OTLP_TRACES_ENDPOINT also enables OTel."""
         os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "http://localhost:4318/v1/traces"
-        mock_exporter_cls.return_value = MagicMock()
+        mock_exporter_cls.return_value = Mock()
 
         otel_provider.initialize_otel(_config())
 
@@ -119,8 +119,8 @@ class TestOtelProvider(unittest.TestCase):
     ):
         """When only OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is set, metrics must not export to .../v1/traces/v1/metrics."""
         os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "http://localhost:4318/v1/traces"
-        mock_span_cls.return_value = MagicMock()
-        mock_metric_cls.return_value = MagicMock()
+        mock_span_cls.return_value = Mock()
+        mock_metric_cls.return_value = Mock()
 
         otel_provider.initialize_otel(_config())
 
@@ -135,8 +135,8 @@ class TestOtelProvider(unittest.TestCase):
     def test_auth_headers_come_from_config_not_env(self, mock_span_cls, mock_metric_cls):
         """Auth headers are always derived from config credentials, never from env vars."""
         os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
-        mock_span_cls.return_value = MagicMock()
-        mock_metric_cls.return_value = MagicMock()
+        mock_span_cls.return_value = Mock()
+        mock_metric_cls.return_value = Mock()
         cfg = _config(CONTRAST_AUTHORIZATION_KEY="my-auth", CONTRAST_API_KEY="my-api")
 
         otel_provider.initialize_otel(cfg)
@@ -222,7 +222,7 @@ class TestOtelProvider(unittest.TestCase):
 
     def test_shutdown_calls_force_flush_then_shutdown(self):
         """shutdown_otel() calls force_flush then shutdown on the provider."""
-        mock_provider = MagicMock()
+        mock_provider = Mock()
         otel_provider._tracer_provider = mock_provider
 
         otel_provider.shutdown_otel()
@@ -232,7 +232,7 @@ class TestOtelProvider(unittest.TestCase):
 
     def test_double_shutdown_is_safe(self):
         """Calling shutdown_otel() twice does not double-flush or raise."""
-        mock_provider = MagicMock()
+        mock_provider = Mock()
         otel_provider._tracer_provider = mock_provider
 
         otel_provider.shutdown_otel()
@@ -248,7 +248,7 @@ class TestOtelProvider(unittest.TestCase):
     def test_start_span_returns_context_manager_when_provider_active(self, mock_exporter_cls):
         """start_span() returns a usable context manager when OTel is initialised."""
         os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
-        mock_exporter_cls.return_value = MagicMock()
+        mock_exporter_cls.return_value = Mock()
         otel_provider.initialize_otel(_config())
 
         with otel_provider.start_span("my-span") as span:

--- a/test/test_otel_provider.py
+++ b/test/test_otel_provider.py
@@ -66,6 +66,15 @@ class TestOtelProvider(unittest.TestCase):
         # Reset global provider so the real SDK TracerProvider installed by a test
         # does not bleed into subsequent tests.
         trace.set_tracer_provider(TracerProvider())
+        # Shut down any MeterProvider created by initialize_otel() so the OTLP
+        # exporter doesn't try to flush at process exit (producing connection
+        # refused tracebacks in CI where no collector is running).
+        if otel_provider._meter_provider is not None:
+            try:
+                otel_provider._meter_provider.shutdown()
+            except Exception:
+                pass
+            otel_provider._meter_provider = None
         otel_provider._tracer_provider = None
         otel_provider._shutdown_called = False
         os.environ.pop("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", None)

--- a/test/test_otel_spans.py
+++ b/test/test_otel_spans.py
@@ -38,7 +38,7 @@ Span hierarchy:
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -323,16 +323,16 @@ class TestLlmCallSpan(unittest.TestCase):
         import src.smartfix.domains.telemetry.otel_provider as otel_provider
         from src.smartfix.extensions.smartfix_litellm import SmartFixLiteLlm
 
-        mock_instance = MagicMock(spec=SmartFixLiteLlm)
+        mock_instance = Mock(spec=SmartFixLiteLlm)
         mock_instance._max_retries = 1
         mock_instance._initial_retry_delay = 0
         mock_instance._retry_multiplier = 2
         mock_instance._is_retryable_exception = lambda e: False
         mock_instance._log_cost_analysis.return_value = (10, 5, 0, 0)
-        mock_instance.llm_client = MagicMock()
+        mock_instance.llm_client = Mock()
         mock_instance._otel_context = None  # use ambient context (fix-vulnerability is current)
 
-        mock_response = MagicMock()
+        mock_response = Mock()
         mock_response.model = "test-model"
         mock_instance.llm_client.acompletion = AsyncMock(return_value=mock_response)
 
@@ -363,16 +363,16 @@ class TestLlmCallSpan(unittest.TestCase):
         """Token counts from _log_cost_analysis() are set on the LLM span."""
         from src.smartfix.extensions.smartfix_litellm import SmartFixLiteLlm
 
-        mock_instance = MagicMock(spec=SmartFixLiteLlm)
+        mock_instance = Mock(spec=SmartFixLiteLlm)
         mock_instance._max_retries = 1
         mock_instance._initial_retry_delay = 0
         mock_instance._retry_multiplier = 2
         mock_instance._is_retryable_exception = lambda e: False
         mock_instance._log_cost_analysis.return_value = (200, 80, 0, 0)
-        mock_instance.llm_client = MagicMock()
+        mock_instance.llm_client = Mock()
         mock_instance._otel_context = None
 
-        mock_response = MagicMock()
+        mock_response = Mock()
         mock_response.model = "usage-model"
         mock_instance.llm_client.acompletion = AsyncMock(return_value=mock_response)
 

--- a/test/test_reconcile_open_remediations.py
+++ b/test/test_reconcile_open_remediations.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 from src.smartfix.domains.workflow.pr_reconciliation import reconcile_open_remediations
 
@@ -11,14 +11,14 @@ class TestReconcileOpenRemediations(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.mock_config = MagicMock(
+        self.mock_config = Mock(
             CONTRAST_HOST='test.contrastsecurity.com',
             CONTRAST_ORG_ID='test-org-id',
             CONTRAST_APP_IDS=['test-app-id'],
             CONTRAST_AUTHORIZATION_KEY='test-auth-key',
             CONTRAST_API_KEY='test-api-key',
         )
-        self.mock_github_ops = MagicMock()
+        self.mock_github_ops = Mock()
 
     @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
     def test_empty_list_makes_no_github_calls(self, mock_contrast_api):

--- a/test/test_reconcile_open_remediations.py
+++ b/test/test_reconcile_open_remediations.py
@@ -3,6 +3,7 @@
 import unittest
 from unittest.mock import patch, Mock
 
+from src.github.github_operations import GitHubOperations
 from src.smartfix.domains.workflow.pr_reconciliation import reconcile_open_remediations
 
 
@@ -18,7 +19,7 @@ class TestReconcileOpenRemediations(unittest.TestCase):
             CONTRAST_AUTHORIZATION_KEY='test-auth-key',
             CONTRAST_API_KEY='test-api-key',
         )
-        self.mock_github_ops = Mock()
+        self.mock_github_ops = Mock(spec=GitHubOperations)
 
     @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
     def test_empty_list_makes_no_github_calls(self, mock_contrast_api):

--- a/test/test_session_handler.py
+++ b/test/test_session_handler.py
@@ -37,7 +37,16 @@ class TestSessionHandler(unittest.TestCase):
     """
 
     def create_session(self, success=True, failure_category=None, pr_body="Test PR body"):
-        """Helper to create a real AgentSession for tests."""
+        """Helper to create a real AgentSession for tests.
+
+        AgentSession.success is derived from is_complete and failure_category,
+        so success=False requires a failure_category to be meaningful.
+        """
+        if not success and failure_category is None:
+            raise ValueError(
+                "create_session(success=False) requires a failure_category; "
+                "AgentSession.success is derived from failure_category being None"
+            )
         session = AgentSession()
         if success:
             session.complete_session(pr_body=pr_body)

--- a/test/test_session_handler.py
+++ b/test/test_session_handler.py
@@ -19,7 +19,7 @@
 #
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, patch
 
 from src.smartfix.domains.workflow.session_handler import (
     SessionOutcome, handle_session_result, generate_qa_section
@@ -37,7 +37,7 @@ class TestSessionHandler(unittest.TestCase):
 
     def create_mock_session(self, success=True, failure_category=None, pr_body="Test PR body"):
         """Helper to create a mock session object."""
-        session = MagicMock()
+        session = Mock()
         session.success = success
         session.failure_category = failure_category
         session.pr_body = pr_body
@@ -89,7 +89,7 @@ class TestSessionHandler(unittest.TestCase):
 
     def test_handle_session_result_failure_with_category(self):
         """Test session result handling for failed session with failure category."""
-        mock_failure_category = MagicMock()
+        mock_failure_category = Mock()
         mock_failure_category.value = "INITIAL_BUILD_FAILURE"
         session = self.create_mock_session(
             success=False,
@@ -122,7 +122,7 @@ class TestSessionHandler(unittest.TestCase):
         # Bug scenario: session failed
         failed_session = self.create_mock_session(
             success=False,
-            failure_category=MagicMock(value="INITIAL_BUILD_FAILURE")
+            failure_category=Mock(value="INITIAL_BUILD_FAILURE")
         )
 
         result = handle_session_result(failed_session)
@@ -146,7 +146,7 @@ class TestSessionHandler(unittest.TestCase):
         """
         Test that session failure returns should_continue=False with a failure category.
         """
-        mock_failure_category = MagicMock()
+        mock_failure_category = Mock()
         mock_failure_category.value = "QA_BUILD_FAILURE"
         failed_session = self.create_mock_session(
             success=False,

--- a/test/test_session_handler.py
+++ b/test/test_session_handler.py
@@ -21,6 +21,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from src.smartfix.domains.agents.agent_session import AgentSession
 from src.smartfix.domains.workflow.session_handler import (
     SessionOutcome, handle_session_result, generate_qa_section
 )
@@ -35,12 +36,13 @@ class TestSessionHandler(unittest.TestCase):
     where failed sessions could generate false positive success messages.
     """
 
-    def create_mock_session(self, success=True, failure_category=None, pr_body="Test PR body"):
-        """Helper to create a mock session object."""
-        session = Mock()
-        session.success = success
-        session.failure_category = failure_category
-        session.pr_body = pr_body
+    def create_session(self, success=True, failure_category=None, pr_body="Test PR body"):
+        """Helper to create a real AgentSession for tests."""
+        session = AgentSession()
+        if success:
+            session.complete_session(pr_body=pr_body)
+        else:
+            session.complete_session(failure_category=failure_category, pr_body=pr_body)
         return session
 
     def test_generate_qa_section_success_with_build_command(self):
@@ -68,7 +70,7 @@ class TestSessionHandler(unittest.TestCase):
 
     def test_handle_session_result_success(self):
         """Test session result handling for successful session."""
-        session = self.create_mock_session(success=True, pr_body="Custom PR body")
+        session = self.create_session(success=True, pr_body="Custom PR body")
 
         result = handle_session_result(session)
 
@@ -79,7 +81,7 @@ class TestSessionHandler(unittest.TestCase):
 
     def test_handle_session_result_success_no_pr_body(self):
         """Test session result handling for successful session without PR body."""
-        session = self.create_mock_session(success=True, pr_body=None)
+        session = self.create_session(success=True, pr_body=None)
 
         result = handle_session_result(session)
 
@@ -89,11 +91,9 @@ class TestSessionHandler(unittest.TestCase):
 
     def test_handle_session_result_failure_with_category(self):
         """Test session result handling for failed session with failure category."""
-        mock_failure_category = Mock()
-        mock_failure_category.value = "INITIAL_BUILD_FAILURE"
-        session = self.create_mock_session(
+        session = self.create_session(
             success=False,
-            failure_category=mock_failure_category
+            failure_category=FailureCategory.INITIAL_BUILD_FAILURE
         )
 
         result = handle_session_result(session)
@@ -103,8 +103,12 @@ class TestSessionHandler(unittest.TestCase):
         self.assertIsNone(result.ai_fix_summary)
 
     def test_handle_session_result_failure_no_category(self):
-        """Test session result handling for failed session without failure category."""
-        session = self.create_mock_session(success=False, failure_category=None)
+        """Test session result handling for failed session without failure category.
+        Uses a Mock because real AgentSession can't represent success=False
+        with failure_category=None (success is derived from failure_category)."""
+        session = Mock()
+        session.success = False
+        session.failure_category = None
 
         result = handle_session_result(session)
 
@@ -120,9 +124,9 @@ class TestSessionHandler(unittest.TestCase):
         "Success (passed on first attempt)" messages.
         """
         # Bug scenario: session failed
-        failed_session = self.create_mock_session(
+        failed_session = self.create_session(
             success=False,
-            failure_category=Mock(value="INITIAL_BUILD_FAILURE")
+            failure_category=FailureCategory.INITIAL_BUILD_FAILURE
         )
 
         result = handle_session_result(failed_session)
@@ -131,7 +135,7 @@ class TestSessionHandler(unittest.TestCase):
         self.assertEqual(result.failure_category, "INITIAL_BUILD_FAILURE")
 
         # Legitimate success scenario should still work
-        success_session = self.create_mock_session(success=True)
+        success_session = self.create_session(success=True)
         result = handle_session_result(success_session)
 
         self.assertTrue(result.should_continue)  # Should continue to PR generation
@@ -146,17 +150,15 @@ class TestSessionHandler(unittest.TestCase):
         """
         Test that session failure returns should_continue=False with a failure category.
         """
-        mock_failure_category = Mock()
-        mock_failure_category.value = "QA_BUILD_FAILURE"
-        failed_session = self.create_mock_session(
+        failed_session = self.create_session(
             success=False,
-            failure_category=mock_failure_category
+            failure_category=FailureCategory.BUILD_VERIFICATION_FAILED
         )
 
         result = handle_session_result(failed_session)
 
         self.assertFalse(result.should_continue)
-        self.assertEqual(result.failure_category, "QA_BUILD_FAILURE")
+        self.assertEqual(result.failure_category, "BUILD_VERIFICATION_FAILED")
         self.assertIsNone(result.ai_fix_summary)
 
 

--- a/test/test_smartfix_agent.py
+++ b/test/test_smartfix_agent.py
@@ -29,7 +29,6 @@ Tests the SmartFixAgent remediation workflow including:
 
 import unittest
 from unittest.mock import patch
-from pathlib import Path
 
 from src.smartfix.domains.agents.smartfix_agent import SmartFixAgent
 from src.smartfix.shared.failure_categories import FailureCategory

--- a/test/test_smartfix_agent.py
+++ b/test/test_smartfix_agent.py
@@ -49,7 +49,7 @@ def _make_context(
     user_build_command=None,
     user_format_command=None,
     repo_path="/tmp/test",
-    language="Java",
+    language=None,
 ):
     """Build a real RemediationContext for tests that exercise _run_fix_agent_execution."""
     vulnerability = Vulnerability(

--- a/test/test_smartfix_agent.py
+++ b/test/test_smartfix_agent.py
@@ -33,7 +33,54 @@ from pathlib import Path
 
 from src.smartfix.domains.agents.smartfix_agent import SmartFixAgent
 from src.smartfix.domains.vulnerability import RemediationContext
+from src.smartfix.domains.vulnerability.context import (
+    PromptConfiguration, BuildConfiguration, RepositoryConfiguration
+)
+from src.smartfix.domains.vulnerability.models import Vulnerability, VulnerabilitySeverity
 from src.smartfix.shared.failure_categories import FailureCategory
+
+
+def _make_context(
+    remediation_id="test-remediation",
+    session_id="test-session",
+    fix_system_prompt="Fix system prompt",
+    fix_user_prompt="Fix user prompt",
+    build_command=None,
+    user_build_command=None,
+    user_format_command=None,
+    repo_path="/tmp/test",
+    language="Java",
+):
+    """Build a real RemediationContext for tests that exercise _run_fix_agent_execution."""
+    vulnerability = Vulnerability(
+        uuid="sample-vuln-uuid",
+        title="Sample Vulnerability",
+        rule_name="sample-rule",
+        severity=VulnerabilitySeverity.HIGH,
+    )
+    prompts = PromptConfiguration(
+        fix_system_prompt=fix_system_prompt,
+        fix_user_prompt=fix_user_prompt,
+    )
+    build_config = BuildConfiguration(
+        build_command=build_command,
+        user_build_command=user_build_command,
+        user_format_command=user_format_command,
+    )
+    repo_config = RepositoryConfiguration(
+        repo_path=repo_path,
+        base_branch="main",
+    )
+    return RemediationContext(
+        remediation_id=remediation_id,
+        vulnerability=vulnerability,
+        prompts=prompts,
+        build_config=build_config,
+        repo_config=repo_config,
+        skip_writing_security_test=False,
+        session_id=session_id,
+        language=language,
+    )
 
 
 class TestSmartFixAgentSuccessScenarios(unittest.TestCase):
@@ -243,19 +290,13 @@ class TestSmartFixAgentBuildToolIntegration(unittest.TestCase):
         mock_event_loop.return_value = "<pr_body>Fix applied</pr_body>"
 
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = False
-        context.build_config.user_build_command = "mvn test"
-        context.build_config.user_format_command = None
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix"
-        context.prompts.fix_user_prompt = "Fix"
-        context.remediation_id = "test-build-tool"
-        context.session_id = "session-bt"
-        context.skip_writing_security_test = False
+        context = _make_context(
+            remediation_id="test-build-tool",
+            session_id="session-bt",
+            fix_system_prompt="Fix",
+            fix_user_prompt="Fix",
+            user_build_command="mvn test",
+        )
 
         with patch.object(agent, '_extract_analytics_data'):
             agent.remediate(context)
@@ -358,19 +399,12 @@ class TestSmartFixAgentCustomInstructions(unittest.TestCase):
         mock_event_loop.return_value = "<pr_body>Fixed</pr_body>"
 
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = False
-        context.build_config.user_build_command = None
-        context.build_config.user_format_command = None
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix system"
-        context.prompts.fix_user_prompt = "Fix this vulnerability"
-        context.remediation_id = "test-ci-123"
-        context.session_id = "session-ci"
-        context.skip_writing_security_test = False
+        context = _make_context(
+            remediation_id="test-ci-123",
+            session_id="session-ci",
+            fix_system_prompt="Fix system",
+            fix_user_prompt="Fix this vulnerability",
+        )
 
         with patch.object(agent, '_extract_analytics_data'):
             agent.remediate(context)
@@ -389,19 +423,12 @@ class TestSmartFixAgentCustomInstructions(unittest.TestCase):
         mock_event_loop.return_value = "<pr_body>Fixed</pr_body>"
 
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = False
-        context.build_config.user_build_command = None
-        context.build_config.user_format_command = None
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix system"
-        context.prompts.fix_user_prompt = "Fix this vulnerability"
-        context.remediation_id = "test-no-ci"
-        context.session_id = "session-no-ci"
-        context.skip_writing_security_test = False
+        context = _make_context(
+            remediation_id="test-no-ci",
+            session_id="session-no-ci",
+            fix_system_prompt="Fix system",
+            fix_user_prompt="Fix this vulnerability",
+        )
 
         with patch.object(agent, '_extract_analytics_data'):
             agent.remediate(context)

--- a/test/test_smartfix_agent.py
+++ b/test/test_smartfix_agent.py
@@ -28,59 +28,12 @@ Tests the SmartFixAgent remediation workflow including:
 """
 
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 from pathlib import Path
 
 from src.smartfix.domains.agents.smartfix_agent import SmartFixAgent
-from src.smartfix.domains.vulnerability import RemediationContext
-from src.smartfix.domains.vulnerability.context import (
-    PromptConfiguration, BuildConfiguration, RepositoryConfiguration
-)
-from src.smartfix.domains.vulnerability.models import Vulnerability, VulnerabilitySeverity
 from src.smartfix.shared.failure_categories import FailureCategory
-
-
-def _make_context(
-    remediation_id="test-remediation",
-    session_id="test-session",
-    fix_system_prompt="Fix system prompt",
-    fix_user_prompt="Fix user prompt",
-    build_command=None,
-    user_build_command=None,
-    user_format_command=None,
-    repo_path="/tmp/test",
-    language=None,
-):
-    """Build a real RemediationContext for tests that exercise _run_fix_agent_execution."""
-    vulnerability = Vulnerability(
-        uuid="sample-vuln-uuid",
-        title="Sample Vulnerability",
-        rule_name="sample-rule",
-        severity=VulnerabilitySeverity.HIGH,
-    )
-    prompts = PromptConfiguration(
-        fix_system_prompt=fix_system_prompt,
-        fix_user_prompt=fix_user_prompt,
-    )
-    build_config = BuildConfiguration(
-        build_command=build_command,
-        user_build_command=user_build_command,
-        user_format_command=user_format_command,
-    )
-    repo_config = RepositoryConfiguration(
-        repo_path=repo_path,
-        base_branch="main",
-    )
-    return RemediationContext(
-        remediation_id=remediation_id,
-        vulnerability=vulnerability,
-        prompts=prompts,
-        build_config=build_config,
-        repo_config=repo_config,
-        skip_writing_security_test=False,
-        session_id=session_id,
-        language=language,
-    )
+from setup_test_env import make_sample_context
 
 
 class TestSmartFixAgentSuccessScenarios(unittest.TestCase):
@@ -90,16 +43,12 @@ class TestSmartFixAgentSuccessScenarios(unittest.TestCase):
         """When fix agent succeeds but no build command is configured,
         PR gate fails with BUILD_VERIFICATION_FAILED."""
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = None
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "You are a security expert"
-        context.prompts.fix_user_prompt = "Fix this vulnerability"
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.remediation_id = "test-fix-123"
-        context.session_id = "session-456"
-        context.skip_writing_security_test = False
+        context = make_sample_context(
+            remediation_id="test-fix-123",
+            session_id="session-456",
+            fix_system_prompt="You are a security expert",
+            fix_user_prompt="Fix this vulnerability",
+        )
 
         with patch.object(agent, '_run_fix_agent_execution', return_value="Agent completed"):
             with patch.object(agent, '_extract_analytics_data'):
@@ -113,20 +62,14 @@ class TestSmartFixAgentSuccessScenarios(unittest.TestCase):
         """When fix agent succeeds and BuildTool recorded a successful build,
         PR gate passes and session succeeds."""
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = True
-        context.build_config.build_command = "mvn test"
-        context.build_config.user_build_command = "mvn test"
-        context.build_config.user_format_command = None
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix system"
-        context.prompts.fix_user_prompt = "Fix user"
-        context.remediation_id = "test-456"
-        context.session_id = "session-789"
-        context.skip_writing_security_test = False
+        context = make_sample_context(
+            remediation_id="test-456",
+            session_id="session-789",
+            fix_system_prompt="Fix system",
+            fix_user_prompt="Fix user",
+            build_command="mvn test",
+            user_build_command="mvn test",
+        )
 
         def fake_execution(ctx):
             # Simulate BuildTool recording a successful build
@@ -149,10 +92,7 @@ class TestSmartFixAgentFixAgentFailures(unittest.TestCase):
         """When fix agent throws an exception,
         should return session with AGENT_FAILURE."""
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = None
-        context.prompts = Mock()
-        context.repo_config = Mock()
+        context = make_sample_context(build_config=None)
 
         with patch.object(agent, '_run_ai_fix_agent', side_effect=Exception("Agent crashed")):
             session = agent.remediate(context)
@@ -164,10 +104,7 @@ class TestSmartFixAgentFixAgentFailures(unittest.TestCase):
         """When fix agent returns None,
         should return session with AGENT_FAILURE."""
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = None
-        context.prompts = Mock()
-        context.repo_config = Mock()
+        context = make_sample_context(build_config=None)
 
         with patch.object(agent, '_run_ai_fix_agent', return_value=None):
             session = agent.remediate(context)
@@ -179,10 +116,7 @@ class TestSmartFixAgentFixAgentFailures(unittest.TestCase):
         """When fix agent returns error message,
         should return session with AGENT_FAILURE."""
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = None
-        context.prompts = Mock()
-        context.repo_config = Mock()
+        context = make_sample_context(build_config=None)
 
         with patch.object(agent, '_run_ai_fix_agent', return_value="Error: Failed to apply fix"):
             session = agent.remediate(context)
@@ -198,20 +132,14 @@ class TestSmartFixAgentPRGate(unittest.TestCase):
         """When build command is configured but agent never verified a build,
         PR gate fails with BUILD_VERIFICATION_FAILED."""
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = True
-        context.build_config.build_command = "mvn test"
-        context.build_config.user_build_command = "mvn test"
-        context.build_config.user_format_command = None
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix"
-        context.prompts.fix_user_prompt = "Fix"
-        context.remediation_id = "test-gate-fail"
-        context.session_id = "session-gate"
-        context.skip_writing_security_test = False
+        context = make_sample_context(
+            remediation_id="test-gate-fail",
+            session_id="session-gate",
+            fix_system_prompt="Fix",
+            fix_user_prompt="Fix",
+            build_command="mvn test",
+            user_build_command="mvn test",
+        )
 
         def fake_execution(ctx):
             # Simulate BuildTool created but no successful build recorded
@@ -229,17 +157,12 @@ class TestSmartFixAgentPRGate(unittest.TestCase):
     def test_pr_gate_fails_when_no_build_config(self):
         """When no build command is configured, PR gate fails."""
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = False
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix"
-        context.prompts.fix_user_prompt = "Fix"
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.remediation_id = "test-no-build"
-        context.session_id = "session-no-build"
-        context.skip_writing_security_test = False
+        context = make_sample_context(
+            remediation_id="test-no-build",
+            session_id="session-no-build",
+            fix_system_prompt="Fix",
+            fix_user_prompt="Fix",
+        )
 
         with patch.object(agent, '_run_fix_agent_execution', return_value="Success"):
             with patch.object(agent, '_extract_analytics_data'):
@@ -253,18 +176,12 @@ class TestSmartFixAgentPRGate(unittest.TestCase):
         """Scenario 4: No pre-configured or detected build command, but agent discovers
         one at runtime and records a successful build — PR gate should pass."""
         agent = SmartFixAgent()
-        context = Mock(spec=RemediationContext)
-        context.build_config = Mock()
-        context.build_config.has_build_command.return_value = False
-        context.build_config.user_build_command = None
-        context.prompts = Mock()
-        context.prompts.fix_system_prompt = "Fix"
-        context.prompts.fix_user_prompt = "Fix"
-        context.repo_config = Mock()
-        context.repo_config.repo_path = Path("/tmp/test")
-        context.remediation_id = "test-discovered-build"
-        context.session_id = "session-discovered"
-        context.skip_writing_security_test = False
+        context = make_sample_context(
+            remediation_id="test-discovered-build",
+            session_id="session-discovered",
+            fix_system_prompt="Fix",
+            fix_user_prompt="Fix",
+        )
 
         def fake_execution(ctx):
             # Agent discovered "pytest" at runtime and ran a successful build
@@ -290,7 +207,7 @@ class TestSmartFixAgentBuildToolIntegration(unittest.TestCase):
         mock_event_loop.return_value = "<pr_body>Fix applied</pr_body>"
 
         agent = SmartFixAgent()
-        context = _make_context(
+        context = make_sample_context(
             remediation_id="test-build-tool",
             session_id="session-bt",
             fix_system_prompt="Fix",
@@ -315,10 +232,7 @@ class TestSmartFixAgentBuildToolIntegration(unittest.TestCase):
         agent = SmartFixAgent()
         agent._build_state = {"build_cmd": "leftover", "format_cmd": None}
 
-        context = Mock(spec=RemediationContext)
-        context.build_config = None
-        context.prompts = Mock()
-        context.repo_config = Mock()
+        context = make_sample_context(build_config=None)
 
         with patch.object(agent, '_run_ai_fix_agent', return_value="<pr_body>Fixed</pr_body>"):
             agent.remediate(context)
@@ -399,7 +313,7 @@ class TestSmartFixAgentCustomInstructions(unittest.TestCase):
         mock_event_loop.return_value = "<pr_body>Fixed</pr_body>"
 
         agent = SmartFixAgent()
-        context = _make_context(
+        context = make_sample_context(
             remediation_id="test-ci-123",
             session_id="session-ci",
             fix_system_prompt="Fix system",
@@ -423,7 +337,7 @@ class TestSmartFixAgentCustomInstructions(unittest.TestCase):
         mock_event_loop.return_value = "<pr_body>Fixed</pr_body>"
 
         agent = SmartFixAgent()
-        context = _make_context(
+        context = make_sample_context(
             remediation_id="test-no-ci",
             session_id="session-no-ci",
             fix_system_prompt="Fix system",

--- a/test/test_smartfix_litellm.py
+++ b/test/test_smartfix_litellm.py
@@ -31,7 +31,7 @@ This module tests the extended LiteLLM functionality including:
 import asyncio
 import unittest
 import json
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, Mock, MagicMock, AsyncMock
 
 # Test setup imports (path is set up by conftest.py)
 from src.smartfix.extensions.smartfix_litellm import SmartFixLiteLlm, TokenCostAccumulator, _derive_system
@@ -429,7 +429,7 @@ class TestLogCostAnalysisReturnValue(unittest.TestCase):
     @patch('src.smartfix.extensions.smartfix_litellm.debug_log')
     def test_returns_token_tuple_from_dict_usage(self, _mock_log):
         """Returns correct 4-tuple when usage is a dict."""
-        response = MagicMock()
+        response = Mock()
         response.get = lambda key, default=None: {
             "usage": {
                 "prompt_tokens": 100,
@@ -447,7 +447,7 @@ class TestLogCostAnalysisReturnValue(unittest.TestCase):
     @patch('src.smartfix.extensions.smartfix_litellm.debug_log')
     def test_returns_zeros_when_no_usage(self, _mock_log):
         """Returns (0, 0, 0, 0) when no usage data is present."""
-        response = MagicMock()
+        response = Mock()
         response.get = lambda key, default=None: default
 
         result = self.model._log_cost_analysis(response)
@@ -468,7 +468,7 @@ class TestCallLlmWithRetryOtelSpan(unittest.TestCase):
         usage = MagicMock()
         usage.__class__.__name__ = "Usage"
         # Make response.get("usage", {}) return the usage object
-        resp = MagicMock()
+        resp = Mock()
         resp.model = model_name
         resp.get = lambda key, default=None: usage if key == "usage" else default
 
@@ -495,17 +495,17 @@ class TestCallLlmWithRetryOtelSpan(unittest.TestCase):
     def test_chat_span_is_created(self, _mock_log):
         """start_span('chat <model>') is called once for a successful call."""
         mock_response = self._make_mock_response()
-        self.model.llm_client = MagicMock()
+        self.model.llm_client = Mock()
         self.model.llm_client.acompletion = AsyncMock(return_value=mock_response)
 
         span_names = []
 
         def mock_start_span(name, context=None):
             span_names.append(name)
-            mock_span = MagicMock()
+            mock_span = Mock()
             mock_span_cm = MagicMock()
-            mock_span_cm.__enter__ = MagicMock(return_value=mock_span)
-            mock_span_cm.__exit__ = MagicMock(return_value=False)
+            mock_span_cm.__enter__ = Mock(return_value=mock_span)
+            mock_span_cm.__exit__ = Mock(return_value=False)
             return mock_span_cm
 
         with patch('src.smartfix.domains.telemetry.otel_provider.start_span', side_effect=mock_start_span):
@@ -517,18 +517,18 @@ class TestCallLlmWithRetryOtelSpan(unittest.TestCase):
     def test_span_has_request_attributes(self, _mock_log):
         """gen_ai.system, gen_ai.request.model, gen_ai.operation.name, contrast.smartfix.retry_attempt are set."""
         mock_response = self._make_mock_response()
-        self.model.llm_client = MagicMock()
+        self.model.llm_client = Mock()
         self.model.llm_client.acompletion = AsyncMock(return_value=mock_response)
 
         captured_span = None
 
         def mock_start_span(name, context=None):
             nonlocal captured_span
-            mock_span = MagicMock()
+            mock_span = Mock()
             captured_span = mock_span
             mock_span_cm = MagicMock()
-            mock_span_cm.__enter__ = MagicMock(return_value=mock_span)
-            mock_span_cm.__exit__ = MagicMock(return_value=False)
+            mock_span_cm.__enter__ = Mock(return_value=mock_span)
+            mock_span_cm.__exit__ = Mock(return_value=False)
             return mock_span_cm
 
         with patch('src.smartfix.domains.telemetry.otel_provider.start_span', side_effect=mock_start_span):
@@ -544,18 +544,18 @@ class TestCallLlmWithRetryOtelSpan(unittest.TestCase):
     def test_span_has_response_model_attribute(self, _mock_log):
         """gen_ai.response.model is set from the response object."""
         mock_response = self._make_mock_response(model_name="claude-3-opus-20240229")
-        self.model.llm_client = MagicMock()
+        self.model.llm_client = Mock()
         self.model.llm_client.acompletion = AsyncMock(return_value=mock_response)
 
         captured_span = None
 
         def mock_start_span(name, context=None):
             nonlocal captured_span
-            mock_span = MagicMock()
+            mock_span = Mock()
             captured_span = mock_span
             mock_span_cm = MagicMock()
-            mock_span_cm.__enter__ = MagicMock(return_value=mock_span)
-            mock_span_cm.__exit__ = MagicMock(return_value=False)
+            mock_span_cm.__enter__ = Mock(return_value=mock_span)
+            mock_span_cm.__exit__ = Mock(return_value=False)
             return mock_span_cm
 
         with patch('src.smartfix.domains.telemetry.otel_provider.start_span', side_effect=mock_start_span):
@@ -573,18 +573,18 @@ class TestCallLlmWithRetryOtelSpan(unittest.TestCase):
         non_retryable_err = _litellm.AuthenticationError(
             message="bad key", llm_provider="anthropic", model="claude-3-opus"
         )
-        self.model.llm_client = MagicMock()
+        self.model.llm_client = Mock()
         self.model.llm_client.acompletion = AsyncMock(side_effect=non_retryable_err)
 
         captured_span = None
 
         def mock_start_span(name, context=None):
             nonlocal captured_span
-            mock_span = MagicMock()
+            mock_span = Mock()
             captured_span = mock_span
             mock_span_cm = MagicMock()
-            mock_span_cm.__enter__ = MagicMock(return_value=mock_span)
-            mock_span_cm.__exit__ = MagicMock(return_value=False)
+            mock_span_cm.__enter__ = Mock(return_value=mock_span)
+            mock_span_cm.__exit__ = Mock(return_value=False)
             return mock_span_cm
 
         with patch('src.smartfix.domains.telemetry.otel_provider.start_span', side_effect=mock_start_span):
@@ -623,22 +623,22 @@ class TestGenerateContentAsyncDoesNotStream(unittest.TestCase):
         """generate_content_async must not insert 'stream' into completion_args."""
         # _get_completion_inputs returns (messages, tools, response_format, generation_params)
         mock_inputs.return_value = ([], None, None, None)
-        mock_response_converter.return_value = MagicMock()
+        mock_response_converter.return_value = Mock()
 
         # Capture completion_args via _call_llm_with_retry mock
-        fake_response = MagicMock()
+        fake_response = Mock()
         fake_response.get = lambda key, default=None: default
         fake_response.model = CONTRAST_CLAUDE_SONNET_4_5
         self.model._call_llm_with_retry = AsyncMock(return_value=fake_response)
 
         # Skip helpers that touch llm_request internals
-        self.model._maybe_append_user_content = MagicMock()
-        self.model._ensure_system_message_for_contrast = MagicMock(return_value=[])
-        self.model._apply_role_conversion_and_caching = MagicMock()
+        self.model._maybe_append_user_content = Mock()
+        self.model._ensure_system_message_for_contrast = Mock(return_value=[])
+        self.model._apply_role_conversion_and_caching = Mock()
         # Provide concrete value for the parent-class attribute the method reads
         self.model._additional_args = {}
 
-        self._consume(self.model.generate_content_async(MagicMock(), stream=False))
+        self._consume(self.model.generate_content_async(Mock(), stream=False))
 
         self.model._call_llm_with_retry.assert_called_once()
         completion_args = self.model._call_llm_with_retry.call_args[0][0]

--- a/test/test_smartfix_litellm_contrast.py
+++ b/test/test_smartfix_litellm_contrast.py
@@ -19,7 +19,9 @@
 #
 
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
+
+from litellm.types.utils import Message
 
 # Test setup imports (path is set up by conftest.py)
 from src.config import get_config, reset_config
@@ -153,10 +155,8 @@ class TestSmartFixLiteLlmContrast(unittest.TestCase):
 
     def test_message_object_handling(self):
         """Test handling of message objects (not just dicts)"""
-        # Create mock message objects
-        user_message = Mock()
-        user_message.role = 'user'
-        user_message.__dict__ = {'role': 'user', 'content': 'Hello'}
+        # Use the real litellm Message type to verify the function handles non-dict objects
+        user_message = Message(role='user', content='Hello')
 
         messages = [user_message]
 

--- a/test/test_smartfix_litellm_contrast.py
+++ b/test/test_smartfix_litellm_contrast.py
@@ -19,7 +19,7 @@
 #
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 # Test setup imports (path is set up by conftest.py)
 from src.config import get_config, reset_config
@@ -154,7 +154,7 @@ class TestSmartFixLiteLlmContrast(unittest.TestCase):
     def test_message_object_handling(self):
         """Test handling of message objects (not just dicts)"""
         # Create mock message objects
-        user_message = MagicMock()
+        user_message = Mock()
         user_message.role = 'user'
         user_message.__dict__ = {'role': 'user', 'content': 'Hello'}
 

--- a/test/test_smartfix_litellm_retry.py
+++ b/test/test_smartfix_litellm_retry.py
@@ -52,7 +52,7 @@ class TestSmartFixLiteLlmRetry(unittest.TestCase):
             message="Rate limit exceeded",
             llm_provider="test",
             model="test-model",
-            response=httpx.Response(429)
+            response=httpx.Response(429, request=httpx.Request("POST", "http://test"))
         )
         result = SmartFixLiteLlm._is_retryable_exception(self.mock_instance, error)
         self.assertTrue(result)
@@ -73,7 +73,7 @@ class TestSmartFixLiteLlmRetry(unittest.TestCase):
             message="Service unavailable",
             llm_provider="test",
             model="test-model",
-            response=httpx.Response(503)
+            response=httpx.Response(503, request=httpx.Request("POST", "http://test"))
         )
         result = SmartFixLiteLlm._is_retryable_exception(self.mock_instance, error)
         self.assertTrue(result)
@@ -199,7 +199,7 @@ class TestSmartFixLiteLlmRetryAsync(unittest.TestCase):
             message="Rate limit",
             llm_provider="test",
             model="test",
-            response=httpx.Response(429)
+            response=httpx.Response(429, request=httpx.Request("POST", "http://test"))
         )
 
         # Fail twice, then succeed
@@ -226,7 +226,7 @@ class TestSmartFixLiteLlmRetryAsync(unittest.TestCase):
             message="Rate limit",
             llm_provider="test",
             model="test",
-            response=httpx.Response(429)
+            response=httpx.Response(429, request=httpx.Request("POST", "http://test"))
         )
 
         # Fail all attempts

--- a/test/test_smartfix_litellm_retry.py
+++ b/test/test_smartfix_litellm_retry.py
@@ -26,7 +26,7 @@ This module tests the exponential backoff retry mechanism for LLM calls.
 
 import asyncio
 import unittest
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import patch, AsyncMock, Mock
 
 import litellm
 
@@ -39,11 +39,11 @@ class TestSmartFixLiteLlmRetry(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         # Create a mock instance with retry config
-        self.mock_instance = MagicMock(spec=SmartFixLiteLlm)
+        self.mock_instance = Mock(spec=SmartFixLiteLlm)
         self.mock_instance._max_retries = 3
         self.mock_instance._initial_retry_delay = 1
         self.mock_instance._retry_multiplier = 2
-        self.mock_instance.llm_client = MagicMock()
+        self.mock_instance.llm_client = Mock()
 
     def test_is_retryable_exception_rate_limit(self):
         """Test that RateLimitError is retryable."""
@@ -51,7 +51,7 @@ class TestSmartFixLiteLlmRetry(unittest.TestCase):
             message="Rate limit exceeded",
             llm_provider="test",
             model="test-model",
-            response=MagicMock()
+            response=Mock()
         )
         result = SmartFixLiteLlm._is_retryable_exception(self.mock_instance, error)
         self.assertTrue(result)
@@ -72,7 +72,7 @@ class TestSmartFixLiteLlmRetry(unittest.TestCase):
             message="Service unavailable",
             llm_provider="test",
             model="test-model",
-            response=MagicMock()
+            response=Mock()
         )
         result = SmartFixLiteLlm._is_retryable_exception(self.mock_instance, error)
         self.assertTrue(result)
@@ -156,11 +156,11 @@ class TestSmartFixLiteLlmRetryAsync(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.mock_instance = MagicMock(spec=SmartFixLiteLlm)
+        self.mock_instance = Mock(spec=SmartFixLiteLlm)
         self.mock_instance._max_retries = 3
         self.mock_instance._initial_retry_delay = 0  # No delay for tests
         self.mock_instance._retry_multiplier = 2
-        self.mock_instance.llm_client = MagicMock()
+        self.mock_instance.llm_client = Mock()
         # Use the real _is_retryable_exception method
         self.mock_instance._is_retryable_exception = lambda e: SmartFixLiteLlm._is_retryable_exception(
             self.mock_instance, e
@@ -198,7 +198,7 @@ class TestSmartFixLiteLlmRetryAsync(unittest.TestCase):
             message="Rate limit",
             llm_provider="test",
             model="test",
-            response=MagicMock()
+            response=Mock()
         )
 
         # Fail twice, then succeed
@@ -225,7 +225,7 @@ class TestSmartFixLiteLlmRetryAsync(unittest.TestCase):
             message="Rate limit",
             llm_provider="test",
             model="test",
-            response=MagicMock()
+            response=Mock()
         )
 
         # Fail all attempts

--- a/test/test_smartfix_litellm_retry.py
+++ b/test/test_smartfix_litellm_retry.py
@@ -28,6 +28,7 @@ import asyncio
 import unittest
 from unittest.mock import patch, AsyncMock, Mock
 
+import httpx
 import litellm
 
 from src.smartfix.extensions.smartfix_litellm import SmartFixLiteLlm
@@ -51,7 +52,7 @@ class TestSmartFixLiteLlmRetry(unittest.TestCase):
             message="Rate limit exceeded",
             llm_provider="test",
             model="test-model",
-            response=Mock()
+            response=httpx.Response(429)
         )
         result = SmartFixLiteLlm._is_retryable_exception(self.mock_instance, error)
         self.assertTrue(result)
@@ -72,7 +73,7 @@ class TestSmartFixLiteLlmRetry(unittest.TestCase):
             message="Service unavailable",
             llm_provider="test",
             model="test-model",
-            response=Mock()
+            response=httpx.Response(503)
         )
         result = SmartFixLiteLlm._is_retryable_exception(self.mock_instance, error)
         self.assertTrue(result)
@@ -198,7 +199,7 @@ class TestSmartFixLiteLlmRetryAsync(unittest.TestCase):
             message="Rate limit",
             llm_provider="test",
             model="test",
-            response=Mock()
+            response=httpx.Response(429)
         )
 
         # Fail twice, then succeed
@@ -225,7 +226,7 @@ class TestSmartFixLiteLlmRetryAsync(unittest.TestCase):
             message="Rate limit",
             llm_provider="test",
             model="test",
-            response=Mock()
+            response=httpx.Response(429)
         )
 
         # Fail all attempts

--- a/test/test_smartfix_llm_agent.py
+++ b/test/test_smartfix_llm_agent.py
@@ -41,7 +41,7 @@ class TestSmartFixLlmAgentFunctionality(unittest.TestCase):
     def test_has_extended_model_true(self):
         """Test has_extended_model returns True when SmartFixLiteLlm reference exists."""
         # Test the method logic directly without full object instantiation
-        agent = Mock()
+        agent = Mock(spec=SmartFixLlmAgent)
         agent.canonical_model = Mock(spec=SmartFixLiteLlm)
 
         # Apply the real method to our mock
@@ -50,15 +50,15 @@ class TestSmartFixLlmAgentFunctionality(unittest.TestCase):
 
     def test_has_extended_model_false(self):
         """Test has_extended_model returns False when no SmartFixLiteLlm reference exists."""
-        agent = Mock()
-        agent.canonical_model = Mock()  # Not a SmartFixLiteLlm
+        agent = Mock(spec=SmartFixLlmAgent)
+        agent.canonical_model = Mock()  # Intentionally no spec: test verifies non-SmartFixLiteLlm is detected
 
         result = SmartFixLlmAgent.has_extended_model(agent)
         self.assertFalse(result)
 
     def test_get_extended_model_with_reference(self):
         """Test get_extended_model returns the canonical model when it's SmartFixLiteLlm."""
-        agent = Mock()
+        agent = Mock(spec=SmartFixLlmAgent)
         mock_extended_model = Mock(spec=SmartFixLiteLlm)
         agent.canonical_model = mock_extended_model
 

--- a/test/test_smartfix_llm_agent.py
+++ b/test/test_smartfix_llm_agent.py
@@ -27,7 +27,7 @@ the extension logic without complex ADK dependencies.
 
 import unittest
 import json
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 
 # ADK mocks are set up globally in conftest.py before any imports
 # Test setup imports (path is set up by conftest.py)
@@ -41,7 +41,7 @@ class TestSmartFixLlmAgentFunctionality(unittest.TestCase):
     def test_has_extended_model_true(self):
         """Test has_extended_model returns True when SmartFixLiteLlm reference exists."""
         # Test the method logic directly without full object instantiation
-        agent = MagicMock()
+        agent = Mock()
         agent.canonical_model = Mock(spec=SmartFixLiteLlm)
 
         # Apply the real method to our mock
@@ -50,7 +50,7 @@ class TestSmartFixLlmAgentFunctionality(unittest.TestCase):
 
     def test_has_extended_model_false(self):
         """Test has_extended_model returns False when no SmartFixLiteLlm reference exists."""
-        agent = MagicMock()
+        agent = Mock()
         agent.canonical_model = Mock()  # Not a SmartFixLiteLlm
 
         result = SmartFixLlmAgent.has_extended_model(agent)
@@ -58,7 +58,7 @@ class TestSmartFixLlmAgentFunctionality(unittest.TestCase):
 
     def test_get_extended_model_with_reference(self):
         """Test get_extended_model returns the canonical model when it's SmartFixLiteLlm."""
-        agent = MagicMock()
+        agent = Mock()
         mock_extended_model = Mock(spec=SmartFixLiteLlm)
         agent.canonical_model = mock_extended_model
 
@@ -69,7 +69,7 @@ class TestSmartFixLlmAgentFunctionality(unittest.TestCase):
 
     def test_reset_accumulated_stats_with_extended_model(self):
         """Test that reset delegates to SmartFixLiteLlm model."""
-        agent = MagicMock()
+        agent = Mock()
         mock_extended_model = Mock(spec=SmartFixLiteLlm)
 
         # The real method calls get_extended_model first
@@ -127,7 +127,7 @@ class TestSmartFixLlmAgentIntegration(unittest.TestCase):
         extended_model = SmartFixLiteLlm(model="test-model-id")
 
         # Create a mock agent
-        agent = MagicMock()
+        agent = Mock()
         agent.name = "test-agent"
         agent.canonical_model = extended_model
         agent.original_extended_model = extended_model

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -29,7 +29,7 @@ These tests verify that:
 """
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, patch
 
 
 class TestLazyInitialisation(unittest.TestCase):
@@ -56,8 +56,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_vulnerability_duration_histogram_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_histogram = MagicMock()
-        mock_meter = MagicMock()
+        mock_histogram = Mock()
+        mock_meter = Mock()
         mock_meter.create_histogram.return_value = mock_histogram
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -71,8 +71,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_pr_count_counter_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_counter = MagicMock()
-        mock_meter = MagicMock()
+        mock_counter = Mock()
+        mock_meter = Mock()
         mock_meter.create_counter.return_value = mock_counter
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -86,8 +86,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_llm_duration_histogram_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_histogram = MagicMock()
-        mock_meter = MagicMock()
+        mock_histogram = Mock()
+        mock_meter = Mock()
         mock_meter.create_histogram.return_value = mock_histogram
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -100,8 +100,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_llm_retries_counter_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_counter = MagicMock()
-        mock_meter = MagicMock()
+        mock_counter = Mock()
+        mock_meter = Mock()
         mock_meter.create_counter.return_value = mock_counter
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -117,7 +117,7 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_histogram = MagicMock()
+        self.mock_histogram = Mock()
         m._vulnerability_duration_histogram = self.mock_histogram
 
     def test_records_with_correct_attributes(self):
@@ -149,7 +149,7 @@ class TestRecordPrAttempt(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_counter = MagicMock()
+        self.mock_counter = Mock()
         m._pr_count_counter = self.mock_counter
 
     def test_records_success(self):
@@ -182,8 +182,8 @@ class TestRecordLlmCallTokens(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_total = MagicMock()
-        self.mock_cache = MagicMock()
+        self.mock_total = Mock()
+        self.mock_cache = Mock()
         m._tokens_total_counter = self.mock_total
         m._cache_tokens_counter = self.mock_cache
 
@@ -233,7 +233,7 @@ class TestRecordLlmDuration(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_histogram = MagicMock()
+        self.mock_histogram = Mock()
         m._llm_duration_histogram = self.mock_histogram
 
     def test_records_with_provider_and_model(self):
@@ -255,7 +255,7 @@ class TestRecordLlmRetry(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_counter = MagicMock()
+        self.mock_counter = Mock()
         m._llm_retries_counter = self.mock_counter
 
     def test_records_with_model_and_error_type(self):

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -31,6 +31,8 @@ These tests verify that:
 import unittest
 from unittest.mock import Mock, patch
 
+from opentelemetry.metrics import Counter, Histogram, Meter
+
 
 class TestLazyInitialisation(unittest.TestCase):
     """Instruments must not be created until the first recording call."""
@@ -56,8 +58,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_vulnerability_duration_histogram_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_histogram = Mock()
-        mock_meter = Mock()
+        mock_histogram = Mock(spec=Histogram)
+        mock_meter = Mock(spec=Meter)
         mock_meter.create_histogram.return_value = mock_histogram
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -71,8 +73,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_pr_count_counter_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_counter = Mock()
-        mock_meter = Mock()
+        mock_counter = Mock(spec=Counter)
+        mock_meter = Mock(spec=Meter)
         mock_meter.create_counter.return_value = mock_counter
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -86,8 +88,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_llm_duration_histogram_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_histogram = Mock()
-        mock_meter = Mock()
+        mock_histogram = Mock(spec=Histogram)
+        mock_meter = Mock(spec=Meter)
         mock_meter.create_histogram.return_value = mock_histogram
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -100,8 +102,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_llm_retries_counter_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_counter = Mock()
-        mock_meter = Mock()
+        mock_counter = Mock(spec=Counter)
+        mock_meter = Mock(spec=Meter)
         mock_meter.create_counter.return_value = mock_counter
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -117,7 +119,7 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_histogram = Mock()
+        self.mock_histogram = Mock(spec=Histogram)
         m._vulnerability_duration_histogram = self.mock_histogram
 
     def test_records_with_correct_attributes(self):
@@ -149,7 +151,7 @@ class TestRecordPrAttempt(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_counter = Mock()
+        self.mock_counter = Mock(spec=Counter)
         m._pr_count_counter = self.mock_counter
 
     def test_records_success(self):
@@ -182,8 +184,8 @@ class TestRecordLlmCallTokens(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_total = Mock()
-        self.mock_cache = Mock()
+        self.mock_total = Mock(spec=Counter)
+        self.mock_cache = Mock(spec=Counter)
         m._tokens_total_counter = self.mock_total
         m._cache_tokens_counter = self.mock_cache
 
@@ -233,7 +235,7 @@ class TestRecordLlmDuration(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_histogram = Mock()
+        self.mock_histogram = Mock(spec=Histogram)
         m._llm_duration_histogram = self.mock_histogram
 
     def test_records_with_provider_and_model(self):
@@ -255,7 +257,7 @@ class TestRecordLlmRetry(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_counter = Mock()
+        self.mock_counter = Mock(spec=Counter)
         m._llm_retries_counter = self.mock_counter
 
     def test_records_with_model_and_error_type(self):

--- a/test/test_sub_agent_executor.py
+++ b/test/test_sub_agent_executor.py
@@ -311,6 +311,8 @@ class TestSubAgentExecutorAgentCreation(unittest.TestCase):
             call_kwargs = mock_llm_class.call_args[1]
             self.assertEqual(call_kwargs["model"], "claude-sonnet-4.5")
             self.assertEqual(call_kwargs["temperature"], 0.2)
+            # Attribution headers should not be present for non-Contrast LLM
+            self.assertNotIn("extra_headers", call_kwargs)
             # Verify agent was created
             mock_agent_class.assert_called_once()
             agent_kwargs = mock_agent_class.call_args[1]
@@ -366,7 +368,12 @@ class TestSubAgentExecutorAgentCreation(unittest.TestCase):
             headers = call_kwargs["extra_headers"]
             self.assertEqual(headers["Api-Key"], "test-api-key")
             self.assertEqual(headers["Authorization"], "test-auth-key")
-            self.assertNotIn("x-contrast-llm-session-id", headers)
+            self.assertEqual(headers["x-contrast-llm-feature"], "SMARTFIX")
+            self.assertEqual(headers["x-contrast-llm-session-id"], "test-123")
+            # Attribution headers with empty defaults should be absent
+            self.assertNotIn("x-contrast-llm-fingerprint", headers)
+            self.assertNotIn("x-contrast-llm-repo", headers)
+            self.assertNotIn("x-contrast-llm-source-language", headers)
             # Verify agent was created with fix agent name
             mock_agent_class.assert_called_once()
             agent_kwargs = mock_agent_class.call_args[1]
@@ -411,6 +418,125 @@ class TestSubAgentExecutorAgentCreation(unittest.TestCase):
             call_args = mock_error_exit.call_args[0]
             self.assertEqual(call_args[0], "test-123")
             self.assertIn("INVALID_LLM_CONFIG", call_args[1])
+
+
+class TestSubAgentExecutorAttributionHeaders(unittest.TestCase):
+    """Test LLM usage attribution headers for Contrast LLM path."""
+
+    def test_contrast_llm_includes_all_attribution_headers(self):
+        """
+        Given all attribution parameters are provided,
+        when creating an agent with Contrast LLM,
+        then all x-contrast-llm-* headers should be present.
+        """
+        with patch('src.config.get_config') as mock_config, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLiteLlm') as mock_llm_class, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLlmAgent') as mock_agent_class, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.setup_contrast_provider'):
+
+            mock_config.return_value = Mock(
+                MAX_EVENTS_PER_AGENT=120,
+                USE_CONTRAST_LLM=True,
+                AGENT_MODEL="contrast/claude-sonnet-4-5",
+                CONTRAST_API_KEY="test-api-key",
+                CONTRAST_AUTHORIZATION_KEY="test-auth-key",
+            )
+            executor = SubAgentExecutor()
+            executor.mcp_manager.get_tools = AsyncMock(return_value=[Mock()])
+            mock_llm_class.return_value = Mock()
+            mock_agent_class.return_value = Mock()
+
+            asyncio.run(executor.create_agent(
+                target_folder=Path("/tmp/test"),
+                remediation_id="rem-001",
+                session_id="sess-001",
+                system_prompt="Fix the vulnerability",
+                vuln_uuid="3MUU-1GC8-U6DE-KDUO",
+                repo_slug="Contrast-Security-Inc/employee-management",
+                language="Java",
+            ))
+
+            headers = mock_llm_class.call_args[1]["extra_headers"]
+            self.assertEqual(headers["x-contrast-llm-feature"], "SMARTFIX")
+            self.assertEqual(headers["x-contrast-llm-fingerprint"], "3MUU-1GC8-U6DE-KDUO")
+            self.assertEqual(headers["x-contrast-llm-session-id"], "rem-001")
+            self.assertEqual(headers["x-contrast-llm-repo"], "Contrast-Security-Inc/employee-management")
+            self.assertEqual(headers["x-contrast-llm-source-language"], "Java")
+
+    def test_contrast_llm_omits_empty_attribution_headers(self):
+        """
+        Given attribution parameters are empty strings,
+        when creating an agent with Contrast LLM,
+        then optional x-contrast-llm-* headers should be absent.
+        """
+        with patch('src.config.get_config') as mock_config, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLiteLlm') as mock_llm_class, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLlmAgent') as mock_agent_class, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.setup_contrast_provider'):
+
+            mock_config.return_value = Mock(
+                MAX_EVENTS_PER_AGENT=120,
+                USE_CONTRAST_LLM=True,
+                AGENT_MODEL="contrast/claude-sonnet-4-5",
+                CONTRAST_API_KEY="test-api-key",
+                CONTRAST_AUTHORIZATION_KEY="test-auth-key",
+            )
+            executor = SubAgentExecutor()
+            executor.mcp_manager.get_tools = AsyncMock(return_value=[Mock()])
+            mock_llm_class.return_value = Mock()
+            mock_agent_class.return_value = Mock()
+
+            asyncio.run(executor.create_agent(
+                target_folder=Path("/tmp/test"),
+                remediation_id="",
+                session_id="sess-001",
+                system_prompt="Fix the vulnerability",
+                vuln_uuid="",
+                repo_slug="",
+                language="",
+            ))
+
+            headers = mock_llm_class.call_args[1]["extra_headers"]
+            # Feature header is always present
+            self.assertEqual(headers["x-contrast-llm-feature"], "SMARTFIX")
+            # All others should be absent when their source values are empty
+            self.assertNotIn("x-contrast-llm-fingerprint", headers)
+            self.assertNotIn("x-contrast-llm-session-id", headers)
+            self.assertNotIn("x-contrast-llm-repo", headers)
+            self.assertNotIn("x-contrast-llm-source-language", headers)
+
+    def test_standard_llm_does_not_receive_attribution_headers(self):
+        """
+        Given attribution parameters are provided,
+        when creating an agent with a standard (non-Contrast) LLM,
+        then no extra_headers should be passed to SmartFixLiteLlm.
+        """
+        with patch('src.config.get_config') as mock_config, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLiteLlm') as mock_llm_class, \
+             patch('src.smartfix.domains.agents.sub_agent_executor.SmartFixLlmAgent') as mock_agent_class:
+
+            mock_config.return_value = Mock(
+                MAX_EVENTS_PER_AGENT=120,
+                USE_CONTRAST_LLM=False,
+                AGENT_MODEL="claude-sonnet-4-5",
+            )
+            executor = SubAgentExecutor()
+            executor.mcp_manager.get_tools = AsyncMock(return_value=[Mock()])
+            mock_llm_class.return_value = Mock()
+            mock_agent_class.return_value = Mock()
+
+            asyncio.run(executor.create_agent(
+                target_folder=Path("/tmp/test"),
+                remediation_id="rem-001",
+                session_id="sess-001",
+                system_prompt="Fix the vulnerability",
+                vuln_uuid="3MUU-1GC8-U6DE-KDUO",
+                repo_slug="Contrast-Security-Inc/employee-management",
+                language="Java",
+            ))
+
+            call_kwargs = mock_llm_class.call_args[1]
+            self.assertNotIn("extra_headers", call_kwargs)
 
 
 class TestSubAgentExecutorFunctionProcessing(unittest.TestCase):

--- a/test/test_version_check.py
+++ b/test/test_version_check.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import requests
 from unittest.mock import patch, Mock
 from packaging.version import Version
 
@@ -23,7 +24,7 @@ class TestVersionCheck(unittest.TestCase):
         self.mock_requests.exceptions.RequestException = Exception
 
         # Set up a default mock response
-        self.mock_response = Mock()
+        self.mock_response = Mock(spec=requests.Response)
         self.mock_response.json.return_value = [
             {'name': 'v1.0.0'},
             {'name': 'v1.1.0'},

--- a/test/test_version_check.py
+++ b/test/test_version_check.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 from packaging.version import Version
 
 # Test setup imports (path is set up by conftest.py)
@@ -19,11 +19,11 @@ class TestVersionCheck(unittest.TestCase):
         self.mock_requests = self.requests_patcher.start()
 
         # Set up mock exceptions
-        self.mock_requests.exceptions = MagicMock()
+        self.mock_requests.exceptions = Mock()
         self.mock_requests.exceptions.RequestException = Exception
 
         # Set up a default mock response
-        self.mock_response = MagicMock()
+        self.mock_response = Mock()
         self.mock_response.json.return_value = [
             {'name': 'v1.0.0'},
             {'name': 'v1.1.0'},

--- a/test/test_vulnerability_context.py
+++ b/test/test_vulnerability_context.py
@@ -361,6 +361,29 @@ class TestRemediationContext(unittest.TestCase):
         self.assertIsInstance(context, RemediationContext)
         self.assertEqual(context.session_id, None)
 
+    def test_create_with_language(self):
+        """Test successful creation of remediation context with language."""
+        context = RemediationContext(
+            remediation_id="api-remediation-789",
+            vulnerability=self.valid_vulnerability,
+            prompts=self.prompts,
+            build_config=self.build_config,
+            repo_config=self.repo_config,
+            language="Java",
+        )
+        self.assertEqual(context.language, "Java")
+
+    def test_create_without_language_defaults_to_none(self):
+        """Test that language defaults to None when not provided."""
+        context = RemediationContext(
+            remediation_id="api-remediation-789",
+            vulnerability=self.valid_vulnerability,
+            prompts=self.prompts,
+            build_config=self.build_config,
+            repo_config=self.repo_config,
+        )
+        self.assertIsNone(context.language)
+
     def test_validate_raw_prompts_data_valid(self):
         """Test validate_raw_prompts_data with valid prompts data."""
         prompts_data = {


### PR DESCRIPTION
**Ticket:**
  https://contrastsecurity.atlassian.net/browse/AIML-771

**Overview:**
- Based off of https://github.com/Contrast-Security-OSS/contrast-ai-smartfix-action/pull/162 which I will merge before this
- Reduce reliance on mock objects across the SmartFix test suite by replacing them with real objects wherever feasible, and adding spec= constraints to the remaining mocks. This makes tests more reliable by catching interface drift, since unspecced mocks silently accept any attribute access.
- This is basically a style preference, and I can just decline it if anyone objects to going this direction. I ran into a problem with a MagicMock while developing my AIML-697 and narrowly avoided adding a bug so in that PR I switched out some mocks for a factory method, and this PR takes it to the next level. My hope is with more limited and intentional use of Mocks that Claude will be less inclined to use them everywhere when a real object would be more appropriate.

**What Changed:**
- Replaced all 315 MagicMock() assignments with plain Mock() where dunder method support isn't needed (46 remain where __enter__/__exit__ is required, plus ADK module shims in conftest)
- Replaced 170 mock objects with real objects: subprocess.CompletedProcess (43), requests.Response (4), CreditTrackingResponse (2), litellm.types.utils.Message (2), and RemediationContext via make_sample_context() (27 call sites)
- Added spec= to 17 additional mocks targeting GitHubOperations, requests.Response, SmartFixLlmAgent, SmartFixLiteLlm, and OpenTelemetry types (Counter, Histogram, Meter)
- Created 4 new factory methods: make_sample_context() (shared), _make_response() (2 files, builds real requests.Response), _make_credit_info() (builds real CreditTrackingResponse)

```
 Mock/MagicMock Summary

  Total mock object assignments

  ┌────────────────┬────────┬───────┬────────┐
  │                │ Before │ After │ Change │
  ├────────────────┼────────┼───────┼────────┤
  │ MagicMock()    │ 315    │ 46    │ -269   │
  ├────────────────┼────────┼───────┼────────┤
  │ Mock()         │ 129    │ 228   │ +99    │
  ├────────────────┼────────┼───────┼────────┤
  │ Combined total │ 444    │ 274   │ -170   │
  └────────────────┴────────┴───────┴────────┘

  The Mock count went up because 134 MagicMocks became plain Mocks (Phase 1), while 170 total mocks were eliminated by replacing them with real objects.

  Mocks with spec=

  ┌────────┬───────┬────────┐
  │ Before │ After │ Change │
  ├────────┼───────┼────────┤
  │ 22     │ 39    │ +17    │
  └────────┴───────┴────────┘

  Real objects replacing mocks

  ┌─────────────────────────────┬────────┬───────┐
  │            Type             │ Before │ After │
  ├─────────────────────────────┼────────┼───────┤
  │ subprocess.CompletedProcess │ 0      │ 43    │
  ├─────────────────────────────┼────────┼───────┤
  │ requests.Response           │ 0      │ 4     │
  ├─────────────────────────────┼────────┼───────┤
  │ CreditTrackingResponse      │ 1      │ 2     │
  ├─────────────────────────────┼────────┼───────┤
  │ litellm Message             │ 0      │ 2     │
  ├─────────────────────────────┼────────┼───────┤
  │ make_sample_context() calls │ 0      │ 27    │
  └─────────────────────────────┴────────┴───────┘

  Factory methods created

  4 new factories (the two _make_context and _make_span_recorder pre-existed):

  ┌───────────────────────┬──────────────────────────────────────┬──────────────────────────────────┐
  │        Factory        │                 File                 │             Purpose              │
  ├───────────────────────┼──────────────────────────────────────┼──────────────────────────────────┤
  │ _make_response()      │ test_contrast_api_credit_tracking.py │ Real requests.Response           │
  ├───────────────────────┼──────────────────────────────────────┼──────────────────────────────────┤
  │ _make_response()      │ test_contrast_api_org_endpoints.py   │ Real requests.Response           │
  ├───────────────────────┼──────────────────────────────────────┼──────────────────────────────────┤
  │ _make_credit_info()   │ test_sanitized_409_messages.py       │ Real CreditTrackingResponse      │
  ├───────────────────────┼──────────────────────────────────────┼──────────────────────────────────┤
  │ make_sample_context() │ setup_test_env.py                    │ Real RemediationContext (shared) │
  └───────────────────────┴──────────────────────────────────────┴──────────────────────────────────┘

  Remaining MagicMocks (46)

  All in two categories that genuinely need __enter__/__exit__ or module-level faking:
  - 28 in test/__init__.py + conftest.py: ADK module fakes (sys.modules shims for google.adk, which isn't importable in test)
  - 7 in test_github_operations.py: NamedTemporaryFile context managers
  - 7 in test_main.py + 4 in test_smartfix_litellm.py: OTel span context managers
```

**Review Notes:**
- This does not touch patched/mocked functions (e.g. @patch decorators replacing callables).
- spec=Config and spec=SmartFixAgent were attempted and reverted because those classes store all attributes in __init__ (which reads env vars). Mock(spec=...) uses dir() on the class, not instances, so instance-only attributes aren't in the spec. Those mocks remain unspecced.
- The remaining 46 MagicMocks are all in conftest/__init__ (ADK module shims), test_github_operations (NamedTemporaryFile context managers), and OTel span context managers in test_main/test_smartfix_litellm.

**How To Test:**
- Run make test (or ./test/run_tests.sh --skip-install). All 938 tests should pass.
- CI output is essentially the same [before](https://github.com/Contrast-Security-OSS/contrast-ai-smartfix-action/actions/runs/25801732386/job/75793356933) and [after](https://github.com/Contrast-Security-OSS/contrast-ai-smartfix-action/actions/runs/25864723867/job/76003623181?pr=165) 