### PR TITLE
AIML-794: Fix OTel reporting — emit metrics for datalake consumption

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -69,9 +69,6 @@ def main():
     # Use lists so _main_impl can mutate them and the finally block sees the
     # correct value even when _main_impl exits via error_exit()/sys.exit().
     vuln_count = [0]
-    # Only counts PRs created by the SmartFix-internal agent.  External-agent
-    # runs (Copilot, Claude Code) create their PR asynchronously after the
-    # GitHub Issue is filed, so they are not reflected here.
     prs_created_count = [0]
     try:
         with otel_provider.start_span("smartfix-run") as run_span:
@@ -85,7 +82,7 @@ def main():
         otel_provider.shutdown_otel()
 
 
-def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # noqa: C901
+def _main_impl(vuln_count, prs_created_count):  # noqa: C901
     """Main orchestration logic."""
 
     start_time = datetime.now()
@@ -200,7 +197,6 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
 
     while True:
         telemetry_handler.reset_vuln_specific_telemetry()
-        smartfix_metrics.reset_vuln_token_accumulator()
         # Check if we've exceeded the maximum runtime
         current_time = datetime.now()
         elapsed_time = current_time - start_time
@@ -274,7 +270,6 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
             vuln_title = vulnerability_data['vulnerabilityTitle']
             remediation_id = vulnerability_data['remediationId']
             session_id = vulnerability_data.get('sessionId')
-            vuln_language = vulnerability_data.get('language')
 
             # Validate and create prompt configuration for SmartFix agent
             try:
@@ -317,7 +312,6 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
             vuln_title = vulnerability_data['vulnerabilityTitle']
             remediation_id = vulnerability_data['remediationId']
             session_id = None  # External agents don't use Contrast LLM sessions
-            vuln_language = vulnerability_data.get('language')
 
             # No prompts required for external agents
             prompts = PromptConfiguration()
@@ -352,6 +346,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
         # Update tracking variable now that we know we're actually processing this vuln
         previous_vuln_uuid = vuln_uuid
         vuln_count[0] += 1
+        smartfix_metrics.reset_vuln_token_accumulator()
 
         log(f"\n\033[0;33m Selected vuln to fix: {vuln_title} \033[0m")
 
@@ -381,7 +376,6 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                     repo_config=repo_config,
                     skip_writing_security_test=config.SKIP_WRITING_SECURITY_TEST,
                     session_id=session_id,
-                    language=vuln_language,
                 )
 
                 # Propagate a build command discovered by a previous agent run so the next

--- a/src/main.py
+++ b/src/main.py
@@ -701,12 +701,21 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                 _total_in, _total_out = smartfix_metrics.get_vuln_token_totals()
                 op_span.set_attribute("contrast.smartfix.total_input_tokens", _total_in)
                 op_span.set_attribute("contrast.smartfix.total_output_tokens", _total_out)
+                _severity = vulnerability.severity.value if vulnerability.severity else None
                 smartfix_metrics.record_vulnerability_duration(
                     elapsed_s=time.monotonic() - _op_fix_start,
                     outcome=_op_outcome,
                     rule_name=vulnerability.rule_name,
                     language=lang or "unknown",
                     source="runtime",
+                    severity=_severity,
+                )
+                smartfix_metrics.record_vulnerability_tokens(
+                    input_tokens=_total_in,
+                    output_tokens=_total_out,
+                    rule_name=vulnerability.rule_name,
+                    language=lang or "unknown",
+                    severity=_severity,
                 )
 
     # Calculate total runtime

--- a/src/main.py
+++ b/src/main.py
@@ -364,6 +364,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
         _op_outcome = "failure"
         _op_fix_start = time.monotonic()
 
+        smartfix_metrics.set_current_rule_name(vulnerability.rule_name)
         with otel_provider.start_span("fix-vulnerability") as op_span:
             op_span.set_attribute("contrast.finding.fingerprint", vulnerability.uuid)
             op_span.set_attribute("contrast.finding.source", "runtime")

--- a/src/main.py
+++ b/src/main.py
@@ -69,6 +69,9 @@ def main():
     # Use lists so _main_impl can mutate them and the finally block sees the
     # correct value even when _main_impl exits via error_exit()/sys.exit().
     vuln_count = [0]
+    # Only counts PRs created by the SmartFix-internal agent.  External-agent
+    # runs (Copilot, Claude Code) create their PR asynchronously after the
+    # GitHub Issue is filed, so they are not reflected here.
     prs_created_count = [0]
     try:
         with otel_provider.start_span("smartfix-run") as run_span:
@@ -82,7 +85,7 @@ def main():
         otel_provider.shutdown_otel()
 
 
-def _main_impl(vuln_count, prs_created_count):  # noqa: C901
+def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # noqa: C901
     """Main orchestration logic."""
 
     start_time = datetime.now()
@@ -197,6 +200,7 @@ def _main_impl(vuln_count, prs_created_count):  # noqa: C901
 
     while True:
         telemetry_handler.reset_vuln_specific_telemetry()
+        smartfix_metrics.reset_vuln_token_accumulator()
         # Check if we've exceeded the maximum runtime
         current_time = datetime.now()
         elapsed_time = current_time - start_time
@@ -346,7 +350,6 @@ def _main_impl(vuln_count, prs_created_count):  # noqa: C901
         # Update tracking variable now that we know we're actually processing this vuln
         previous_vuln_uuid = vuln_uuid
         vuln_count[0] += 1
-        smartfix_metrics.reset_vuln_token_accumulator()
 
         log(f"\n\033[0;33m Selected vuln to fix: {vuln_title} \033[0m")
 

--- a/src/main.py
+++ b/src/main.py
@@ -710,13 +710,6 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                     source="runtime",
                     severity=_severity,
                 )
-                smartfix_metrics.record_vulnerability_tokens(
-                    input_tokens=_total_in,
-                    output_tokens=_total_out,
-                    rule_name=vulnerability.rule_name,
-                    language=lang or "unknown",
-                    severity=_severity,
-                )
 
     # Calculate total runtime
     end_time = datetime.now()

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -181,6 +181,9 @@ def handle_merged_pr():
     config = get_config()
     telemetry_handler.initialize_telemetry()
     otel_provider.initialize_otel(config)
+    # atexit guard ensures flush even when sys.exit() is called deep in a
+    # helper.  The explicit finally below handles normal flow; shutdown_otel
+    # is idempotent (guarded by _shutdown_called) so double-calling is safe.
     atexit.register(otel_provider.shutdown_otel)
 
     log("--- Handling Merged Contrast AI SmartFix Pull Request ---")

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -188,23 +188,20 @@ def handle_merged_pr():
 
     log("--- Handling Merged Contrast AI SmartFix Pull Request ---")
 
-    # Load and validate event before starting the span so non-merge events
-    # don't produce a smartfix-merge span with pr_merged=true.
+    # Validate event and extract all identifiers before opening the span so that
+    # sys.exit() in any helper does not flush a merge span with pr_merged=true
+    # but without remediation_id / fingerprint (which creates uncorrelatable events).
     event_data = _load_github_event()
     pull_request = _validate_pr_event(event_data)
+    remediation_id, labels = _extract_remediation_info(pull_request)
+    vuln_uuid = _extract_vulnerability_info(labels)
 
     try:
         with otel_provider.start_span("smartfix-merge") as merge_span:
             merge_span.set_attribute("contrast.smartfix.pr_merged", True)
-
-            # Extract remediation and vulnerability information
-            remediation_id, labels = _extract_remediation_info(pull_request)
-            vuln_uuid = _extract_vulnerability_info(labels)
-
             merge_span.set_attribute("contrast.smartfix.remediation_id", remediation_id)
             merge_span.set_attribute("contrast.finding.fingerprint", vuln_uuid)
 
-            # Update telemetry with extracted information
             debug_log(f"Extracted Remediation ID: {remediation_id}")
             telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)
             telemetry_handler.update_telemetry("vulnInfo.vulnId", vuln_uuid)

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -188,13 +188,14 @@ def handle_merged_pr():
 
     log("--- Handling Merged Contrast AI SmartFix Pull Request ---")
 
+    # Load and validate event before starting the span so non-merge events
+    # don't produce a smartfix-merge span with pr_merged=true.
+    event_data = _load_github_event()
+    pull_request = _validate_pr_event(event_data)
+
     try:
         with otel_provider.start_span("smartfix-merge") as merge_span:
             merge_span.set_attribute("contrast.smartfix.pr_merged", True)
-
-            # Load and validate GitHub event data
-            event_data = _load_github_event()
-            pull_request = _validate_pr_event(event_data)
 
             # Extract remediation and vulnerability information
             remediation_id, labels = _extract_remediation_info(pull_request)

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -181,27 +181,26 @@ def handle_merged_pr():
     config = get_config()
     telemetry_handler.initialize_telemetry()
     otel_provider.initialize_otel(config)
-    # atexit guard ensures flush even when sys.exit() is called deep in a
-    # helper.  The explicit finally below handles normal flow; shutdown_otel
-    # is idempotent (guarded by _shutdown_called) so double-calling is safe.
     atexit.register(otel_provider.shutdown_otel)
 
     log("--- Handling Merged Contrast AI SmartFix Pull Request ---")
 
-    # Validate event and extract all identifiers before opening the span so that
-    # sys.exit() in any helper does not flush a merge span with pr_merged=true
-    # but without remediation_id / fingerprint (which creates uncorrelatable events).
-    event_data = _load_github_event()
-    pull_request = _validate_pr_event(event_data)
-    remediation_id, labels = _extract_remediation_info(pull_request)
-    vuln_uuid = _extract_vulnerability_info(labels)
-
     try:
         with otel_provider.start_span("smartfix-merge") as merge_span:
             merge_span.set_attribute("contrast.smartfix.pr_merged", True)
+
+            # Load and validate GitHub event data
+            event_data = _load_github_event()
+            pull_request = _validate_pr_event(event_data)
+
+            # Extract remediation and vulnerability information
+            remediation_id, labels = _extract_remediation_info(pull_request)
+            vuln_uuid = _extract_vulnerability_info(labels)
+
             merge_span.set_attribute("contrast.smartfix.remediation_id", remediation_id)
             merge_span.set_attribute("contrast.finding.fingerprint", vuln_uuid)
 
+            # Update telemetry with extracted information
             debug_log(f"Extracted Remediation ID: {remediation_id}")
             telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)
             telemetry_handler.update_telemetry("vulnInfo.vulnId", vuln_uuid)

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -28,6 +28,7 @@ from src.config import get_config  # Using get_config function instead of direct
 from src.utils import debug_log, extract_remediation_id_from_branch, extract_remediation_id_from_labels, log
 from src.github.github_operations import GitHubOperations
 from src.smartfix.domains.telemetry import otel_provider, telemetry_handler
+from src.smartfix.domains.telemetry import smartfix_metrics
 
 
 def _load_github_event() -> dict:
@@ -201,6 +202,8 @@ def handle_merged_pr():
             merge_span.set_attribute("contrast.smartfix.pr_merged", True)
             merge_span.set_attribute("contrast.smartfix.remediation_id", remediation_id)
             merge_span.set_attribute("contrast.finding.fingerprint", vuln_uuid)
+
+            smartfix_metrics.record_pr_merged(coding_agent=config.CODING_AGENT.lower())
 
             debug_log(f"Extracted Remediation ID: {remediation_id}")
             telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -55,7 +55,6 @@ _METER_NAME = "smartfix"
 
 # --- Lazy instrument handles ---
 _vulnerability_duration_histogram = None
-_vulnerability_tokens_histogram = None
 _pr_count_counter = None
 _pr_merged_counter = None
 _tokens_total_counter = None
@@ -87,17 +86,6 @@ def _get_vulnerability_duration_histogram():
             description="End-to-end time to process each vulnerability fix attempt.",
         )
     return _vulnerability_duration_histogram
-
-
-def _get_vulnerability_tokens_histogram():
-    global _vulnerability_tokens_histogram
-    if _vulnerability_tokens_histogram is None:
-        _vulnerability_tokens_histogram = otel_provider.get_meter(_METER_NAME).create_histogram(
-            name="smartfix.vulnerability.tokens",
-            unit="{token}",
-            description="Total LLM tokens consumed per vulnerability fix attempt.",
-        )
-    return _vulnerability_tokens_histogram
 
 
 def _get_pr_count_counter():
@@ -225,37 +213,6 @@ def record_vulnerability_duration(
         if severity:
             attrs["severity"] = severity
         _get_vulnerability_duration_histogram().record(elapsed_s, attrs)
-    except Exception:
-        pass
-
-
-def record_vulnerability_tokens(
-    input_tokens: int, output_tokens: int, rule_name: str, language: Optional[str],
-    severity: Optional[str] = None,
-) -> None:
-    """Record total LLM token consumption for a single vulnerability fix attempt.
-
-    Emitted once per vulnerability (after all LLM calls complete) so that
-    Munir's datalake can compute average token cost per rule/language/severity
-    without needing per-invocation span data.
-
-    Args:
-        input_tokens: Total input tokens (new + cache) across all LLM calls.
-        output_tokens: Total output tokens across all LLM calls.
-        rule_name: Contrast rule name.
-        language: Programming language detected for this app.
-        severity: Vulnerability severity.
-    """
-    try:
-        attrs = {
-            "rule_name": rule_name,
-            "language": language or "unknown",
-        }
-        if severity:
-            attrs["severity"] = severity
-        hist = _get_vulnerability_tokens_histogram()
-        hist.record(input_tokens, {**attrs, "gen_ai.token.type": "input"})
-        hist.record(output_tokens, {**attrs, "gen_ai.token.type": "output"})
     except Exception:
         pass
 

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -183,6 +183,10 @@ def record_vulnerability_duration(
 def record_pr_attempt(outcome: str, rule_name: str, coding_agent: str) -> None:
     """Record a PR creation attempt.
 
+    Note for dashboard consumers: this counter reflects only PRs created by the
+    internal SmartFix agent. External-agent PRs (Copilot, Claude Code) are not
+    counted here, though they may produce merge spans via handle_merged_pr().
+
     Args:
         outcome: "success" or "failure".
         rule_name: Contrast rule name.

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -36,6 +36,15 @@ Per-LLM-call (emitted from smartfix_litellm.py):
 Per-vulnerability (emitted from main.py):
   smartfix.vulnerability.duration  histogram(s)  end-to-end fix latency
   smartfix.pr.count                counter       PR creation attempts
+
+Per-vulnerability token accumulator
+------------------------------------
+Module-level integers (_vuln_input_tokens, _vuln_output_tokens) that are
+reset via reset_vuln_token_accumulator() at the start of each vulnerability
+loop iteration, and incremented by record_llm_call_tokens() on every LLM call.
+Call get_vuln_token_totals() in the fix-vulnerability span's finally block to
+attach total token usage as span attributes.  Accumulation happens outside the
+OTel try/except so a failed counter write never silently zeroes the totals.
 """
 
 from typing import Optional
@@ -139,7 +148,7 @@ def reset_vuln_token_accumulator() -> None:
     _vuln_output_tokens = 0
 
 
-def get_vuln_token_totals() -> tuple:
+def get_vuln_token_totals() -> tuple[int, int]:
     """Return (total_input_tokens, total_output_tokens) accumulated for the current vulnerability."""
     return _vuln_input_tokens, _vuln_output_tokens
 
@@ -206,9 +215,13 @@ def record_llm_call_tokens(
         model: LiteLLM model string (e.g. "contrast/claude-sonnet-4-5").
     """
     global _vuln_input_tokens, _vuln_output_tokens
+    total_input = input_tokens + cache_read_tokens + cache_write_tokens
+    # Accumulate outside the try block so that a failure in the OTel counter
+    # (e.g. meter not yet initialised) never silently zeroes the per-vulnerability totals.
+    _vuln_input_tokens += total_input
+    _vuln_output_tokens += output_tokens
     try:
         total_counter = _get_tokens_total_counter()
-        total_input = input_tokens + cache_read_tokens + cache_write_tokens
         total_counter.add(total_input, {"gen_ai.token.type": "input", "gen_ai.request.model": model})
         total_counter.add(output_tokens, {"gen_ai.token.type": "output", "gen_ai.request.model": model})
 
@@ -218,9 +231,6 @@ def record_llm_call_tokens(
                 cache_counter.add(cache_read_tokens, {"gen_ai.token.type": "read", "gen_ai.request.model": model})
             if cache_write_tokens:
                 cache_counter.add(cache_write_tokens, {"gen_ai.token.type": "write", "gen_ai.request.model": model})
-
-        _vuln_input_tokens += total_input
-        _vuln_output_tokens += output_tokens
     except Exception:
         pass
 

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -36,15 +36,6 @@ Per-LLM-call (emitted from smartfix_litellm.py):
 Per-vulnerability (emitted from main.py):
   smartfix.vulnerability.duration  histogram(s)  end-to-end fix latency
   smartfix.pr.count                counter       PR creation attempts
-
-Per-vulnerability token accumulator
-------------------------------------
-Module-level integers (_vuln_input_tokens, _vuln_output_tokens) that are
-reset via reset_vuln_token_accumulator() at the start of each vulnerability
-loop iteration, and incremented by record_llm_call_tokens() on every LLM call.
-Call get_vuln_token_totals() in the fix-vulnerability span's finally block to
-attach total token usage as span attributes.  Accumulation happens outside the
-OTel try/except so a failed counter write never silently zeroes the totals.
 """
 
 from typing import Optional
@@ -148,7 +139,7 @@ def reset_vuln_token_accumulator() -> None:
     _vuln_output_tokens = 0
 
 
-def get_vuln_token_totals() -> tuple[int, int]:
+def get_vuln_token_totals() -> tuple:
     """Return (total_input_tokens, total_output_tokens) accumulated for the current vulnerability."""
     return _vuln_input_tokens, _vuln_output_tokens
 
@@ -183,10 +174,6 @@ def record_vulnerability_duration(
 def record_pr_attempt(outcome: str, rule_name: str, coding_agent: str) -> None:
     """Record a PR creation attempt.
 
-    Note for dashboard consumers: this counter reflects only PRs created by the
-    internal SmartFix agent. External-agent PRs (Copilot, Claude Code) are not
-    counted here, though they may produce merge spans via handle_merged_pr().
-
     Args:
         outcome: "success" or "failure".
         rule_name: Contrast rule name.
@@ -219,13 +206,9 @@ def record_llm_call_tokens(
         model: LiteLLM model string (e.g. "contrast/claude-sonnet-4-5").
     """
     global _vuln_input_tokens, _vuln_output_tokens
-    total_input = input_tokens + cache_read_tokens + cache_write_tokens
-    # Accumulate outside the try block so that a failure in the OTel counter
-    # (e.g. meter not yet initialised) never silently zeroes the per-vulnerability totals.
-    _vuln_input_tokens += total_input
-    _vuln_output_tokens += output_tokens
     try:
         total_counter = _get_tokens_total_counter()
+        total_input = input_tokens + cache_read_tokens + cache_write_tokens
         total_counter.add(total_input, {"gen_ai.token.type": "input", "gen_ai.request.model": model})
         total_counter.add(output_tokens, {"gen_ai.token.type": "output", "gen_ai.request.model": model})
 
@@ -235,6 +218,9 @@ def record_llm_call_tokens(
                 cache_counter.add(cache_read_tokens, {"gen_ai.token.type": "read", "gen_ai.request.model": model})
             if cache_write_tokens:
                 cache_counter.add(cache_write_tokens, {"gen_ai.token.type": "write", "gen_ai.request.model": model})
+
+        _vuln_input_tokens += total_input
+        _vuln_output_tokens += output_tokens
     except Exception:
         pass
 

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -56,6 +56,7 @@ _METER_NAME = "smartfix"
 # --- Lazy instrument handles ---
 _vulnerability_duration_histogram = None
 _pr_count_counter = None
+_pr_merged_counter = None
 _tokens_total_counter = None
 _cache_tokens_counter = None
 _llm_duration_histogram = None
@@ -65,6 +66,11 @@ _llm_retries_counter = None
 # Reset at the start of each vulnerability; read in the fix-vulnerability span finally block.
 _vuln_input_tokens: int = 0
 _vuln_output_tokens: int = 0
+
+# --- Current vulnerability rule name ---
+# Set once per vulnerability loop iteration so that record_llm_call_tokens() can attach
+# rule_id to token counters without requiring it to be threaded through every LLM callback.
+_current_rule_name: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +97,17 @@ def _get_pr_count_counter():
             description="Number of PR creation attempts.",
         )
     return _pr_count_counter
+
+
+def _get_pr_merged_counter():
+    global _pr_merged_counter
+    if _pr_merged_counter is None:
+        _pr_merged_counter = otel_provider.get_meter(_METER_NAME).create_counter(
+            name="smartfix.pr.merged",
+            unit="{pr}",
+            description="Number of SmartFix PRs merged.",
+        )
+    return _pr_merged_counter
 
 
 def _get_tokens_total_counter():
@@ -142,10 +159,25 @@ def _get_llm_retries_counter():
 # ---------------------------------------------------------------------------
 
 def reset_vuln_token_accumulator() -> None:
-    """Reset per-vulnerability token counters. Call at the start of each vulnerability loop."""
-    global _vuln_input_tokens, _vuln_output_tokens
+    """Reset per-vulnerability token counters and rule name. Call at the start of each vulnerability loop."""
+    global _vuln_input_tokens, _vuln_output_tokens, _current_rule_name
     _vuln_input_tokens = 0
     _vuln_output_tokens = 0
+    _current_rule_name = ""
+
+
+def set_current_rule_name(rule_name: str) -> None:
+    """Set the rule name for the vulnerability currently being processed.
+
+    Called once per vulnerability loop iteration so that record_llm_call_tokens()
+    can attach rule_id to smartfix.tokens.total and smartfix.cache.tokens without
+    requiring rule_name to be threaded through every LLM callback.
+
+    Args:
+        rule_name: Contrast rule identifier (e.g. "sql-injection").
+    """
+    global _current_rule_name
+    _current_rule_name = rule_name
 
 
 def get_vuln_token_totals() -> tuple[int, int]:
@@ -225,16 +257,23 @@ def record_llm_call_tokens(
     _vuln_input_tokens += total_input
     _vuln_output_tokens += output_tokens
     try:
+        # rule_id is required by the datalake schema for per-rule cost attribution.
+        # It is set via set_current_rule_name() at the start of each vulnerability loop
+        # iteration and read here, since LiteLLM callbacks don't carry vulnerability context.
+        token_attrs = {"gen_ai.request.model": model}
+        if _current_rule_name:
+            token_attrs["rule_id"] = _current_rule_name
+
         total_counter = _get_tokens_total_counter()
-        total_counter.add(total_input, {"gen_ai.token.type": "input", "gen_ai.request.model": model})
-        total_counter.add(output_tokens, {"gen_ai.token.type": "output", "gen_ai.request.model": model})
+        total_counter.add(total_input, {**token_attrs, "gen_ai.token.type": "input"})
+        total_counter.add(output_tokens, {**token_attrs, "gen_ai.token.type": "output"})
 
         if cache_read_tokens or cache_write_tokens:
             cache_counter = _get_cache_tokens_counter()
             if cache_read_tokens:
-                cache_counter.add(cache_read_tokens, {"gen_ai.token.type": "read", "gen_ai.request.model": model})
+                cache_counter.add(cache_read_tokens, {**token_attrs, "gen_ai.token.type": "cache_read"})
             if cache_write_tokens:
-                cache_counter.add(cache_write_tokens, {"gen_ai.token.type": "write", "gen_ai.request.model": model})
+                cache_counter.add(cache_write_tokens, {**token_attrs, "gen_ai.token.type": "cache_creation"})
     except Exception:
         pass
 
@@ -252,6 +291,21 @@ def record_llm_duration(elapsed_s: float, provider_name: str, model: str) -> Non
             "gen_ai.provider.name": provider_name,
             "gen_ai.request.model": model,
         })
+    except Exception:
+        pass
+
+
+def record_pr_merged(coding_agent: str) -> None:
+    """Record a SmartFix PR merge event as a metric.
+
+    Emits smartfix.pr.merged so the datalake can track merge volume independently
+    from PR creation attempts (smartfix.pr.count).
+
+    Args:
+        coding_agent: Coding agent identifier (e.g. "smartfix", "github_copilot").
+    """
+    try:
+        _get_pr_merged_counter().add(1, {"coding_agent": coding_agent})
     except Exception:
         pass
 

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -55,6 +55,7 @@ _METER_NAME = "smartfix"
 
 # --- Lazy instrument handles ---
 _vulnerability_duration_histogram = None
+_vulnerability_tokens_histogram = None
 _pr_count_counter = None
 _pr_merged_counter = None
 _tokens_total_counter = None
@@ -86,6 +87,17 @@ def _get_vulnerability_duration_histogram():
             description="End-to-end time to process each vulnerability fix attempt.",
         )
     return _vulnerability_duration_histogram
+
+
+def _get_vulnerability_tokens_histogram():
+    global _vulnerability_tokens_histogram
+    if _vulnerability_tokens_histogram is None:
+        _vulnerability_tokens_histogram = otel_provider.get_meter(_METER_NAME).create_histogram(
+            name="smartfix.vulnerability.tokens",
+            unit="{token}",
+            description="Total LLM tokens consumed per vulnerability fix attempt.",
+        )
+    return _vulnerability_tokens_histogram
 
 
 def _get_pr_count_counter():
@@ -191,6 +203,7 @@ def get_vuln_token_totals() -> tuple[int, int]:
 
 def record_vulnerability_duration(
     elapsed_s: float, outcome: str, rule_name: str, language: Optional[str], source: str,
+    severity: Optional[str] = None,
 ) -> None:
     """Record end-to-end vulnerability fix duration.
 
@@ -200,14 +213,49 @@ def record_vulnerability_duration(
         rule_name: Contrast rule name (e.g. "sql-injection").
         language: Programming language detected for this app.
         source: Finding source (e.g. "runtime").
+        severity: Vulnerability severity (e.g. "CRITICAL", "HIGH").
     """
     try:
-        _get_vulnerability_duration_histogram().record(elapsed_s, {
+        attrs = {
             "outcome": outcome,
             "rule_name": rule_name,
             "language": language or "unknown",
             "source": source,
-        })
+        }
+        if severity:
+            attrs["severity"] = severity
+        _get_vulnerability_duration_histogram().record(elapsed_s, attrs)
+    except Exception:
+        pass
+
+
+def record_vulnerability_tokens(
+    input_tokens: int, output_tokens: int, rule_name: str, language: Optional[str],
+    severity: Optional[str] = None,
+) -> None:
+    """Record total LLM token consumption for a single vulnerability fix attempt.
+
+    Emitted once per vulnerability (after all LLM calls complete) so that
+    Munir's datalake can compute average token cost per rule/language/severity
+    without needing per-invocation span data.
+
+    Args:
+        input_tokens: Total input tokens (new + cache) across all LLM calls.
+        output_tokens: Total output tokens across all LLM calls.
+        rule_name: Contrast rule name.
+        language: Programming language detected for this app.
+        severity: Vulnerability severity.
+    """
+    try:
+        attrs = {
+            "rule_name": rule_name,
+            "language": language or "unknown",
+        }
+        if severity:
+            attrs["severity"] = severity
+        hist = _get_vulnerability_tokens_histogram()
+        hist.record(input_tokens, {**attrs, "gen_ai.token.type": "input"})
+        hist.record(output_tokens, {**attrs, "gen_ai.token.type": "output"})
     except Exception:
         pass
 

--- a/test/test_otel_spans.py
+++ b/test/test_otel_spans.py
@@ -460,6 +460,27 @@ class TestSmartFixMergeSpan(unittest.TestCase):
         spans = _spans_named(self.exporter, "smartfix-merge")
         self.assertEqual(spans[0].attributes["contrast.finding.fingerprint"], "vuln-abc123")
 
+    @patch('src.merge_handler.otel_provider.shutdown_otel')
+    @patch('src.merge_handler.atexit.register')
+    @patch('src.merge_handler.otel_provider.initialize_otel')
+    @patch('src.smartfix.domains.telemetry.telemetry_handler.initialize_telemetry')
+    @patch('src.merge_handler._validate_pr_event')
+    @patch('src.merge_handler._load_github_event')
+    @patch('src.merge_handler._extract_remediation_info', side_effect=SystemExit(1))
+    def test_no_merge_span_when_extraction_fails(
+        self, _mock_extract, mock_load, mock_validate,
+        _mock_init_tel, _mock_init_otel, _mock_atexit, _mock_shutdown
+    ):
+        """Extraction failure before start_span must produce zero smartfix-merge spans."""
+        mock_load.return_value = {}
+        mock_validate.return_value = {"merged": True}
+
+        with self.assertRaises(SystemExit):
+            import src.merge_handler as merge_handler
+            merge_handler.handle_merged_pr()
+
+        self.assertEqual(len(_spans_named(self.exporter, "smartfix-merge")), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_otel_spans.py
+++ b/test/test_otel_spans.py
@@ -38,7 +38,7 @@ Span hierarchy:
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -352,16 +352,16 @@ class TestLlmCallSpan(unittest.TestCase):
         import src.smartfix.domains.telemetry.otel_provider as otel_provider
         from src.smartfix.extensions.smartfix_litellm import SmartFixLiteLlm
 
-        mock_instance = Mock(spec=SmartFixLiteLlm)
+        mock_instance = MagicMock(spec=SmartFixLiteLlm)
         mock_instance._max_retries = 1
         mock_instance._initial_retry_delay = 0
         mock_instance._retry_multiplier = 2
         mock_instance._is_retryable_exception = lambda e: False
         mock_instance._log_cost_analysis.return_value = (10, 5, 0, 0)
-        mock_instance.llm_client = Mock()
+        mock_instance.llm_client = MagicMock()
         mock_instance._otel_context = None  # use ambient context (fix-vulnerability is current)
 
-        mock_response = Mock()
+        mock_response = MagicMock()
         mock_response.model = "test-model"
         mock_instance.llm_client.acompletion = AsyncMock(return_value=mock_response)
 
@@ -392,16 +392,16 @@ class TestLlmCallSpan(unittest.TestCase):
         """Token counts from _log_cost_analysis() are set on the LLM span."""
         from src.smartfix.extensions.smartfix_litellm import SmartFixLiteLlm
 
-        mock_instance = Mock(spec=SmartFixLiteLlm)
+        mock_instance = MagicMock(spec=SmartFixLiteLlm)
         mock_instance._max_retries = 1
         mock_instance._initial_retry_delay = 0
         mock_instance._retry_multiplier = 2
         mock_instance._is_retryable_exception = lambda e: False
         mock_instance._log_cost_analysis.return_value = (200, 80, 0, 0)
-        mock_instance.llm_client = Mock()
+        mock_instance.llm_client = MagicMock()
         mock_instance._otel_context = None
 
-        mock_response = Mock()
+        mock_response = MagicMock()
         mock_response.model = "usage-model"
         mock_instance.llm_client.acompletion = AsyncMock(return_value=mock_response)
 
@@ -459,27 +459,6 @@ class TestSmartFixMergeSpan(unittest.TestCase):
         self._emit_merge_span(vuln_uuid="vuln-abc123")
         spans = _spans_named(self.exporter, "smartfix-merge")
         self.assertEqual(spans[0].attributes["contrast.finding.fingerprint"], "vuln-abc123")
-
-    @patch('src.merge_handler.otel_provider.shutdown_otel')
-    @patch('src.merge_handler.atexit.register')
-    @patch('src.merge_handler.otel_provider.initialize_otel')
-    @patch('src.smartfix.domains.telemetry.telemetry_handler.initialize_telemetry')
-    @patch('src.merge_handler._validate_pr_event')
-    @patch('src.merge_handler._load_github_event')
-    @patch('src.merge_handler._extract_remediation_info', side_effect=SystemExit(1))
-    def test_no_merge_span_when_extraction_fails(
-        self, _mock_extract, mock_load, mock_validate,
-        _mock_init_tel, _mock_init_otel, _mock_atexit, _mock_shutdown
-    ):
-        """Extraction failure before start_span must produce zero smartfix-merge spans."""
-        mock_load.return_value = {}
-        mock_validate.return_value = {"merged": True}
-
-        with self.assertRaises(SystemExit):
-            import src.merge_handler as merge_handler
-            merge_handler.handle_merged_pr()
-
-        self.assertEqual(len(_spans_named(self.exporter, "smartfix-merge")), 0)
 
 
 if __name__ == "__main__":

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -159,54 +159,6 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
         m.record_vulnerability_duration(1.0, "success", "sql-injection", "java", "runtime")
 
 
-class TestRecordVulnerabilityTokens(unittest.TestCase):
-
-    def setUp(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_histogram = MagicMock()
-        m._vulnerability_tokens_histogram = self.mock_histogram
-
-    def tearDown(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m._vulnerability_tokens_histogram = None
-
-    def test_records_input_and_output_separately(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.record_vulnerability_tokens(100, 50, "sql-injection", "java")
-
-        calls = self.mock_histogram.record.call_args_list
-        self.assertEqual(len(calls), 2)
-        token_types = {c[0][1]["gen_ai.token.type"] for c in calls}
-        self.assertEqual(token_types, {"input", "output"})
-
-    def test_includes_severity_when_provided(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.record_vulnerability_tokens(100, 50, "xss", "java", severity="HIGH")
-
-        for call in self.mock_histogram.record.call_args_list:
-            self.assertEqual(call[0][1]["severity"], "HIGH")
-
-    def test_omits_severity_when_not_provided(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.record_vulnerability_tokens(100, 50, "xss", "java")
-
-        for call in self.mock_histogram.record.call_args_list:
-            self.assertNotIn("severity", call[0][1])
-
-    def test_uses_unknown_for_missing_language(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.record_vulnerability_tokens(100, 50, "xss", None)
-
-        for call in self.mock_histogram.record.call_args_list:
-            self.assertEqual(call[0][1]["language"], "unknown")
-
-    def test_suppresses_instrument_errors(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_histogram.record.side_effect = RuntimeError("otel broken")
-        # Must not raise.
-        m.record_vulnerability_tokens(100, 50, "xss", "java")
-
-
 class TestRecordPrAttempt(unittest.TestCase):
 
     def setUp(self):

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -278,11 +278,15 @@ class TestVulnTokenAccumulator(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
+        self._m = m
+        self._orig_total = m._tokens_total_counter
+        self._orig_cache = m._cache_tokens_counter
         m.reset_vuln_token_accumulator()
 
     def tearDown(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.reset_vuln_token_accumulator()
+        self._m._tokens_total_counter = self._orig_total
+        self._m._cache_tokens_counter = self._orig_cache
+        self._m.reset_vuln_token_accumulator()
 
     def test_reset_clears_counts(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -214,8 +214,8 @@ class TestRecordLlmCallTokens(unittest.TestCase):
 
         cache_calls = self.mock_cache.add.call_args_list
         token_types = {c[0][1]["gen_ai.token.type"] for c in cache_calls}
-        self.assertIn("read", token_types)
-        self.assertIn("write", token_types)
+        self.assertIn("cache_read", token_types)
+        self.assertIn("cache_creation", token_types)
 
     def test_skips_cache_counter_when_no_cache_tokens(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
@@ -295,6 +295,55 @@ class TestVulnTokenAccumulator(unittest.TestCase):
         m.reset_vuln_token_accumulator()
         self.assertEqual(m._vuln_input_tokens, 0)
         self.assertEqual(m._vuln_output_tokens, 0)
+
+    def test_reset_clears_rule_name(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.set_current_rule_name("sql-injection")
+        m.reset_vuln_token_accumulator()
+        self.assertEqual(m._current_rule_name, "")
+
+    def test_set_current_rule_name(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.set_current_rule_name("xss")
+        self.assertEqual(m._current_rule_name, "xss")
+
+    def test_token_counter_includes_rule_id_when_set(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        mock_total = MagicMock()
+        mock_cache = MagicMock()
+        m._tokens_total_counter = mock_total
+        m._cache_tokens_counter = mock_cache
+        m.set_current_rule_name("sql-injection")
+
+        m.record_llm_call_tokens(10, 5, 0, 0, "model-a")
+
+        call_kwargs = mock_total.add.call_args_list[0][0][1]
+        self.assertEqual(call_kwargs["rule_id"], "sql-injection")
+
+    def test_token_counter_omits_rule_id_when_not_set(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        mock_total = MagicMock()
+        mock_cache = MagicMock()
+        m._tokens_total_counter = mock_total
+        m._cache_tokens_counter = mock_cache
+
+        m.record_llm_call_tokens(10, 5, 0, 0, "model-a")
+
+        call_kwargs = mock_total.add.call_args_list[0][0][1]
+        self.assertNotIn("rule_id", call_kwargs)
+
+    def test_cache_token_type_labels_match_spec(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        mock_total = MagicMock()
+        mock_cache = MagicMock()
+        m._tokens_total_counter = mock_total
+        m._cache_tokens_counter = mock_cache
+
+        m.record_llm_call_tokens(0, 0, 30, 20, "model-a")
+
+        types = {call[0][1]["gen_ai.token.type"] for call in mock_cache.add.call_args_list}
+        self.assertIn("cache_read", types)
+        self.assertIn("cache_creation", types)
 
     def test_get_totals_returns_zero_after_reset(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -131,6 +131,20 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
             "source": "runtime",
         })
 
+    def test_includes_severity_when_provided(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_duration(2.5, "success", "sql-injection", "java", "runtime", severity="CRITICAL")
+
+        attrs = self.mock_histogram.record.call_args[0][1]
+        self.assertEqual(attrs["severity"], "CRITICAL")
+
+    def test_omits_severity_when_not_provided(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_duration(2.5, "success", "sql-injection", "java", "runtime")
+
+        attrs = self.mock_histogram.record.call_args[0][1]
+        self.assertNotIn("severity", attrs)
+
     def test_uses_unknown_for_missing_language(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
         m.record_vulnerability_duration(1.0, "failure", "xss", None, "runtime")
@@ -143,6 +157,54 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
         self.mock_histogram.record.side_effect = RuntimeError("otel broken")
         # Must not raise.
         m.record_vulnerability_duration(1.0, "success", "sql-injection", "java", "runtime")
+
+
+class TestRecordVulnerabilityTokens(unittest.TestCase):
+
+    def setUp(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        self.mock_histogram = MagicMock()
+        m._vulnerability_tokens_histogram = self.mock_histogram
+
+    def tearDown(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m._vulnerability_tokens_histogram = None
+
+    def test_records_input_and_output_separately(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_tokens(100, 50, "sql-injection", "java")
+
+        calls = self.mock_histogram.record.call_args_list
+        self.assertEqual(len(calls), 2)
+        token_types = {c[0][1]["gen_ai.token.type"] for c in calls}
+        self.assertEqual(token_types, {"input", "output"})
+
+    def test_includes_severity_when_provided(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_tokens(100, 50, "xss", "java", severity="HIGH")
+
+        for call in self.mock_histogram.record.call_args_list:
+            self.assertEqual(call[0][1]["severity"], "HIGH")
+
+    def test_omits_severity_when_not_provided(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_tokens(100, 50, "xss", "java")
+
+        for call in self.mock_histogram.record.call_args_list:
+            self.assertNotIn("severity", call[0][1])
+
+    def test_uses_unknown_for_missing_language(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_tokens(100, 50, "xss", None)
+
+        for call in self.mock_histogram.record.call_args_list:
+            self.assertEqual(call[0][1]["language"], "unknown")
+
+    def test_suppresses_instrument_errors(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        self.mock_histogram.record.side_effect = RuntimeError("otel broken")
+        # Must not raise.
+        m.record_vulnerability_tokens(100, 50, "xss", "java")
 
 
 class TestRecordPrAttempt(unittest.TestCase):

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -29,9 +29,7 @@ These tests verify that:
 """
 
 import unittest
-from unittest.mock import Mock, patch, MagicMock
-
-from opentelemetry.metrics import Counter, Histogram, Meter
+from unittest.mock import MagicMock, patch
 
 
 class TestLazyInitialisation(unittest.TestCase):
@@ -58,8 +56,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_vulnerability_duration_histogram_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_histogram = Mock(spec=Histogram)
-        mock_meter = Mock(spec=Meter)
+        mock_histogram = MagicMock()
+        mock_meter = MagicMock()
         mock_meter.create_histogram.return_value = mock_histogram
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -73,8 +71,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_pr_count_counter_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_counter = Mock(spec=Counter)
-        mock_meter = Mock(spec=Meter)
+        mock_counter = MagicMock()
+        mock_meter = MagicMock()
         mock_meter.create_counter.return_value = mock_counter
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -88,8 +86,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_llm_duration_histogram_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_histogram = Mock(spec=Histogram)
-        mock_meter = Mock(spec=Meter)
+        mock_histogram = MagicMock()
+        mock_meter = MagicMock()
         mock_meter.create_histogram.return_value = mock_histogram
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -102,8 +100,8 @@ class TestLazyInitialisation(unittest.TestCase):
 
     def test_llm_retries_counter_created_on_first_call(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        mock_counter = Mock(spec=Counter)
-        mock_meter = Mock(spec=Meter)
+        mock_counter = MagicMock()
+        mock_meter = MagicMock()
         mock_meter.create_counter.return_value = mock_counter
 
         with patch("src.smartfix.domains.telemetry.smartfix_metrics.otel_provider") as mock_provider:
@@ -119,7 +117,7 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_histogram = Mock(spec=Histogram)
+        self.mock_histogram = MagicMock()
         m._vulnerability_duration_histogram = self.mock_histogram
 
     def test_records_with_correct_attributes(self):
@@ -151,7 +149,7 @@ class TestRecordPrAttempt(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_counter = Mock(spec=Counter)
+        self.mock_counter = MagicMock()
         m._pr_count_counter = self.mock_counter
 
     def test_records_success(self):
@@ -184,8 +182,8 @@ class TestRecordLlmCallTokens(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_total = Mock(spec=Counter)
-        self.mock_cache = Mock(spec=Counter)
+        self.mock_total = MagicMock()
+        self.mock_cache = MagicMock()
         m._tokens_total_counter = self.mock_total
         m._cache_tokens_counter = self.mock_cache
 
@@ -235,7 +233,7 @@ class TestRecordLlmDuration(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_histogram = Mock(spec=Histogram)
+        self.mock_histogram = MagicMock()
         m._llm_duration_histogram = self.mock_histogram
 
     def test_records_with_provider_and_model(self):
@@ -257,7 +255,7 @@ class TestRecordLlmRetry(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_counter = Mock(spec=Counter)
+        self.mock_counter = MagicMock()
         m._llm_retries_counter = self.mock_counter
 
     def test_records_with_model_and_error_type(self):
@@ -280,15 +278,11 @@ class TestVulnTokenAccumulator(unittest.TestCase):
 
     def setUp(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self._m = m
-        self._orig_total = m._tokens_total_counter
-        self._orig_cache = m._cache_tokens_counter
         m.reset_vuln_token_accumulator()
 
     def tearDown(self):
-        self._m._tokens_total_counter = self._orig_total
-        self._m._cache_tokens_counter = self._orig_cache
-        self._m.reset_vuln_token_accumulator()
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.reset_vuln_token_accumulator()
 
     def test_reset_clears_counts(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m


### PR DESCRIPTION
## Jira

[AIML-794](https://contrast.atlassian.net/browse/AIML-794)

## Context

AIML-655 added new OTel span attributes for Faya's dashboard. Munir's datalake pipeline consumes OTel metrics only (`aiml.otlp-metrics.v1` Kafka topic) — span attributes are Datadog-only and were not reaching Snowflake at all.

This PR adds metric equivalents for each value so both pipelines receive the data. Span attributes are intentionally kept for Datadog (Faya's dashboard). `remediation_id` and `fingerprint` are per-invocation IDs that cannot be meaningfully aggregated — they remain span-only per Shane's spec.

## Signal coverage

| Value | Span (Datadog / Faya) | Metric (Snowflake / Munir) | Notes |
|---|---|---|---|
| `severity` | `contrast.finding.severity` on `fix-vulnerability` | `severity` label on `smartfix.vulnerability.duration` | Added in this PR |
| `total_input_tokens` per vuln | `contrast.smartfix.total_input_tokens` on `fix-vulnerability` | `smartfix.tokens.total` with `rule_id` label | Covered by existing metric with rule_id fix in this PR |
| `total_output_tokens` per vuln | `contrast.smartfix.total_output_tokens` on `fix-vulnerability` | `smartfix.tokens.total` with `rule_id` label | Covered by existing metric with rule_id fix in this PR |
| `prs_created_total` per run | `contrast.smartfix.prs_created_total` on `smartfix-run` | `smartfix.pr.count` cumulative counter, `outcome=success` | Already existed |
| `pr_merged` | `contrast.smartfix.pr_merged` on `smartfix-merge` | `smartfix.pr.merged` counter | Added in this PR |
| `rule_id` on token counters | — | `rule_id` label on `smartfix.tokens.total` and `smartfix.cache.tokens` | Added in this PR — fixes gap vs Shane's schema |
| `cache token type` labels | — | `cache_read` / `cache_creation` (was `read` / `write`) | Fixed in this PR — now matches OTel gen_ai spec |
| `remediation_id` | `contrast.smartfix.remediation_id` on `smartfix-merge` | — span only | Per-invocation ID; not aggregatable. Datadog only per Shane's spec |
| `fingerprint` | `contrast.finding.fingerprint` on `smartfix-merge` | — span only | Per-invocation ID; not aggregatable. Datadog only per Shane's spec |

## Test plan

- [ ] 969 tests pass (`make test`)
- [ ] Verify `smartfix.tokens.total` carries `rule_id` label in a live run
- [ ] Verify `smartfix.vulnerability.duration` carries `severity` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIML-794]: https://contrast.atlassian.net/browse/AIML-794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ