### PR TITLE
AIML-802: SmartFix tech debt cleanup (metrics consistency, action upgrades)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -207,7 +207,7 @@ runs:
     # Checkout with reduced verbosity (only if not already checked out)
     - name: Checkout repository
       if: steps.check_git.outputs.already_checked_out != 'true'
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
@@ -223,7 +223,7 @@ runs:
 
     # Reduce Python setup verbosity
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.13'
 
@@ -273,7 +273,7 @@ runs:
         echo ""
         echo "➡️ Setting up Node.js 22..."
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22'
         check-latest: false

--- a/src/main.py
+++ b/src/main.py
@@ -641,12 +641,21 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                 _total_in, _total_out = smartfix_metrics.get_vuln_token_totals()
                 op_span.set_attribute("contrast.smartfix.total_input_tokens", _total_in)
                 op_span.set_attribute("contrast.smartfix.total_output_tokens", _total_out)
+                _severity = vulnerability.severity.value if vulnerability.severity else None
                 smartfix_metrics.record_vulnerability_duration(
                     elapsed_s=time.monotonic() - _op_fix_start,
                     outcome=_op_outcome,
                     rule_name=vulnerability.rule_name,
                     language=lang or "unknown",
                     source="runtime",
+                    severity=_severity,
+                )
+                smartfix_metrics.record_vulnerability_tokens(
+                    input_tokens=_total_in,
+                    output_tokens=_total_out,
+                    rule_name=vulnerability.rule_name,
+                    language=lang or "unknown",
+                    severity=_severity,
                 )
 
     # Calculate total runtime

--- a/src/main.py
+++ b/src/main.py
@@ -330,6 +330,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
         _op_outcome = "failure"
         _op_fix_start = time.monotonic()
 
+        smartfix_metrics.set_current_rule_name(vulnerability.rule_name)
         with otel_provider.start_span("fix-vulnerability") as op_span:
             op_span.set_attribute("contrast.finding.fingerprint", vulnerability.uuid)
             op_span.set_attribute("contrast.finding.source", "runtime")

--- a/src/main.py
+++ b/src/main.py
@@ -650,13 +650,6 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                     source="runtime",
                     severity=_severity,
                 )
-                smartfix_metrics.record_vulnerability_tokens(
-                    input_tokens=_total_in,
-                    output_tokens=_total_out,
-                    rule_name=vulnerability.rule_name,
-                    language=lang or "unknown",
-                    severity=_severity,
-                )
 
     # Calculate total runtime
     end_time = datetime.now()

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -28,6 +28,7 @@ from src.config import get_config  # Using get_config function instead of direct
 from src.utils import debug_log, extract_remediation_id_from_branch, extract_remediation_id_from_labels, log
 from src.github.github_operations import GitHubOperations
 from src.smartfix.domains.telemetry import otel_provider, telemetry_handler
+from src.smartfix.domains.telemetry import smartfix_metrics
 
 
 def _load_github_event() -> dict:
@@ -201,6 +202,8 @@ def handle_merged_pr():
             merge_span.set_attribute("contrast.smartfix.pr_merged", True)
             merge_span.set_attribute("contrast.smartfix.remediation_id", remediation_id)
             merge_span.set_attribute("contrast.finding.fingerprint", vuln_uuid)
+
+            smartfix_metrics.record_pr_merged(coding_agent=config.CODING_AGENT.lower())
 
             debug_log(f"Extracted Remediation ID: {remediation_id}")
             telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -197,13 +197,23 @@ def handle_merged_pr():
     remediation_id, labels = _extract_remediation_info(pull_request)
     vuln_uuid = _extract_vulnerability_info(labels)
 
+    # Derive agent from branch prefix so external-agent merges (Copilot, Claude Code)
+    # are not misattributed as "smartfix" in the datalake.
+    branch_name = pull_request.get("head", {}).get("ref") or ""
+    if branch_name.startswith("claude/issue-"):
+        _merge_agent = "external-claude_code"
+    elif branch_name.startswith("copilot/fix"):
+        _merge_agent = "external-github_copilot"
+    else:
+        _merge_agent = config.CODING_AGENT.lower()
+
     try:
         with otel_provider.start_span("smartfix-merge") as merge_span:
             merge_span.set_attribute("contrast.smartfix.pr_merged", True)
             merge_span.set_attribute("contrast.smartfix.remediation_id", remediation_id)
             merge_span.set_attribute("contrast.finding.fingerprint", vuln_uuid)
 
-            smartfix_metrics.record_pr_merged(coding_agent=config.CODING_AGENT.lower())
+            smartfix_metrics.record_pr_merged(coding_agent=_merge_agent)
 
             debug_log(f"Extracted Remediation ID: {remediation_id}")
             telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -55,7 +55,6 @@ _METER_NAME = "smartfix"
 
 # --- Lazy instrument handles ---
 _vulnerability_duration_histogram = None
-_vulnerability_tokens_histogram = None
 _pr_count_counter = None
 _pr_merged_counter = None
 _tokens_total_counter = None
@@ -87,17 +86,6 @@ def _get_vulnerability_duration_histogram():
             description="End-to-end time to process each vulnerability fix attempt.",
         )
     return _vulnerability_duration_histogram
-
-
-def _get_vulnerability_tokens_histogram():
-    global _vulnerability_tokens_histogram
-    if _vulnerability_tokens_histogram is None:
-        _vulnerability_tokens_histogram = otel_provider.get_meter(_METER_NAME).create_histogram(
-            name="smartfix.vulnerability.tokens",
-            unit="{token}",
-            description="Total LLM tokens consumed per vulnerability fix attempt.",
-        )
-    return _vulnerability_tokens_histogram
 
 
 def _get_pr_count_counter():
@@ -225,37 +213,6 @@ def record_vulnerability_duration(
         if severity:
             attrs["severity"] = severity
         _get_vulnerability_duration_histogram().record(elapsed_s, attrs)
-    except Exception:
-        pass
-
-
-def record_vulnerability_tokens(
-    input_tokens: int, output_tokens: int, rule_name: str, language: Optional[str],
-    severity: Optional[str] = None,
-) -> None:
-    """Record total LLM token consumption for a single vulnerability fix attempt.
-
-    Emitted once per vulnerability (after all LLM calls complete) so that
-    Munir's datalake can compute average token cost per rule/language/severity
-    without needing per-invocation span data.
-
-    Args:
-        input_tokens: Total input tokens (new + cache) across all LLM calls.
-        output_tokens: Total output tokens across all LLM calls.
-        rule_name: Contrast rule name.
-        language: Programming language detected for this app.
-        severity: Vulnerability severity.
-    """
-    try:
-        attrs = {
-            "rule_name": rule_name,
-            "language": language or "unknown",
-        }
-        if severity:
-            attrs["severity"] = severity
-        hist = _get_vulnerability_tokens_histogram()
-        hist.record(input_tokens, {**attrs, "gen_ai.token.type": "input"})
-        hist.record(output_tokens, {**attrs, "gen_ai.token.type": "output"})
     except Exception:
         pass
 

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -50,6 +50,7 @@ OTel try/except so a failed counter write never silently zeroes the totals.
 from typing import Optional
 
 from src.smartfix.domains.telemetry import otel_provider
+from src.utils import debug_log
 
 _METER_NAME = "smartfix"
 
@@ -209,12 +210,11 @@ def record_vulnerability_duration(
             "rule_name": rule_name,
             "language": language or "unknown",
             "source": source,
+            "severity": severity or "unknown",
         }
-        if severity:
-            attrs["severity"] = severity
         _get_vulnerability_duration_histogram().record(elapsed_s, attrs)
-    except Exception:
-        pass
+    except Exception as e:
+        debug_log(f"OTel metric error in record_vulnerability_duration: {e}")
 
 
 def record_pr_attempt(outcome: str, rule_name: str, coding_agent: str) -> None:
@@ -267,7 +267,7 @@ def record_llm_call_tokens(
         # iteration and read here, since LiteLLM callbacks don't carry vulnerability context.
         token_attrs = {"gen_ai.request.model": model}
         if _current_rule_name:
-            token_attrs["rule_id"] = _current_rule_name
+            token_attrs["rule_name"] = _current_rule_name
 
         total_counter = _get_tokens_total_counter()
         total_counter.add(total_input, {**token_attrs, "gen_ai.token.type": "input"})
@@ -311,8 +311,8 @@ def record_pr_merged(coding_agent: str) -> None:
     """
     try:
         _get_pr_merged_counter().add(1, {"coding_agent": coding_agent})
-    except Exception:
-        pass
+    except Exception as e:
+        debug_log(f"OTel metric error in record_pr_merged: {e}")
 
 
 def record_llm_retry(model: str, error_type: str) -> None:

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -56,6 +56,7 @@ _METER_NAME = "smartfix"
 # --- Lazy instrument handles ---
 _vulnerability_duration_histogram = None
 _pr_count_counter = None
+_pr_merged_counter = None
 _tokens_total_counter = None
 _cache_tokens_counter = None
 _llm_duration_histogram = None
@@ -65,6 +66,11 @@ _llm_retries_counter = None
 # Reset at the start of each vulnerability; read in the fix-vulnerability span finally block.
 _vuln_input_tokens: int = 0
 _vuln_output_tokens: int = 0
+
+# --- Current vulnerability rule name ---
+# Set once per vulnerability loop iteration so that record_llm_call_tokens() can attach
+# rule_id to token counters without requiring it to be threaded through every LLM callback.
+_current_rule_name: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +97,17 @@ def _get_pr_count_counter():
             description="Number of PR creation attempts.",
         )
     return _pr_count_counter
+
+
+def _get_pr_merged_counter():
+    global _pr_merged_counter
+    if _pr_merged_counter is None:
+        _pr_merged_counter = otel_provider.get_meter(_METER_NAME).create_counter(
+            name="smartfix.pr.merged",
+            unit="{pr}",
+            description="Number of SmartFix PRs merged.",
+        )
+    return _pr_merged_counter
 
 
 def _get_tokens_total_counter():
@@ -142,10 +159,25 @@ def _get_llm_retries_counter():
 # ---------------------------------------------------------------------------
 
 def reset_vuln_token_accumulator() -> None:
-    """Reset per-vulnerability token counters. Call at the start of each vulnerability loop."""
-    global _vuln_input_tokens, _vuln_output_tokens
+    """Reset per-vulnerability token counters and rule name. Call at the start of each vulnerability loop."""
+    global _vuln_input_tokens, _vuln_output_tokens, _current_rule_name
     _vuln_input_tokens = 0
     _vuln_output_tokens = 0
+    _current_rule_name = ""
+
+
+def set_current_rule_name(rule_name: str) -> None:
+    """Set the rule name for the vulnerability currently being processed.
+
+    Called once per vulnerability loop iteration so that record_llm_call_tokens()
+    can attach rule_id to smartfix.tokens.total and smartfix.cache.tokens without
+    requiring rule_name to be threaded through every LLM callback.
+
+    Args:
+        rule_name: Contrast rule identifier (e.g. "sql-injection").
+    """
+    global _current_rule_name
+    _current_rule_name = rule_name
 
 
 def get_vuln_token_totals() -> tuple[int, int]:
@@ -225,16 +257,23 @@ def record_llm_call_tokens(
     _vuln_input_tokens += total_input
     _vuln_output_tokens += output_tokens
     try:
+        # rule_id is required by the datalake schema for per-rule cost attribution.
+        # It is set via set_current_rule_name() at the start of each vulnerability loop
+        # iteration and read here, since LiteLLM callbacks don't carry vulnerability context.
+        token_attrs = {"gen_ai.request.model": model}
+        if _current_rule_name:
+            token_attrs["rule_id"] = _current_rule_name
+
         total_counter = _get_tokens_total_counter()
-        total_counter.add(total_input, {"gen_ai.token.type": "input", "gen_ai.request.model": model})
-        total_counter.add(output_tokens, {"gen_ai.token.type": "output", "gen_ai.request.model": model})
+        total_counter.add(total_input, {**token_attrs, "gen_ai.token.type": "input"})
+        total_counter.add(output_tokens, {**token_attrs, "gen_ai.token.type": "output"})
 
         if cache_read_tokens or cache_write_tokens:
             cache_counter = _get_cache_tokens_counter()
             if cache_read_tokens:
-                cache_counter.add(cache_read_tokens, {"gen_ai.token.type": "read", "gen_ai.request.model": model})
+                cache_counter.add(cache_read_tokens, {**token_attrs, "gen_ai.token.type": "cache_read"})
             if cache_write_tokens:
-                cache_counter.add(cache_write_tokens, {"gen_ai.token.type": "write", "gen_ai.request.model": model})
+                cache_counter.add(cache_write_tokens, {**token_attrs, "gen_ai.token.type": "cache_creation"})
     except Exception:
         pass
 
@@ -252,6 +291,21 @@ def record_llm_duration(elapsed_s: float, provider_name: str, model: str) -> Non
             "gen_ai.provider.name": provider_name,
             "gen_ai.request.model": model,
         })
+    except Exception:
+        pass
+
+
+def record_pr_merged(coding_agent: str) -> None:
+    """Record a SmartFix PR merge event as a metric.
+
+    Emits smartfix.pr.merged so the datalake can track merge volume independently
+    from PR creation attempts (smartfix.pr.count).
+
+    Args:
+        coding_agent: Coding agent identifier (e.g. "smartfix", "github_copilot").
+    """
+    try:
+        _get_pr_merged_counter().add(1, {"coding_agent": coding_agent})
     except Exception:
         pass
 

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -55,6 +55,7 @@ _METER_NAME = "smartfix"
 
 # --- Lazy instrument handles ---
 _vulnerability_duration_histogram = None
+_vulnerability_tokens_histogram = None
 _pr_count_counter = None
 _pr_merged_counter = None
 _tokens_total_counter = None
@@ -86,6 +87,17 @@ def _get_vulnerability_duration_histogram():
             description="End-to-end time to process each vulnerability fix attempt.",
         )
     return _vulnerability_duration_histogram
+
+
+def _get_vulnerability_tokens_histogram():
+    global _vulnerability_tokens_histogram
+    if _vulnerability_tokens_histogram is None:
+        _vulnerability_tokens_histogram = otel_provider.get_meter(_METER_NAME).create_histogram(
+            name="smartfix.vulnerability.tokens",
+            unit="{token}",
+            description="Total LLM tokens consumed per vulnerability fix attempt.",
+        )
+    return _vulnerability_tokens_histogram
 
 
 def _get_pr_count_counter():
@@ -191,6 +203,7 @@ def get_vuln_token_totals() -> tuple[int, int]:
 
 def record_vulnerability_duration(
     elapsed_s: float, outcome: str, rule_name: str, language: Optional[str], source: str,
+    severity: Optional[str] = None,
 ) -> None:
     """Record end-to-end vulnerability fix duration.
 
@@ -200,14 +213,49 @@ def record_vulnerability_duration(
         rule_name: Contrast rule name (e.g. "sql-injection").
         language: Programming language detected for this app.
         source: Finding source (e.g. "runtime").
+        severity: Vulnerability severity (e.g. "CRITICAL", "HIGH").
     """
     try:
-        _get_vulnerability_duration_histogram().record(elapsed_s, {
+        attrs = {
             "outcome": outcome,
             "rule_name": rule_name,
             "language": language or "unknown",
             "source": source,
-        })
+        }
+        if severity:
+            attrs["severity"] = severity
+        _get_vulnerability_duration_histogram().record(elapsed_s, attrs)
+    except Exception:
+        pass
+
+
+def record_vulnerability_tokens(
+    input_tokens: int, output_tokens: int, rule_name: str, language: Optional[str],
+    severity: Optional[str] = None,
+) -> None:
+    """Record total LLM token consumption for a single vulnerability fix attempt.
+
+    Emitted once per vulnerability (after all LLM calls complete) so that
+    Munir's datalake can compute average token cost per rule/language/severity
+    without needing per-invocation span data.
+
+    Args:
+        input_tokens: Total input tokens (new + cache) across all LLM calls.
+        output_tokens: Total output tokens across all LLM calls.
+        rule_name: Contrast rule name.
+        language: Programming language detected for this app.
+        severity: Vulnerability severity.
+    """
+    try:
+        attrs = {
+            "rule_name": rule_name,
+            "language": language or "unknown",
+        }
+        if severity:
+            attrs["severity"] = severity
+        hist = _get_vulnerability_tokens_histogram()
+        hist.record(input_tokens, {**attrs, "gen_ai.token.type": "input"})
+        hist.record(output_tokens, {**attrs, "gen_ai.token.type": "output"})
     except Exception:
         pass
 

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -133,6 +133,20 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
             "source": "runtime",
         })
 
+    def test_includes_severity_when_provided(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_duration(2.5, "success", "sql-injection", "java", "runtime", severity="CRITICAL")
+
+        attrs = self.mock_histogram.record.call_args[0][1]
+        self.assertEqual(attrs["severity"], "CRITICAL")
+
+    def test_omits_severity_when_not_provided(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_duration(2.5, "success", "sql-injection", "java", "runtime")
+
+        attrs = self.mock_histogram.record.call_args[0][1]
+        self.assertNotIn("severity", attrs)
+
     def test_uses_unknown_for_missing_language(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
         m.record_vulnerability_duration(1.0, "failure", "xss", None, "runtime")
@@ -145,6 +159,54 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
         self.mock_histogram.record.side_effect = RuntimeError("otel broken")
         # Must not raise.
         m.record_vulnerability_duration(1.0, "success", "sql-injection", "java", "runtime")
+
+
+class TestRecordVulnerabilityTokens(unittest.TestCase):
+
+    def setUp(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        self.mock_histogram = MagicMock()
+        m._vulnerability_tokens_histogram = self.mock_histogram
+
+    def tearDown(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m._vulnerability_tokens_histogram = None
+
+    def test_records_input_and_output_separately(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_tokens(100, 50, "sql-injection", "java")
+
+        calls = self.mock_histogram.record.call_args_list
+        self.assertEqual(len(calls), 2)
+        token_types = {c[0][1]["gen_ai.token.type"] for c in calls}
+        self.assertEqual(token_types, {"input", "output"})
+
+    def test_includes_severity_when_provided(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_tokens(100, 50, "xss", "java", severity="HIGH")
+
+        for call in self.mock_histogram.record.call_args_list:
+            self.assertEqual(call[0][1]["severity"], "HIGH")
+
+    def test_omits_severity_when_not_provided(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_tokens(100, 50, "xss", "java")
+
+        for call in self.mock_histogram.record.call_args_list:
+            self.assertNotIn("severity", call[0][1])
+
+    def test_uses_unknown_for_missing_language(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_tokens(100, 50, "xss", None)
+
+        for call in self.mock_histogram.record.call_args_list:
+            self.assertEqual(call[0][1]["language"], "unknown")
+
+    def test_suppresses_instrument_errors(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        self.mock_histogram.record.side_effect = RuntimeError("otel broken")
+        # Must not raise.
+        m.record_vulnerability_tokens(100, 50, "xss", "java")
 
 
 class TestRecordPrAttempt(unittest.TestCase):

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -131,6 +131,7 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
             "rule_name": "sql-injection",
             "language": "java",
             "source": "runtime",
+            "severity": "unknown",
         })
 
     def test_includes_severity_when_provided(self):
@@ -140,12 +141,12 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
         attrs = self.mock_histogram.record.call_args[0][1]
         self.assertEqual(attrs["severity"], "CRITICAL")
 
-    def test_omits_severity_when_not_provided(self):
+    def test_uses_unknown_severity_when_not_provided(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
         m.record_vulnerability_duration(2.5, "success", "sql-injection", "java", "runtime")
 
         attrs = self.mock_histogram.record.call_args[0][1]
-        self.assertNotIn("severity", attrs)
+        self.assertEqual(attrs["severity"], "unknown")
 
     def test_uses_unknown_for_missing_language(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
@@ -192,6 +193,33 @@ class TestRecordPrAttempt(unittest.TestCase):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
         self.mock_counter.add.side_effect = RuntimeError("otel broken")
         m.record_pr_attempt("success", "sql-injection", "smartfix")
+
+
+class TestRecordPrMerged(unittest.TestCase):
+
+    def setUp(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        self.mock_counter = MagicMock()
+        m._pr_merged_counter = self.mock_counter
+
+    def tearDown(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m._pr_merged_counter = None
+
+    def test_records_coding_agent(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_pr_merged("smartfix")
+        self.mock_counter.add.assert_called_once_with(1, {"coding_agent": "smartfix"})
+
+    def test_records_external_agent(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_pr_merged("external-github_copilot")
+        self.mock_counter.add.assert_called_once_with(1, {"coding_agent": "external-github_copilot"})
+
+    def test_suppresses_instrument_errors(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        self.mock_counter.add.side_effect = RuntimeError("otel broken")
+        m.record_pr_merged("smartfix")  # must not raise
 
 
 class TestRecordLlmCallTokens(unittest.TestCase):
@@ -323,7 +351,7 @@ class TestVulnTokenAccumulator(unittest.TestCase):
         m.set_current_rule_name("xss")
         self.assertEqual(m._current_rule_name, "xss")
 
-    def test_token_counter_includes_rule_id_when_set(self):
+    def test_token_counter_includes_rule_name_when_set(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
         mock_total = MagicMock()
         mock_cache = MagicMock()
@@ -334,9 +362,9 @@ class TestVulnTokenAccumulator(unittest.TestCase):
         m.record_llm_call_tokens(10, 5, 0, 0, "model-a")
 
         call_kwargs = mock_total.add.call_args_list[0][0][1]
-        self.assertEqual(call_kwargs["rule_id"], "sql-injection")
+        self.assertEqual(call_kwargs["rule_name"], "sql-injection")
 
-    def test_token_counter_omits_rule_id_when_not_set(self):
+    def test_token_counter_omits_rule_name_when_not_set(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
         mock_total = MagicMock()
         mock_cache = MagicMock()
@@ -346,7 +374,7 @@ class TestVulnTokenAccumulator(unittest.TestCase):
         m.record_llm_call_tokens(10, 5, 0, 0, "model-a")
 
         call_kwargs = mock_total.add.call_args_list[0][0][1]
-        self.assertNotIn("rule_id", call_kwargs)
+        self.assertNotIn("rule_name", call_kwargs)
 
     def test_cache_token_type_labels_match_spec(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -161,54 +161,6 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
         m.record_vulnerability_duration(1.0, "success", "sql-injection", "java", "runtime")
 
 
-class TestRecordVulnerabilityTokens(unittest.TestCase):
-
-    def setUp(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_histogram = MagicMock()
-        m._vulnerability_tokens_histogram = self.mock_histogram
-
-    def tearDown(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m._vulnerability_tokens_histogram = None
-
-    def test_records_input_and_output_separately(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.record_vulnerability_tokens(100, 50, "sql-injection", "java")
-
-        calls = self.mock_histogram.record.call_args_list
-        self.assertEqual(len(calls), 2)
-        token_types = {c[0][1]["gen_ai.token.type"] for c in calls}
-        self.assertEqual(token_types, {"input", "output"})
-
-    def test_includes_severity_when_provided(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.record_vulnerability_tokens(100, 50, "xss", "java", severity="HIGH")
-
-        for call in self.mock_histogram.record.call_args_list:
-            self.assertEqual(call[0][1]["severity"], "HIGH")
-
-    def test_omits_severity_when_not_provided(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.record_vulnerability_tokens(100, 50, "xss", "java")
-
-        for call in self.mock_histogram.record.call_args_list:
-            self.assertNotIn("severity", call[0][1])
-
-    def test_uses_unknown_for_missing_language(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.record_vulnerability_tokens(100, 50, "xss", None)
-
-        for call in self.mock_histogram.record.call_args_list:
-            self.assertEqual(call[0][1]["language"], "unknown")
-
-    def test_suppresses_instrument_errors(self):
-        import src.smartfix.domains.telemetry.smartfix_metrics as m
-        self.mock_histogram.record.side_effect = RuntimeError("otel broken")
-        # Must not raise.
-        m.record_vulnerability_tokens(100, 50, "xss", "java")
-
-
 class TestRecordPrAttempt(unittest.TestCase):
 
     def setUp(self):

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -216,8 +216,8 @@ class TestRecordLlmCallTokens(unittest.TestCase):
 
         cache_calls = self.mock_cache.add.call_args_list
         token_types = {c[0][1]["gen_ai.token.type"] for c in cache_calls}
-        self.assertIn("read", token_types)
-        self.assertIn("write", token_types)
+        self.assertIn("cache_read", token_types)
+        self.assertIn("cache_creation", token_types)
 
     def test_skips_cache_counter_when_no_cache_tokens(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
@@ -297,6 +297,55 @@ class TestVulnTokenAccumulator(unittest.TestCase):
         m.reset_vuln_token_accumulator()
         self.assertEqual(m._vuln_input_tokens, 0)
         self.assertEqual(m._vuln_output_tokens, 0)
+
+    def test_reset_clears_rule_name(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.set_current_rule_name("sql-injection")
+        m.reset_vuln_token_accumulator()
+        self.assertEqual(m._current_rule_name, "")
+
+    def test_set_current_rule_name(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.set_current_rule_name("xss")
+        self.assertEqual(m._current_rule_name, "xss")
+
+    def test_token_counter_includes_rule_id_when_set(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        mock_total = MagicMock()
+        mock_cache = MagicMock()
+        m._tokens_total_counter = mock_total
+        m._cache_tokens_counter = mock_cache
+        m.set_current_rule_name("sql-injection")
+
+        m.record_llm_call_tokens(10, 5, 0, 0, "model-a")
+
+        call_kwargs = mock_total.add.call_args_list[0][0][1]
+        self.assertEqual(call_kwargs["rule_id"], "sql-injection")
+
+    def test_token_counter_omits_rule_id_when_not_set(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        mock_total = MagicMock()
+        mock_cache = MagicMock()
+        m._tokens_total_counter = mock_total
+        m._cache_tokens_counter = mock_cache
+
+        m.record_llm_call_tokens(10, 5, 0, 0, "model-a")
+
+        call_kwargs = mock_total.add.call_args_list[0][0][1]
+        self.assertNotIn("rule_id", call_kwargs)
+
+    def test_cache_token_type_labels_match_spec(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        mock_total = MagicMock()
+        mock_cache = MagicMock()
+        m._tokens_total_counter = mock_total
+        m._cache_tokens_counter = mock_cache
+
+        m.record_llm_call_tokens(0, 0, 30, 20, "model-a")
+
+        types = {call[0][1]["gen_ai.token.type"] for call in mock_cache.add.call_args_list}
+        self.assertIn("cache_read", types)
+        self.assertIn("cache_creation", types)
 
     def test_get_totals_returns_zero_after_reset(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m


### PR DESCRIPTION
## Jira

[AIML-802](https://contrast.atlassian.net/browse/AIML-802)

## Summary

Miscellaneous tech debt and code review follow-up items.

**OTel metrics consistency (from AIML-794 review)**
- Standardize on `rule_name` attribute key across all `record_*` metric functions (was `rule_id` in `record_llm_call_tokens`)
- Fix merge metric misattribution — `record_pr_merged` now derives coding agent from branch prefix rather than `config.CODING_AGENT`, so external-agent PRs (Copilot, Claude Code) are correctly attributed in the datalake
- Replace bare `except Exception: pass` with `debug_log` on new functions added in AIML-794
- Use `"unknown"` fallback for `severity` in `record_vulnerability_duration` (consistent with `language` handling)
- Add `TestRecordPrMerged` test class

**GitHub Actions Node.js upgrade (flagged by Doug Jeremias)**
- Update `actions/checkout` v4.3.1 → v6.0.2 (Node 24)
- Update `actions/setup-python` v5.6.0 → v6.2.0 (Node 24)
- Update `actions/setup-node` v4 → v6.4.0 (Node 24)
- Node.js 20 actions deprecated June 2, 2026

## Test plan

- [ ] 960 tests pass (`make test`)
- [ ] Verify no Node.js 20 deprecation warnings in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIML-802]: https://contrast.atlassian.net/browse/AIML-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ