### PR TITLE
AIML-820: SmartFix NorthStar action changes — NS mode label, URL, and identifier support

### DIFF
--- a/src/closed_handler.py
+++ b/src/closed_handler.py
@@ -123,10 +123,13 @@ def _extract_vulnerability_info(labels: list) -> str:
                 break
         elif label_name.startswith("contrast-issue-id:"):
             # Extract issueId from label format "contrast-issue-id:{issueId}"
-            primary_id = label_name[len("contrast-issue-id:"):]
-            if primary_id:
+            extracted = label_name[len("contrast-issue-id:"):]
+            if extracted:
+                primary_id = extracted
                 debug_log(f"Extracted NorthStar issue ID from PR label: {primary_id}")
                 break
+            else:
+                debug_log(f"Found contrast-issue-id label with empty value on PR label '{label_name}'; skipping.")
 
     if primary_id == "unknown":
         debug_log("Could not extract finding identifier from PR labels. Telemetry may be incomplete.")

--- a/src/closed_handler.py
+++ b/src/closed_handler.py
@@ -105,23 +105,33 @@ def _extract_remediation_info(pull_request: dict) -> tuple:
 
 
 def _extract_vulnerability_info(labels: list) -> str:
-    """Extract vulnerability UUID from PR labels."""
-    vuln_uuid = "unknown"
+    """Extract primary finding identifier from PR labels.
+
+    Recognises both Classic (contrast-vuln-id:VULN-*) and NorthStar
+    (contrast-issue-id:*) label formats.
+    """
+    primary_id = "unknown"
 
     for label in labels:
         label_name = label.get("name", "")
         if label_name.startswith("contrast-vuln-id:VULN-"):
             # Extract UUID from label format "contrast-vuln-id:VULN-{vuln_uuid}"
             label_name_parts = label_name.split("VULN-")
-            vuln_uuid = label_name_parts[1] if len(label_name_parts) > 1 else "unknown"
-            if vuln_uuid and vuln_uuid != "unknown":
-                debug_log(f"Extracted Vulnerability UUID from PR label: {vuln_uuid}")
+            primary_id = label_name_parts[1] if len(label_name_parts) > 1 else "unknown"
+            if primary_id and primary_id != "unknown":
+                debug_log(f"Extracted vulnerability UUID from PR label: {primary_id}")
+                break
+        elif label_name.startswith("contrast-issue-id:"):
+            # Extract issueId from label format "contrast-issue-id:{issueId}"
+            primary_id = label_name[len("contrast-issue-id:"):]
+            if primary_id:
+                debug_log(f"Extracted NorthStar issue ID from PR label: {primary_id}")
                 break
 
-    if vuln_uuid == "unknown":
-        debug_log("Could not extract vulnerability UUID from PR labels. Telemetry may be incomplete.")
+    if primary_id == "unknown":
+        debug_log("Could not extract finding identifier from PR labels. Telemetry may be incomplete.")
 
-    return vuln_uuid
+    return primary_id
 
 
 def _notify_remediation_service(remediation_id: str, pr_number: int = None):

--- a/src/github/constants.py
+++ b/src/github/constants.py
@@ -33,4 +33,4 @@ GITHUB_WORKFLOW_RUN_LIMIT = 50
 
 # SmartFix-managed PR/issue label prefixes — used to identify labels SmartFix
 # attaches (and now removes on PR close/merge).
-SMARTFIX_LABEL_PREFIXES = ("smartfix-id:", "contrast-vuln-id:")
+SMARTFIX_LABEL_PREFIXES = ("smartfix-id:", "contrast-vuln-id:", "contrast-issue-id:")

--- a/src/github/external_coding_agent.py
+++ b/src/github/external_coding_agent.py
@@ -62,6 +62,9 @@ class ExternalCodingAgent(CodingAgentStrategy):
         # Extract key details with safe fallbacks
         vuln_title = vulnerability_details.get('vulnerabilityTitle', 'Unknown Vulnerability')
         vuln_uuid = vulnerability_details.get('vulnerabilityUuid', 'Unknown UUID')
+        mode = vulnerability_details.get('mode', 'CLASSIC')
+        issue_id = vulnerability_details.get('issueId')
+        primary_id = issue_id if mode == 'NORTHSTAR_ONLY' else vuln_uuid
         vuln_rule = vulnerability_details.get('vulnerabilityRuleName', 'Unknown Rule')
         vuln_severity = vulnerability_details.get('vulnerabilitySeverity', 'Unknown Severity')
         vuln_status = vulnerability_details.get('vulnerabilityStatus', 'Unknown Status')
@@ -81,7 +84,11 @@ class ExternalCodingAgent(CodingAgentStrategy):
         # If neither is available (monorepo with no singular app configured), omit the app
         # segment to avoid a broken link.
         application_id = vulnerability_details.get('applicationId') or self.config.CONTRAST_APP_ID
-        if application_id:
+        if mode == 'NORTHSTAR_ONLY' and issue_id:
+            # NorthStar UI deeplink: /Contrast/cs/index.html#{orgId}/issues/{issueId}
+            contrast_url = (f"https://{self.config.CONTRAST_HOST}/Contrast/cs/index.html#"
+                            f"{self.config.CONTRAST_ORG_ID}/issues/{issue_id}")
+        elif application_id:
             contrast_url = (f"https://{self.config.CONTRAST_HOST}/Contrast/static/ng/index.html#/"
                             f"{self.config.CONTRAST_ORG_ID}/applications/{application_id}/vulns/{vuln_uuid}")
         else:
@@ -91,7 +98,7 @@ class ExternalCodingAgent(CodingAgentStrategy):
         issue_body = f"""
 # Contrast AI SmartFix Issue Report
 
-This issue should address a vulnerability identified by the Contrast Security platform (ID: [{vuln_uuid}]({contrast_url})).
+This issue should address a security finding identified by the Contrast Security platform (ID: [{primary_id}]({contrast_url})).
 
 # Security Vulnerability: {vuln_title}
 

--- a/src/github/external_coding_agent.py
+++ b/src/github/external_coding_agent.py
@@ -28,6 +28,7 @@ from src.smartfix.domains.telemetry import telemetry_handler
 from src.contrast_api import notify_remediation_pr_opened_org
 from src.smartfix.shared.failure_categories import FailureCategory
 from src.smartfix.shared.coding_agents import CodingAgents
+from src.smartfix.shared.constants import CLASSIC, NORTHSTAR_ONLY
 from src.smartfix.domains.agents.coding_agent import CodingAgentStrategy
 from src.smartfix.domains.agents.agent_session import AgentSession
 from src.smartfix.domains.vulnerability.context import RemediationContext
@@ -62,9 +63,9 @@ class ExternalCodingAgent(CodingAgentStrategy):
         # Extract key details with safe fallbacks
         vuln_title = vulnerability_details.get('vulnerabilityTitle', 'Unknown Vulnerability')
         vuln_uuid = vulnerability_details.get('vulnerabilityUuid', 'Unknown UUID')
-        mode = vulnerability_details.get('mode', 'CLASSIC')
+        mode = vulnerability_details.get('mode', CLASSIC)
         issue_id = vulnerability_details.get('issueId')
-        primary_id = issue_id if mode == 'NORTHSTAR_ONLY' else vuln_uuid
+        primary_id = issue_id if mode == NORTHSTAR_ONLY else vuln_uuid
         vuln_rule = vulnerability_details.get('vulnerabilityRuleName', 'Unknown Rule')
         vuln_severity = vulnerability_details.get('vulnerabilitySeverity', 'Unknown Severity')
         vuln_status = vulnerability_details.get('vulnerabilityStatus', 'Unknown Status')
@@ -84,7 +85,7 @@ class ExternalCodingAgent(CodingAgentStrategy):
         # If neither is available (monorepo with no singular app configured), omit the app
         # segment to avoid a broken link.
         application_id = vulnerability_details.get('applicationId') or self.config.CONTRAST_APP_ID
-        if mode == 'NORTHSTAR_ONLY' and issue_id:
+        if mode == NORTHSTAR_ONLY and issue_id:
             # NorthStar UI deeplink: /Contrast/cs/index.html#{orgId}/issues/{issueId}
             contrast_url = (f"https://{self.config.CONTRAST_HOST}/Contrast/cs/index.html#"
                             f"{self.config.CONTRAST_ORG_ID}/issues/{issue_id}")
@@ -193,7 +194,10 @@ Please review this security vulnerability and implement appropriate fixes to add
             )
 
             # Generate labels and issue details
-            vulnerability_label = f"contrast-vuln-id:VULN-{vuln_uuid}"
+            github_ops = GitHubOperations()
+            vulnerability_label, _, _ = github_ops.generate_label_details(
+                vuln_uuid, mode=context.mode, issue_id=context.issue_id
+            )
             remediation_label = f"smartfix-id:{remediation_id}"
             issue_title = vuln_title
 
@@ -207,7 +211,6 @@ Please review this security vulnerability and implement appropriate fixes to add
                 error_exit(remediation_id, FailureCategory.AGENT_FAILURE.value)
 
             # Use GitHubOperations to find if there's an existing issue with this label
-            github_ops = GitHubOperations()
             issue_number = github_ops.find_issue_with_label(vulnerability_label)
 
             is_existing_issue = False

--- a/src/github/github_operations.py
+++ b/src/github/github_operations.py
@@ -23,6 +23,7 @@ import re
 from typing import List, Optional, Set, TypedDict
 from src.utils import run_command, debug_log, log, error_exit, CommandExecutionError
 from src.smartfix.shared.failure_categories import FailureCategory
+from src.smartfix.shared.constants import CLASSIC, NORTHSTAR_ONLY
 from src.config import get_config
 from src.smartfix.shared.coding_agents import CodingAgents
 from src.smartfix.domains.scm.git_operations import GitOperations
@@ -272,13 +273,13 @@ class GitHubOperations(ScmOperations):
                 debug_log(f"Error checking if Issues are enabled, assuming they are: {e}")
                 return True
 
-    def generate_label_details(self, vuln_uuid: str, mode: str = 'CLASSIC', issue_id: str = None) -> tuple[str, str, str]:
+    def generate_label_details(self, vuln_uuid: str, mode: str = CLASSIC, issue_id: str = None) -> tuple[str, str, str]:
         """Generates the label name, description, and color.
 
         For NORTHSTAR_ONLY mode uses contrast-issue-id:{issueId}.
         For CLASSIC mode uses contrast-vuln-id:VULN-{vuln_uuid}.
         """
-        if mode == 'NORTHSTAR_ONLY' and issue_id:
+        if mode == NORTHSTAR_ONLY and issue_id:
             label_name = f"contrast-issue-id:{issue_id}"
             label_description = "Issue identified by Contrast AI SmartFix"
         else:

--- a/src/github/github_operations.py
+++ b/src/github/github_operations.py
@@ -273,7 +273,7 @@ class GitHubOperations(ScmOperations):
                 debug_log(f"Error checking if Issues are enabled, assuming they are: {e}")
                 return True
 
-    def generate_label_details(self, vuln_uuid: str, mode: str = CLASSIC, issue_id: str = None) -> tuple[str, str, str]:
+    def generate_label_details(self, vuln_uuid: str, mode: str = CLASSIC, issue_id: Optional[str] = None) -> tuple[str, str, str]:
         """Generates the label name, description, and color.
 
         For NORTHSTAR_ONLY mode uses contrast-issue-id:{issueId}.

--- a/src/github/github_operations.py
+++ b/src/github/github_operations.py
@@ -272,10 +272,18 @@ class GitHubOperations(ScmOperations):
                 debug_log(f"Error checking if Issues are enabled, assuming they are: {e}")
                 return True
 
-    def generate_label_details(self, vuln_uuid: str) -> tuple[str, str, str]:
-        """Generates the label name, description, and color."""
-        label_name = f"contrast-vuln-id:VULN-{vuln_uuid}"
-        label_description = "Vulnerability identified by Contrast AI SmartFix"
+    def generate_label_details(self, vuln_uuid: str, mode: str = 'CLASSIC', issue_id: str = None) -> tuple[str, str, str]:
+        """Generates the label name, description, and color.
+
+        For NORTHSTAR_ONLY mode uses contrast-issue-id:{issueId}.
+        For CLASSIC mode uses contrast-vuln-id:VULN-{vuln_uuid}.
+        """
+        if mode == 'NORTHSTAR_ONLY' and issue_id:
+            label_name = f"contrast-issue-id:{issue_id}"
+            label_description = "Issue identified by Contrast AI SmartFix"
+        else:
+            label_name = f"contrast-vuln-id:VULN-{vuln_uuid}"
+            label_description = "Vulnerability identified by Contrast AI SmartFix"
         label_color = "ff0000"  # Red
         return label_name, label_description, label_color
 
@@ -432,12 +440,12 @@ class GitHubOperations(ScmOperations):
         debug_log(f"No existing OPEN or MERGED PR found for label {label_name}.")
         return "NONE"
 
-    def count_open_prs_with_prefix(self, label_prefix: str, remediation_id: str) -> int:
+    def count_open_prs_with_prefix(self, label_prefix, remediation_id: str) -> int:
         """
         Counts the number of open GitHub PRs with at least one label starting with the given prefix.
 
         Args:
-            label_prefix: Prefix to match against PR labels
+            label_prefix: Prefix string or tuple of prefix strings to match against PR labels
             remediation_id: Remediation ID for error context
         """
         log(f"Counting open PRs with label prefix: '{label_prefix}' (remediation: {remediation_id})")
@@ -1152,6 +1160,8 @@ class GitHubOperations(ScmOperations):
         for label_name in labels:
             if label_name.startswith("contrast-vuln-id:"):
                 self.ensure_label(label_name, "Vulnerability identified by Contrast", "ff0000")  # Red
+            elif label_name.startswith("contrast-issue-id:"):
+                self.ensure_label(label_name, "Issue identified by Contrast AI SmartFix", "ff0000")  # Red
             elif label_name.startswith("smartfix-id:"):
                 self.ensure_label(label_name, "Remediation ID for Contrast vulnerability", "0075ca")  # Blue
             else:

--- a/src/main.py
+++ b/src/main.py
@@ -63,6 +63,18 @@ github_ops = GitHubOperations()
 apply_asyncio_workarounds()
 
 
+def _extract_finding_ids(vulnerability_data: dict, fallback_remediation_id: str) -> tuple:
+    """Extract and validate vuln_uuid, mode, issue_id, and primary_id from API response data."""
+    vuln_uuid = vulnerability_data['vulnerabilityUuid']
+    mode = vulnerability_data.get('mode', CLASSIC)
+    issue_id = vulnerability_data.get('issueId')
+    if mode == NORTHSTAR_ONLY and not issue_id:
+        debug_log(f"NORTHSTAR_ONLY finding missing issueId; vuln_uuid={vuln_uuid}, remediationId={vulnerability_data.get('remediationId', 'unknown')}")
+        error_exit(vulnerability_data.get('remediationId', fallback_remediation_id), FailureCategory.GENERAL_FAILURE.value)
+    primary_id = issue_id if mode == NORTHSTAR_ONLY else vuln_uuid
+    return vuln_uuid, mode, issue_id, primary_id
+
+
 def main():
     """Entry point: initialise OTel, start root span, then run the implementation."""
     otel_provider.initialize_otel(config)
@@ -227,13 +239,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                 log(f"Warning: {len(skipped_app_ids)} app(s) were inaccessible and skipped: {skipped_app_ids}", is_warning=True)
 
             # Extract vulnerability details and prompts from the response
-            vuln_uuid = vulnerability_data['vulnerabilityUuid']
-            mode = vulnerability_data.get('mode', CLASSIC)
-            issue_id = vulnerability_data.get('issueId')
-            if mode == NORTHSTAR_ONLY and not issue_id:
-                debug_log(f"NORTHSTAR_ONLY finding missing issueId; vuln_uuid={vuln_uuid}, remediationId={vulnerability_data.get('remediationId', 'unknown')}")
-                error_exit(vulnerability_data.get('remediationId', remediation_id), FailureCategory.GENERAL_FAILURE.value)
-            primary_id = issue_id if mode == NORTHSTAR_ONLY else vuln_uuid
+            vuln_uuid, mode, issue_id, primary_id = _extract_finding_ids(vulnerability_data, remediation_id)
 
             # Check if this is the same primary identifier as the previous iteration
             if primary_id == previous_primary_id:
@@ -278,13 +284,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                 log(f"Warning: {len(skipped_app_ids)} app(s) were inaccessible and skipped: {skipped_app_ids}", is_warning=True)
 
             # Extract vulnerability details from the response (no prompts for external agents)
-            vuln_uuid = vulnerability_data['vulnerabilityUuid']
-            mode = vulnerability_data.get('mode', CLASSIC)
-            issue_id = vulnerability_data.get('issueId')
-            if mode == NORTHSTAR_ONLY and not issue_id:
-                debug_log(f"NORTHSTAR_ONLY finding missing issueId; vuln_uuid={vuln_uuid}, remediationId={vulnerability_data.get('remediationId', 'unknown')}")
-                error_exit(vulnerability_data.get('remediationId', remediation_id), FailureCategory.GENERAL_FAILURE.value)
-            primary_id = issue_id if mode == NORTHSTAR_ONLY else vuln_uuid
+            vuln_uuid, mode, issue_id, primary_id = _extract_finding_ids(vulnerability_data, remediation_id)
 
             # Check if this is the same primary identifier as the previous iteration
             if primary_id == previous_primary_id:

--- a/src/main.py
+++ b/src/main.py
@@ -173,7 +173,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
     debug_log(f"GitHub repository URL: {github_repo_url}")
     skipped_vulns = set()  # TS-39904
     remediation_id = "unknown"
-    previous_vuln_uuid = None  # Track previous vulnerability UUID to detect duplicates
+    previous_primary_id = None  # Track previous primary identifier to detect duplicates
     discovered_build_cmd = None   # Build command found by agent at runtime; carried forward across iterations
     discovered_format_cmd = None  # Format command found by agent at runtime; carried forward across iterations
 
@@ -227,13 +227,16 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
 
             # Extract vulnerability details and prompts from the response
             vuln_uuid = vulnerability_data['vulnerabilityUuid']
+            mode = vulnerability_data.get('mode', 'CLASSIC')
+            issue_id = vulnerability_data.get('issueId')
+            primary_id = issue_id if mode == 'NORTHSTAR_ONLY' else vuln_uuid
 
-            # Check if this is the same vulnerability UUID as the previous iteration
-            if vuln_uuid == previous_vuln_uuid:
-                if vuln_uuid in skipped_vulns:
-                    log(f"Vulnerability {vuln_uuid} was re-served after being handled. Breaking loop to avoid infinite processing.")
+            # Check if this is the same primary identifier as the previous iteration
+            if primary_id == previous_primary_id:
+                if primary_id in skipped_vulns:
+                    log(f"Finding {primary_id} was re-served after being handled. Breaking loop to avoid infinite processing.")
                     break
-                log(f"Error: Backend provided the same vulnerability UUID ({vuln_uuid}) as the previous iteration. This indicates a backend error.", is_warning=True)
+                log(f"Error: Backend provided the same primary identifier ({primary_id}) as the previous iteration. This indicates a backend error.", is_warning=True)
                 error_exit(remediation_id, FailureCategory.GENERAL_FAILURE.value)
 
             vuln_title = vulnerability_data['vulnerabilityTitle']
@@ -272,10 +275,13 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
 
             # Extract vulnerability details from the response (no prompts for external agents)
             vuln_uuid = vulnerability_data['vulnerabilityUuid']
+            mode = vulnerability_data.get('mode', 'CLASSIC')
+            issue_id = vulnerability_data.get('issueId')
+            primary_id = issue_id if mode == 'NORTHSTAR_ONLY' else vuln_uuid
 
-            # Check if this is the same vulnerability UUID as the previous iteration
-            if vuln_uuid == previous_vuln_uuid:
-                log(f"Error: Backend provided the same vulnerability UUID ({vuln_uuid}) as the previous iteration. This indicates a backend error.", is_warning=True)
+            # Check if this is the same primary identifier as the previous iteration
+            if primary_id == previous_primary_id:
+                log(f"Error: Backend provided the same primary identifier ({primary_id}) as the previous iteration. This indicates a backend error.", is_warning=True)
                 error_exit(remediation_id, FailureCategory.GENERAL_FAILURE.value)
 
             vuln_title = vulnerability_data['vulnerabilityTitle']
@@ -287,34 +293,35 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
             prompts = PromptConfiguration()
 
         # Populate vulnInfo in telemetry
-        telemetry_handler.update_telemetry("vulnInfo.vulnId", vuln_uuid)
+        telemetry_handler.update_telemetry("vulnInfo.vulnId", primary_id)
         telemetry_handler.update_telemetry("vulnInfo.vulnRule", vulnerability_data['vulnerabilityRuleName'])
         telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)
 
-        log(f"\n::group::--- Considering Vulnerability: {vuln_title} (UUID: {vuln_uuid}) ---")
+        log(f"\n::group::--- Considering Finding: {vuln_title} (ID: {primary_id}) ---")
 
         # --- Check for Existing PRs ---
+        # label_name will use primary_id once I.2+I.3 updates generate_label_details for NS mode
         label_name, _, _ = github_ops.generate_label_details(vuln_uuid)
         pr_status = github_ops.check_pr_status_for_label(label_name)
 
         # Changed this logic to check only for OPEN PRs for dev purposes
         if pr_status == "OPEN":
-            log(f"Skipping vulnerability {vuln_uuid} as an OPEN PR with label '{label_name}' already exists.")
+            log(f"Skipping finding {primary_id} as an OPEN PR with label '{label_name}' already exists.")
             log("\n::endgroup::")
-            if vuln_uuid in skipped_vulns:
-                log(f"Vulnerability {vuln_uuid} was re-suggested after being skipped. "
+            if primary_id in skipped_vulns:
+                log(f"Finding {primary_id} was re-suggested after being skipped. "
                     f"This may indicate GitHub returned incorrect PR data. "
                     f"See https://www.githubstatus.com/ for possible incidents. "
                     f"Breaking loop to avoid infinite processing.")
                 break
-            skipped_vulns.add(vuln_uuid)
+            skipped_vulns.add(primary_id)
             continue
         else:
-            log(f"No existing OPEN or MERGED PR found for vulnerability {vuln_uuid}. Proceeding with fix attempt.")
+            log(f"No existing OPEN or MERGED PR found for finding {primary_id}. Proceeding with fix attempt.")
         log("\n::endgroup::")
 
-        # Update tracking variable now that we know we're actually processing this vuln
-        previous_vuln_uuid = vuln_uuid
+        # Update tracking variable now that we know we're actually processing this finding
+        previous_primary_id = primary_id
         vuln_count[0] += 1
 
         log(f"\n\033[0;33m Selected vuln to fix: {vuln_title} \033[0m")

--- a/src/main.py
+++ b/src/main.py
@@ -346,7 +346,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
 
         smartfix_metrics.set_current_rule_name(vulnerability.rule_name)
         with otel_provider.start_span("fix-vulnerability") as op_span:
-            op_span.set_attribute("contrast.finding.fingerprint", vulnerability.uuid)
+            op_span.set_attribute("contrast.finding.fingerprint", primary_id)
             op_span.set_attribute("contrast.finding.source", "runtime")
             op_span.set_attribute("contrast.finding.rule_id", vulnerability.rule_name)
             op_span.set_attribute("contrast.smartfix.coding_agent", config.CODING_AGENT.lower())

--- a/src/main.py
+++ b/src/main.py
@@ -295,6 +295,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
         # Populate vulnInfo in telemetry
         telemetry_handler.update_telemetry("vulnInfo.vulnId", primary_id)
         telemetry_handler.update_telemetry("vulnInfo.vulnRule", vulnerability_data['vulnerabilityRuleName'])
+        telemetry_handler.update_telemetry("vulnInfo.northstarMode", mode == 'NORTHSTAR_ONLY')
         telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)
 
         log(f"\n::group::--- Considering Finding: {vuln_title} (ID: {primary_id}) ---")
@@ -595,6 +596,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                         outcome=pr_metric_outcome,
                         rule_name=vulnerability.rule_name,
                         coding_agent=config.CODING_AGENT.lower(),
+                        northstar_mode=(mode == 'NORTHSTAR_ONLY'),
                     )
 
                     if not pr_creation_success:
@@ -655,6 +657,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                     language=lang or "unknown",
                     source="runtime",
                     severity=_severity,
+                    northstar_mode=(mode == 'NORTHSTAR_ONLY'),
                 )
 
     # Calculate total runtime

--- a/src/main.py
+++ b/src/main.py
@@ -166,12 +166,12 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
     label_prefix_to_check = ("contrast-vuln-id:", "contrast-issue-id:")
     current_open_pr_count = github_ops.count_open_prs_with_prefix(label_prefix_to_check, "unknown")
     if current_open_pr_count >= max_open_prs_setting:
-        log(f"Found {current_open_pr_count} open PR(s) with label prefix '{label_prefix_to_check}'.")
+        log(f"Found {current_open_pr_count} open PR(s) with label prefix '{', '.join(label_prefix_to_check)}'.")
         log(f"This meets or exceeds the configured limit of {max_open_prs_setting}.")
         log("Exiting script to avoid creating more PRs.")
         sys.exit(0)
     else:
-        log(f"Found {current_open_pr_count} open PR(s) with label prefix '{label_prefix_to_check}' (Limit: {max_open_prs_setting}). Proceeding...")
+        log(f"Found {current_open_pr_count} open PR(s) with label prefix '{', '.join(label_prefix_to_check)}' (Limit: {max_open_prs_setting}). Proceeding...")
     log("\n::endgroup::")
     # END Check Open PR Limit
 

--- a/src/main.py
+++ b/src/main.py
@@ -295,7 +295,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
         # Populate vulnInfo in telemetry
         telemetry_handler.update_telemetry("vulnInfo.vulnId", primary_id)
         telemetry_handler.update_telemetry("vulnInfo.vulnRule", vulnerability_data['vulnerabilityRuleName'])
-        telemetry_handler.update_telemetry("vulnInfo.northstarMode", mode == 'NORTHSTAR_ONLY')
+        telemetry_handler.update_telemetry("vulnInfo.northstarMode", mode)
         telemetry_handler.update_telemetry("additionalAttributes.remediationId", remediation_id)
 
         log(f"\n::group::--- Considering Finding: {vuln_title} (ID: {primary_id}) ---")
@@ -596,7 +596,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                         outcome=pr_metric_outcome,
                         rule_name=vulnerability.rule_name,
                         coding_agent=config.CODING_AGENT.lower(),
-                        northstar_mode=(mode == 'NORTHSTAR_ONLY'),
+                        mode=mode,
                     )
 
                     if not pr_creation_success:
@@ -657,7 +657,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                     language=lang or "unknown",
                     source="runtime",
                     severity=_severity,
-                    northstar_mode=(mode == 'NORTHSTAR_ONLY'),
+                    mode=mode,
                 )
 
     # Calculate total runtime

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ from src.config import get_config
 from src.smartfix.domains.telemetry import otel_provider
 from src.smartfix.domains.telemetry import smartfix_metrics
 from src.smartfix.shared.coding_agents import CodingAgents
+from src.smartfix.shared.constants import CLASSIC, NORTHSTAR_ONLY
 from src.smartfix.shared.exceptions import TokenBalanceExhaustedError
 from src.utils import debug_log, log, error_exit
 from src.smartfix.domains.telemetry import telemetry_handler
@@ -227,9 +228,12 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
 
             # Extract vulnerability details and prompts from the response
             vuln_uuid = vulnerability_data['vulnerabilityUuid']
-            mode = vulnerability_data.get('mode', 'CLASSIC')
+            mode = vulnerability_data.get('mode', CLASSIC)
             issue_id = vulnerability_data.get('issueId')
-            primary_id = issue_id if mode == 'NORTHSTAR_ONLY' else vuln_uuid
+            if mode == NORTHSTAR_ONLY and not issue_id:
+                debug_log(f"NORTHSTAR_ONLY finding missing issueId; vuln_uuid={vuln_uuid}, remediationId={vulnerability_data.get('remediationId', 'unknown')}")
+                error_exit(vulnerability_data.get('remediationId', remediation_id), FailureCategory.GENERAL_FAILURE.value)
+            primary_id = issue_id if mode == NORTHSTAR_ONLY else vuln_uuid
 
             # Check if this is the same primary identifier as the previous iteration
             if primary_id == previous_primary_id:
@@ -275,9 +279,12 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
 
             # Extract vulnerability details from the response (no prompts for external agents)
             vuln_uuid = vulnerability_data['vulnerabilityUuid']
-            mode = vulnerability_data.get('mode', 'CLASSIC')
+            mode = vulnerability_data.get('mode', CLASSIC)
             issue_id = vulnerability_data.get('issueId')
-            primary_id = issue_id if mode == 'NORTHSTAR_ONLY' else vuln_uuid
+            if mode == NORTHSTAR_ONLY and not issue_id:
+                debug_log(f"NORTHSTAR_ONLY finding missing issueId; vuln_uuid={vuln_uuid}, remediationId={vulnerability_data.get('remediationId', 'unknown')}")
+                error_exit(vulnerability_data.get('remediationId', remediation_id), FailureCategory.GENERAL_FAILURE.value)
+            primary_id = issue_id if mode == NORTHSTAR_ONLY else vuln_uuid
 
             # Check if this is the same primary identifier as the previous iteration
             if primary_id == previous_primary_id:
@@ -354,6 +361,8 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                     skip_writing_security_test=config.SKIP_WRITING_SECURITY_TEST,
                     session_id=session_id,
                     language=vuln_language,
+                    mode=mode,
+                    issue_id=issue_id,
                 )
 
                 # Propagate a build command discovered by a previous agent run so the next
@@ -499,7 +508,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
                 # --- Push and Create PR ---
                 git_ops.push_branch(new_branch_name)  # Push the final commit (original or amended)
 
-                label_name, label_desc, label_color = github_ops.generate_label_details(vuln_uuid)
+                label_name, label_desc, label_color = github_ops.generate_label_details(vuln_uuid, mode=mode, issue_id=issue_id)
                 label_created = github_ops.ensure_label(label_name, label_desc, label_color)
                 if not label_created:
                     log(f"Could not create GitHub label '{label_name}'. PR will be created without a label.", is_warning=True)

--- a/src/main.py
+++ b/src/main.py
@@ -150,7 +150,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
 
     # Check Open PR Limit
     log("\n::group::--- Checking Open PR Limit ---")
-    label_prefix_to_check = "contrast-vuln-id:"
+    label_prefix_to_check = ("contrast-vuln-id:", "contrast-issue-id:")
     current_open_pr_count = github_ops.count_open_prs_with_prefix(label_prefix_to_check, "unknown")
     if current_open_pr_count >= max_open_prs_setting:
         log(f"Found {current_open_pr_count} open PR(s) with label prefix '{label_prefix_to_check}'.")
@@ -300,8 +300,7 @@ def _main_impl(vuln_count: list[int], prs_created_count: list[int]) -> None:  # 
         log(f"\n::group::--- Considering Finding: {vuln_title} (ID: {primary_id}) ---")
 
         # --- Check for Existing PRs ---
-        # label_name will use primary_id once I.2+I.3 updates generate_label_details for NS mode
-        label_name, _, _ = github_ops.generate_label_details(vuln_uuid)
+        label_name, _, _ = github_ops.generate_label_details(vuln_uuid, mode=mode, issue_id=issue_id)
         pr_status = github_ops.check_pr_status_for_label(label_name)
 
         # Changed this logic to check only for OPEN PRs for dev purposes

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -130,10 +130,13 @@ def _extract_vulnerability_info(labels: list) -> str:
                 break
         elif label_name.startswith("contrast-issue-id:"):
             # Extract issueId from label format "contrast-issue-id:{issueId}"
-            primary_id = label_name[len("contrast-issue-id:"):]
-            if primary_id:
+            extracted = label_name[len("contrast-issue-id:"):]
+            if extracted:
+                primary_id = extracted
                 debug_log(f"Extracted NorthStar issue ID from PR label: {primary_id}")
                 break
+            else:
+                debug_log(f"Found contrast-issue-id label with empty value on PR label '{label_name}'; skipping.")
 
     if primary_id == "unknown":
         debug_log("Could not extract finding identifier from PR labels. Telemetry may be incomplete.")

--- a/src/merge_handler.py
+++ b/src/merge_handler.py
@@ -112,23 +112,33 @@ def _extract_remediation_info(pull_request: dict) -> tuple:
 
 
 def _extract_vulnerability_info(labels: list) -> str:
-    """Extract vulnerability UUID from PR labels."""
-    vuln_uuid = "unknown"
+    """Extract primary finding identifier from PR labels.
+
+    Recognises both Classic (contrast-vuln-id:VULN-*) and NorthStar
+    (contrast-issue-id:*) label formats.
+    """
+    primary_id = "unknown"
 
     for label in labels:
         label_name = label.get("name", "")
         if label_name.startswith("contrast-vuln-id:VULN-"):
             # Extract UUID from label format "contrast-vuln-id:VULN-{vuln_uuid}"
             label_name_parts = label_name.split("VULN-")
-            vuln_uuid = label_name_parts[1] if len(label_name_parts) > 1 else "unknown"
-            if vuln_uuid and vuln_uuid != "unknown":
-                debug_log(f"Extracted Vulnerability UUID from PR label: {vuln_uuid}")
+            primary_id = label_name_parts[1] if len(label_name_parts) > 1 else "unknown"
+            if primary_id and primary_id != "unknown":
+                debug_log(f"Extracted vulnerability UUID from PR label: {primary_id}")
+                break
+        elif label_name.startswith("contrast-issue-id:"):
+            # Extract issueId from label format "contrast-issue-id:{issueId}"
+            primary_id = label_name[len("contrast-issue-id:"):]
+            if primary_id:
+                debug_log(f"Extracted NorthStar issue ID from PR label: {primary_id}")
                 break
 
-    if vuln_uuid == "unknown":
-        debug_log("Could not extract vulnerability UUID from PR labels. Telemetry may be incomplete.")
+    if primary_id == "unknown":
+        debug_log("Could not extract finding identifier from PR labels. Telemetry may be incomplete.")
 
-    return vuln_uuid
+    return primary_id
 
 
 def _notify_remediation_service(remediation_id: str):

--- a/src/smartfix/domains/scm/scm_operations.py
+++ b/src/smartfix/domains/scm/scm_operations.py
@@ -6,7 +6,8 @@ for implementing SCM platform-specific operations (GitHub, GitLab, BitBucket, et
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple, Union
+from src.smartfix.shared.constants import CLASSIC
 
 
 class ScmOperations(ABC):
@@ -79,12 +80,14 @@ class ScmOperations(ABC):
         pass
 
     @abstractmethod
-    def generate_label_details(self, vuln_uuid: str) -> Tuple[str, str, str]:
+    def generate_label_details(self, vuln_uuid: str, mode: str = CLASSIC, issue_id: Optional[str] = None) -> Tuple[str, str, str]:
         """
         Generates label name, description, and color for a vulnerability.
 
         Args:
             vuln_uuid (str): Vulnerability UUID
+            mode (str): Finding mode ('CLASSIC' or 'NORTHSTAR_ONLY')
+            issue_id (str): NorthStar issue ID (required when mode is NORTHSTAR_ONLY)
 
         Returns:
             Tuple[str, str, str]: Label name, description, and color
@@ -120,12 +123,12 @@ class ScmOperations(ABC):
         pass
 
     @abstractmethod
-    def count_open_prs_with_prefix(self, label_prefix: str, remediation_id: str) -> int:
+    def count_open_prs_with_prefix(self, label_prefix: Union[str, tuple], remediation_id: str) -> int:
         """
         Counts open PRs with labels matching a prefix.
 
         Args:
-            label_prefix (str): Label prefix to match
+            label_prefix: Label prefix to match; accepts a tuple for str.startswith multi-prefix matching
             remediation_id (str): Remediation ID for error context
 
         Returns:

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -193,7 +193,7 @@ def get_vuln_token_totals() -> tuple[int, int]:
 def record_vulnerability_duration(
     elapsed_s: float, outcome: str, rule_name: str, language: Optional[str], source: str,
     severity: Optional[str] = None,
-    northstar_mode: bool = False,
+    mode: str = "CLASSIC",
 ) -> None:
     """Record end-to-end vulnerability fix duration.
 
@@ -204,7 +204,7 @@ def record_vulnerability_duration(
         language: Programming language detected for this app.
         source: Finding source (e.g. "runtime").
         severity: Vulnerability severity (e.g. "CRITICAL", "HIGH").
-        northstar_mode: True when the finding was served via NORTHSTAR_ONLY mode.
+        mode: Remediation mode string from the API (e.g. "CLASSIC", "NORTHSTAR_ONLY").
     """
     try:
         attrs = {
@@ -216,14 +216,14 @@ def record_vulnerability_duration(
             # contrast.finding.source. Keep it as `source`; do not "align" it to the span key.
             "source": source,
             "severity": severity or "unknown",
-            "northstar_mode": northstar_mode,
+            "mode": mode,
         }
         _get_vulnerability_duration_histogram().record(elapsed_s, attrs)
     except Exception as e:
         debug_log(f"OTel metric error in record_vulnerability_duration: {e}")
 
 
-def record_pr_attempt(outcome: str, rule_name: str, coding_agent: str, northstar_mode: bool = False) -> None:
+def record_pr_attempt(outcome: str, rule_name: str, coding_agent: str, mode: str = "CLASSIC") -> None:
     """Record a PR creation attempt.
 
     Note for dashboard consumers: this counter reflects only PRs created by the
@@ -234,14 +234,14 @@ def record_pr_attempt(outcome: str, rule_name: str, coding_agent: str, northstar
         outcome: "success" or "failure".
         rule_name: Contrast rule name.
         coding_agent: Coding agent identifier (e.g. "smartfix").
-        northstar_mode: True when the finding was served via NORTHSTAR_ONLY mode.
+        mode: Remediation mode string from the API (e.g. "CLASSIC", "NORTHSTAR_ONLY").
     """
     try:
         _get_pr_count_counter().add(1, {
             "outcome": outcome,
             "rule_name": rule_name,
             "coding_agent": coding_agent,
-            "northstar_mode": northstar_mode,
+            "mode": mode,
         })
     except Exception:
         pass

--- a/src/smartfix/domains/telemetry/smartfix_metrics.py
+++ b/src/smartfix/domains/telemetry/smartfix_metrics.py
@@ -193,6 +193,7 @@ def get_vuln_token_totals() -> tuple[int, int]:
 def record_vulnerability_duration(
     elapsed_s: float, outcome: str, rule_name: str, language: Optional[str], source: str,
     severity: Optional[str] = None,
+    northstar_mode: bool = False,
 ) -> None:
     """Record end-to-end vulnerability fix duration.
 
@@ -203,6 +204,7 @@ def record_vulnerability_duration(
         language: Programming language detected for this app.
         source: Finding source (e.g. "runtime").
         severity: Vulnerability severity (e.g. "CRITICAL", "HIGH").
+        northstar_mode: True when the finding was served via NORTHSTAR_ONLY mode.
     """
     try:
         attrs = {
@@ -214,13 +216,14 @@ def record_vulnerability_duration(
             # contrast.finding.source. Keep it as `source`; do not "align" it to the span key.
             "source": source,
             "severity": severity or "unknown",
+            "northstar_mode": northstar_mode,
         }
         _get_vulnerability_duration_histogram().record(elapsed_s, attrs)
     except Exception as e:
         debug_log(f"OTel metric error in record_vulnerability_duration: {e}")
 
 
-def record_pr_attempt(outcome: str, rule_name: str, coding_agent: str) -> None:
+def record_pr_attempt(outcome: str, rule_name: str, coding_agent: str, northstar_mode: bool = False) -> None:
     """Record a PR creation attempt.
 
     Note for dashboard consumers: this counter reflects only PRs created by the
@@ -231,12 +234,14 @@ def record_pr_attempt(outcome: str, rule_name: str, coding_agent: str) -> None:
         outcome: "success" or "failure".
         rule_name: Contrast rule name.
         coding_agent: Coding agent identifier (e.g. "smartfix").
+        northstar_mode: True when the finding was served via NORTHSTAR_ONLY mode.
     """
     try:
         _get_pr_count_counter().add(1, {
             "outcome": outcome,
             "rule_name": rule_name,
             "coding_agent": coding_agent,
+            "northstar_mode": northstar_mode,
         })
     except Exception:
         pass

--- a/src/smartfix/domains/telemetry/telemetry_handler.py
+++ b/src/smartfix/domains/telemetry/telemetry_handler.py
@@ -39,7 +39,7 @@ def reset_vuln_specific_telemetry() -> None:
 
     _telemetry_data["vulnInfo"]["vulnId"] = None
     _telemetry_data["vulnInfo"]["vulnRule"] = None
-    _telemetry_data["vulnInfo"]["northstarMode"] = False
+    _telemetry_data["vulnInfo"]["northstarMode"] = "CLASSIC"
     _telemetry_data["appInfo"]["programmingLanguage"] = None
     _telemetry_data["appInfo"]["technicalStackInfo"] = None
     _telemetry_data["appInfo"]["frameworksAndLibraries"] = []
@@ -65,7 +65,7 @@ def initialize_telemetry() -> None:
         "vulnInfo": {
             "vulnId": None,
             "vulnRule": None,
-            "northstarMode": False,
+            "northstarMode": "CLASSIC",
         },
         "appInfo": {
             "programmingLanguage": None,

--- a/src/smartfix/domains/telemetry/telemetry_handler.py
+++ b/src/smartfix/domains/telemetry/telemetry_handler.py
@@ -39,6 +39,7 @@ def reset_vuln_specific_telemetry() -> None:
 
     _telemetry_data["vulnInfo"]["vulnId"] = None
     _telemetry_data["vulnInfo"]["vulnRule"] = None
+    _telemetry_data["vulnInfo"]["northstarMode"] = False
     _telemetry_data["appInfo"]["programmingLanguage"] = None
     _telemetry_data["appInfo"]["technicalStackInfo"] = None
     _telemetry_data["appInfo"]["frameworksAndLibraries"] = []
@@ -63,7 +64,8 @@ def initialize_telemetry() -> None:
         "teamServerHost": config.CONTRAST_HOST,
         "vulnInfo": {
             "vulnId": None,
-            "vulnRule": None
+            "vulnRule": None,
+            "northstarMode": False,
         },
         "appInfo": {
             "programmingLanguage": None,

--- a/src/smartfix/domains/vulnerability/context.py
+++ b/src/smartfix/domains/vulnerability/context.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from dataclasses import dataclass
 
 from .models import Vulnerability
+from src.smartfix.shared.constants import CLASSIC
 
 
 @dataclass
@@ -240,3 +241,5 @@ class RemediationContext:
     session_id: Optional[str] = None
     issue_body: Optional[str] = None
     language: Optional[str] = None
+    mode: str = CLASSIC
+    issue_id: Optional[str] = None

--- a/src/smartfix/shared/constants.py
+++ b/src/smartfix/shared/constants.py
@@ -1,0 +1,21 @@
+# -
+# #%L
+# Contrast AI SmartFix
+# %%
+# Copyright (C) 2026 Contrast Security, Inc.
+# %%
+# Contact: support@contrastsecurity.com
+# License: Commercial
+# NOTICE: This Software and the patented inventions embodied within may only be
+# used as part of Contrast Security's commercial offerings. Even though it is
+# made available through public repositories, use of this Software is subject to
+# the applicable End User Licensing Agreement found at
+# https://www.contrastsecurity.com/enduser-terms-0317a or as otherwise agreed
+# between Contrast Security and the End User. The Software may not be reverse
+# engineered, modified, repackaged, sold, redistributed or otherwise used in a
+# way not consistent with the End User License Agreement.
+# #L%
+#
+
+CLASSIC = "CLASSIC"
+NORTHSTAR_ONLY = "NORTHSTAR_ONLY"

--- a/test/test_closed_handler.py
+++ b/test/test_closed_handler.py
@@ -185,6 +185,18 @@ class TestClosedHandler(unittest.TestCase):
             result = closed_handler._extract_remediation_info(pull_request)
         self.assertEqual(result[0], "REM-999")
 
+    def test_extract_vulnerability_info_northstar_issue_id(self):
+        """Test _extract_vulnerability_info returns issueId from contrast-issue-id: label."""
+        labels = [{"name": "contrast-issue-id:ISS-2026-42"}]
+        result = closed_handler._extract_vulnerability_info(labels)
+        self.assertEqual(result, "ISS-2026-42")
+
+    def test_extract_vulnerability_info_classic_label(self):
+        """Test _extract_vulnerability_info still handles classic contrast-vuln-id: label."""
+        labels = [{"name": "contrast-vuln-id:VULN-classic-uuid"}]
+        result = closed_handler._extract_vulnerability_info(labels)
+        self.assertEqual(result, "classic-uuid")
+
     def test_load_github_event_missing_path(self):
         """Test _load_github_event when GITHUB_EVENT_PATH is not set"""
         # Reset the mock to clear any previous calls

--- a/test/test_github_operations.py
+++ b/test/test_github_operations.py
@@ -42,6 +42,22 @@ class TestGitHubOperations(unittest.TestCase):
         self.assertEqual(description, expected_desc)
         self.assertEqual(color, expected_color)
 
+    def test_generate_label_details_northstar_mode(self):
+        """Test label details generation for NORTHSTAR_ONLY mode uses contrast-issue-id prefix."""
+        label_name, description, color = self.github_ops.generate_label_details(
+            "test-uuid-123", mode="NORTHSTAR_ONLY", issue_id="ISS-2026-42"
+        )
+        self.assertEqual(label_name, "contrast-issue-id:ISS-2026-42")
+        self.assertEqual(description, "Issue identified by Contrast AI SmartFix")
+        self.assertEqual(color, "ff0000")
+
+    def test_generate_label_details_classic_mode_unchanged(self):
+        """Test label details for CLASSIC mode unchanged when mode is explicit."""
+        label_name, description, color = self.github_ops.generate_label_details(
+            "test-uuid-123", mode="CLASSIC"
+        )
+        self.assertEqual(label_name, "contrast-vuln-id:VULN-test-uuid-123")
+
     def test_generate_pr_title(self):
         """Test PR title generation."""
         result = self.github_ops.generate_pr_title("SQL Injection vulnerability")

--- a/test/test_github_operations.py
+++ b/test/test_github_operations.py
@@ -168,6 +168,20 @@ class TestGitHubOperations(unittest.TestCase):
         result = self.github_ops.count_open_prs_with_prefix("smartfix-id:", "test-remediation-id")
         self.assertEqual(result, 3)  # Three PRs have smartfix-id: labels
 
+    @patch('src.github.github_operations.run_command')
+    def test_count_open_prs_with_prefix_tuple(self, mock_run_command):
+        """Test counting open PRs accepts a tuple of prefixes (classic + northstar)."""
+        mock_run_command.return_value = json.dumps([
+            {"labels": [{"name": "contrast-vuln-id:VULN-aaa"}]},
+            {"labels": [{"name": "contrast-issue-id:ISS-2026-1"}]},
+            {"labels": [{"name": "unrelated-label"}]},
+        ])
+
+        result = self.github_ops.count_open_prs_with_prefix(
+            ("contrast-vuln-id:", "contrast-issue-id:"), "test-remediation-id"
+        )
+        self.assertEqual(result, 2)
+
     @patch('src.github.github_operations.error_exit')
     @patch('src.github.github_operations.log')
     @patch('src.github.github_operations.run_command')

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -189,7 +189,7 @@ class TestMain(unittest.TestCase):
                         output = buf.getvalue()
 
                     # Verify the vulnerability was skipped both times
-                    self.assertIn("Skipping vulnerability TEST-VULN-UUID-123", output)
+                    self.assertIn("Skipping finding TEST-VULN-UUID-123", output)
                     self.assertIn("TEST-VULN-UUID-123 was re-suggested after being skipped", output)
 
                     # Verify the loop broke cleanly

--- a/test/test_merge_handler.py
+++ b/test/test_merge_handler.py
@@ -334,6 +334,24 @@ class TestMergeHandler(unittest.TestCase):
         result = merge_handler._extract_vulnerability_info(labels)
         self.assertEqual(result, "unknown")
 
+    def test_extract_vulnerability_info_with_northstar_issue_id(self):
+        """Test _extract_vulnerability_info returns issueId from contrast-issue-id: label."""
+        labels = [
+            {"name": "contrast-issue-id:ISS-2026-42"},
+            {"name": "other-label"}
+        ]
+        result = merge_handler._extract_vulnerability_info(labels)
+        self.assertEqual(result, "ISS-2026-42")
+
+    def test_extract_vulnerability_info_prefers_first_matching_label(self):
+        """Test _extract_vulnerability_info returns the first SmartFix label found."""
+        labels = [
+            {"name": "other-label"},
+            {"name": "contrast-vuln-id:VULN-classic-uuid"},
+        ]
+        result = merge_handler._extract_vulnerability_info(labels)
+        self.assertEqual(result, "classic-uuid")
+
     @patch('src.merge_handler.get_config')
     @patch('src.merge_handler.contrast_api.notify_remediation_pr_merged_org')
     def test_notify_remediation_service_success(self, mock_notify, mock_get_config):

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -132,22 +132,22 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
             "language": "java",
             "source": "runtime",
             "severity": "unknown",
-            "northstar_mode": False,
+            "mode": "CLASSIC",
         })
 
-    def test_records_northstar_mode_true(self):
+    def test_records_northstar_only_mode(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.record_vulnerability_duration(1.0, "success", "sql-injection", "java", "runtime", northstar_mode=True)
+        m.record_vulnerability_duration(1.0, "success", "sql-injection", "java", "runtime", mode="NORTHSTAR_ONLY")
 
         attrs = self.mock_histogram.record.call_args[0][1]
-        self.assertTrue(attrs["northstar_mode"])
+        self.assertEqual(attrs["mode"], "NORTHSTAR_ONLY")
 
-    def test_records_northstar_mode_false_by_default(self):
+    def test_records_classic_mode_by_default(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
         m.record_vulnerability_duration(1.0, "success", "sql-injection", "java", "runtime")
 
         attrs = self.mock_histogram.record.call_args[0][1]
-        self.assertFalse(attrs["northstar_mode"])
+        self.assertEqual(attrs["mode"], "CLASSIC")
 
     def test_includes_severity_when_provided(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
@@ -192,7 +192,7 @@ class TestRecordPrAttempt(unittest.TestCase):
             "outcome": "success",
             "rule_name": "sql-injection",
             "coding_agent": "smartfix",
-            "northstar_mode": False,
+            "mode": "CLASSIC",
         })
 
     def test_records_failure(self):
@@ -203,15 +203,15 @@ class TestRecordPrAttempt(unittest.TestCase):
             "outcome": "failure",
             "rule_name": "xss",
             "coding_agent": "github_copilot",
-            "northstar_mode": False,
+            "mode": "CLASSIC",
         })
 
-    def test_records_northstar_mode_true(self):
+    def test_records_northstar_only_mode(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
-        m.record_pr_attempt("success", "sql-injection", "smartfix", northstar_mode=True)
+        m.record_pr_attempt("success", "sql-injection", "smartfix", mode="NORTHSTAR_ONLY")
 
         attrs = self.mock_counter.add.call_args[0][1]
-        self.assertTrue(attrs["northstar_mode"])
+        self.assertEqual(attrs["mode"], "NORTHSTAR_ONLY")
 
     def test_suppresses_instrument_errors(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m

--- a/test/test_smartfix_metrics.py
+++ b/test/test_smartfix_metrics.py
@@ -132,7 +132,22 @@ class TestRecordVulnerabilityDuration(unittest.TestCase):
             "language": "java",
             "source": "runtime",
             "severity": "unknown",
+            "northstar_mode": False,
         })
+
+    def test_records_northstar_mode_true(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_duration(1.0, "success", "sql-injection", "java", "runtime", northstar_mode=True)
+
+        attrs = self.mock_histogram.record.call_args[0][1]
+        self.assertTrue(attrs["northstar_mode"])
+
+    def test_records_northstar_mode_false_by_default(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_vulnerability_duration(1.0, "success", "sql-injection", "java", "runtime")
+
+        attrs = self.mock_histogram.record.call_args[0][1]
+        self.assertFalse(attrs["northstar_mode"])
 
     def test_includes_severity_when_provided(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m
@@ -177,6 +192,7 @@ class TestRecordPrAttempt(unittest.TestCase):
             "outcome": "success",
             "rule_name": "sql-injection",
             "coding_agent": "smartfix",
+            "northstar_mode": False,
         })
 
     def test_records_failure(self):
@@ -187,7 +203,15 @@ class TestRecordPrAttempt(unittest.TestCase):
             "outcome": "failure",
             "rule_name": "xss",
             "coding_agent": "github_copilot",
+            "northstar_mode": False,
         })
+
+    def test_records_northstar_mode_true(self):
+        import src.smartfix.domains.telemetry.smartfix_metrics as m
+        m.record_pr_attempt("success", "sql-injection", "smartfix", northstar_mode=True)
+
+        attrs = self.mock_counter.add.call_args[0][1]
+        self.assertTrue(attrs["northstar_mode"])
 
     def test_suppresses_instrument_errors(self):
         import src.smartfix.domains.telemetry.smartfix_metrics as m


### PR DESCRIPTION
## Summary

Adds NorthStar-only mode support to `contrast-ai-smartfix-action`. When `aiml-remediation-api` returns `mode = NORTHSTAR_ONLY` in the vulnerability response, the action uses `issueId` as the primary identifier throughout. Classic mode behaviour is unchanged.

## Jira

[AIML-820](https://contrast.atlassian.net/browse/AIML-820) — child of [AIML-16](https://contrast.atlassian.net/browse/AIML-16)

## Changes

**I.1 — `src/main.py`:** Extract `mode` and `issueId` from API response in both processing paths (SmartFix and external agents). Compute `primary_id = issueId if NORTHSTAR_ONLY else vuln_uuid`. Use `primary_id` for duplicate detection, `skipped_vulns`, telemetry, and logging. Rename `previous_vuln_uuid` → `previous_primary_id`. Change `label_prefix_to_check` to a tuple covering both prefixes.

**I.2+I.3 — `src/github/github_operations.py`, `src/github/constants.py`, `src/merge_handler.py`, `src/closed_handler.py`:**
- `generate_label_details`: new `mode` + `issue_id` params; returns `contrast-issue-id:{issueId}` for NS, `contrast-vuln-id:VULN-{uuid}` for Classic
- `SMARTFIX_LABEL_PREFIXES`: add `contrast-issue-id:` so `filter_smartfix_labels` and `add_labels_to_pr` recognise NS labels
- `_extract_vulnerability_info` (both handlers): recognise `contrast-issue-id:` in addition to `contrast-vuln-id:VULN-`
- `count_open_prs_with_prefix`: accepts string or tuple of prefixes

**I.4 — Branch naming:** No-op — `remediationId` in the response is always a backend UUID (independent of vuln UUID or issue ID). Branch format `smartfix/remediation-{remediationId}` already works correctly for NS mode.

**I.5 — `src/github/external_coding_agent.py`:** For `NORTHSTAR_ONLY`, builds NorthStar UI deeplink `{host}/Contrast/cs/index.html#{orgId}/issues/{issueId}`. Classic URL unchanged.

## Testing

- ✅ 976 tests passing (`make test`)
- New tests: NS label generation, NS label parsing (merge + closed handlers), NS URL in external agent

[AIML-820]: https://contrast.atlassian.net/browse/AIML-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIML-16]: https://contrast.atlassian.net/browse/AIML-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ