### PR TITLE
AIML-1005: Update docs to document NorthStar-only (SAST-only) mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ When you use Contrast AI SmartFix, you agree that your code and other data will 
 
 ## Introduction
 
-Welcome to Contrast AI SmartFix\! SmartFix is an AI-powered agent that automatically generates code fixes for vulnerabilities identified by Contrast Assess. It integrates into your developer workflow via GitHub Actions, creating Pull Requests (PRs) with proposed remediations.
+Welcome to Contrast AI SmartFix\! SmartFix is an AI-powered agent that automatically generates code fixes for security vulnerabilities identified by Contrast Security. It integrates into your developer workflow via GitHub Actions, creating Pull Requests (PRs) with proposed remediations.
 
 **Key Benefits:**
 
 * **Automated Remediation:** Reduces the manual effort and time required to fix vulnerabilities.
 * **Developer-Focused:** Delivers fixes as PRs directly in your GitHub repository, fitting naturally into existing workflows.
-* **Runtime Context:** Leverages Contrast Assess's runtime analysis (IAST) to provide more accurate and relevant fixes.
+* **Vulnerability Context:** Leverages Contrast's vulnerability data — including IAST runtime findings from Contrast Assess and static findings from NorthStar — to provide accurate and relevant fixes.
 
 ## Getting Started
 
@@ -41,7 +41,7 @@ Please follow the specific setup instructions link for the coding agent of your 
 ## FAQ
 
 * **Q: Can I use SmartFix if I don't use Contrast Assess?**
-  * A: No, SmartFix relies on vulnerability data from Contrast Assess. In the future we plan to expand to include more.
+  * A: Yes, if your organization uses static analysis (NorthStar/SAST), SmartFix can operate in SAST-only mode. Simply omit `contrast_app_id` and `contrast_app_ids` from your workflow configuration. SmartFix still requires a Contrast account and organization.
 * **Q: How often does SmartFix run?**
   * A: This is determined by the `schedule` trigger in your GitHub Actions workflow file. You can customize it.
 * **Q: What happens if the AI cannot generate a fix?**

--- a/docs/claude_code.md
+++ b/docs/claude_code.md
@@ -14,13 +14,13 @@ When the `@claude` handle is mentioned in the title of a SmartFix-created GitHub
 
 * **Automated Remediation:** Reduces the manual effort and time required to fix vulnerabilities.
 * **Developer-Focused:** Delivers fixes as PRs directly in your GitHub repository, fitting naturally into existing workflows.
-* **Runtime Context:** Leverages Contrast Assess's runtime analysis (IAST) to provide more accurate and relevant fixes.
+* **Vulnerability Context:** Leverages Contrast's vulnerability data — including IAST runtime findings from Contrast Assess and static findings from NorthStar — to provide accurate and relevant fixes.
 
 ## Getting Started
 
 ### Prerequisites
 
-* **Contrast Assess:** You need an active Contrast Assess deployment identifying vulnerabilities in your application.
+* **Contrast Security:** You need an active Contrast deployment identifying vulnerabilities in your application — either Contrast Assess (IAST) for runtime findings, or NorthStar (SAST) for static-only organizations.
 * **GitHub:** Your project must be hosted on GitHub and use GitHub Actions.  In the GitHub repository's Settings, enable the Actions > General > Workflow Permissions checkbox for "Allow GitHub Actions to create and approve pull requests".
 * **Claude Code Requirements:**
     * Follow the Claude setup docs: [Claude Code GitHub Actions](https://docs.claude.com/en/docs/claude-code/github-actions#setup)
@@ -34,7 +34,7 @@ When the `@claude` handle is mentioned in the title of a SmartFix-created GitHub
     * **Actions**: Read (optional, for monitoring workflow status)
     * **Metadata**: Read (automatically included with all fine-grained PATs)
   * **Suggestion:** Set up a GitHub service account and use that to make the PAT for more explicit tracking of SmartFix's work in GitHub.
-* **Contrast API Credentials:** You will need your Contrast Host, Organization ID, Application ID, Authorization Key, and API Key.
+* **Contrast API Credentials:** You will need your Contrast Host, Organization ID, Authorization Key, and API Key. Also provide your Application ID if your organization uses Contrast Assess (IAST); omit it for NorthStar-only (SAST-only) organizations.
 * **LLM Access:** Ensure that you have access to one of our recommended LLMs for use with SmartFix.  If using an AWS Bedrock model, please see Amazon's User Guide on [model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 
 Set the gathered values as secrets and variables for the GitHub repository at Settings tab > Secrets and Variables in the sidebar > Actions.
@@ -47,7 +47,7 @@ Secrets:
 Variables:
 * CONTRAST_HOST (The host name of your Contrast SaaS instance, e.g. 'app.contrastsecurity.com')
 * CONTRAST_ORG_ID (The UUID of your Contrast organization)
-* CONTRAST_APP_ID (The UUID that is specific to the application in this repository.)
+* CONTRAST_APP_ID (The UUID that is specific to the application in this repository. Omit for NorthStar-only/SAST-only organizations.)
 * Any other non-secret values, such as the AWS region for a Bedrock-provided LLM
 
 ### Installation and Configuration
@@ -95,7 +95,7 @@ jobs:
           # Contrast Configuration
           contrast_host: ${{ vars.CONTRAST_HOST }} # The host name of your Contrast SaaS instance, e.g. 'app.contrastsecurity.com'
           contrast_org_id: ${{ vars.CONTRAST_ORG_ID }} # The UUID of your Contrast organization
-          contrast_app_id: ${{ vars.CONTRAST_APP_ID }} # The UUID that is specific to the application in this repository.
+          contrast_app_id: ${{ vars.CONTRAST_APP_ID }} # Optional: omit for NorthStar-only (SAST-only) organizations
           contrast_authorization_key: ${{ secrets.CONTRAST_AUTHORIZATION_KEY }}
           contrast_api_key: ${{ secrets.CONTRAST_API_KEY }}
 
@@ -113,7 +113,7 @@ jobs:
 
 * Store all sensitive values (API keys, tokens) as GitHub Secrets in your repository or Github organization settings.
 * Replace `v1` with the specific version of the SmartFix GitHub Action you intend to use.
-* The `contrast_app_id` must correspond to the Contrast Application ID for the code in the repository where this action runs.  To find the app ID, visit the application page in the Contrast web UI, then use the last UUID in the URL (immediately after `/applications/`) as the app ID value.
+* The `contrast_app_id` must correspond to the Contrast Application ID for the code in the repository where this action runs.  To find the app ID, visit the application page in the Contrast web UI, then use the last UUID in the URL (immediately after `/applications/`) as the app ID value.  Omit `contrast_app_id` (and `contrast_app_ids`) for NorthStar-only organizations — SmartFix will run in SAST-only mode and address static findings without an app ID.
 * Set the `coding_agent` value to `CLAUDE_CODE` to force the SmartFix GitHub Action to use the Claude Code coding agent.
 
 ### Supported Languages
@@ -131,7 +131,7 @@ Note: the SmartFix action's setup steps rely on the bash shell.  Please ensure t
 
 SmartFix focuses on remediating:
 
-* **CRITICAL** and **HIGH** severity vulnerabilities identified by Contrast Assess.
+* **CRITICAL** and **HIGH** severity vulnerabilities identified by Contrast, including IAST findings from Contrast Assess and static SAST findings from NorthStar.
 * **Exclusions:**
   * Cross-Site Request Forgery (CSRF) is currently excluded due to the complexity of fixes often requiring API changes.
   * Other specific vulnerability types may be excluded based on ongoing testing by Contrast Labs.
@@ -167,7 +167,7 @@ The following are key inputs for the SmartFix GitHub Action using the GitHub Cla
 | `base_branch` | Base branch for PRs. | No | `${{ github.event.repository.default_branch }}` |
 | `contrast_host` | Contrast Security API host. | Yes |  |
 | `contrast_org_id` | Contrast Organization ID. | Yes |  |
-| `contrast_app_id` | Contrast Application ID for the repository. | Yes |  |
+| `contrast_app_id` | Contrast Application ID for the repository. Omit for NorthStar-only (SAST-only) organizations. | No |  |
 | `contrast_authorization_key` | Contrast Authorization Key. | Yes |  |
 | `contrast_api_key` | Contrast API Key. | Yes |  |
 | `coding_agent` | Specify that SmartFix should use Claude Code as the coding agent. | Yes | `CLAUDE_CODE` |
@@ -205,7 +205,7 @@ SmartFix collects telemetry data to help improve the service and diagnose issues
   * Ensure the `PAT_token` has the necessary permissions (Issues: read-write, Pull requests: read-write, Contents: read-write, Actions: read, Metadata: read).
   * Check for branch protection rules that might prevent PR creation.
 * **No Fixes Generated:**
-  * Confirm there are eligible CRITICAL or HIGH severity vulnerabilities in Contrast Assess for the configured `contrast_app_id`. SmartFix only attempts to fix vulnerabilities that are in the REPORTED state.
+  * Confirm there are eligible CRITICAL or HIGH severity vulnerabilities in Contrast. For Contrast Assess (IAST) deployments, check under the configured `contrast_app_id`. For NorthStar-only (SAST-only) deployments — where `contrast_app_id` is intentionally omitted — confirm there are eligible SAST findings in your Contrast organization. SmartFix only attempts to fix vulnerabilities that are in the REPORTED state.
   * Check the `max_open_prs` limit; if the number of PRs SmartFix has created that are still open matches this limit, no new PRs will be created.
   * Review the GitHub Action logs for messages indicating why vulnerabilities might have been skipped.
 * **Incorrect Fixes:** The AI-generated fixes should **always** be reviewed carefully. If a fix is incorrect or incomplete:
@@ -219,7 +219,7 @@ SmartFix collects telemetry data to help improve the service and diagnose issues
 ## FAQ
 
 * **Q: Can I use SmartFix if I don't use Contrast Assess?**
-  * A: No, SmartFix relies on vulnerability data from Contrast Assess. In the future we plan to expand to include more.
+  * A: Yes, if your organization uses static analysis (NorthStar/SAST), SmartFix can operate in SAST-only mode. Simply omit `contrast_app_id` and `contrast_app_ids` from your workflow configuration. SmartFix still requires a Contrast account and organization.
 * **Q: How often does SmartFix run?**
   * A: This is determined by the `schedule` trigger in your GitHub Actions workflow file. You can customize it.
 * **Q: What happens if the AI cannot generate a fix?**

--- a/docs/claude_code.md
+++ b/docs/claude_code.md
@@ -161,19 +161,19 @@ SmartFix focuses on remediating:
 
 The following are key inputs for the SmartFix GitHub Action using the GitHub Claude code coding agent. Refer to the `action.yml` in the SmartFix GitHub Action repository for a complete list and default values.
 
-| Input                        | Description                                                                                                                                                                                            | Required | Default                                         |
-| :--------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :---------------------------------------------- |
-| `github_token`               | GitHub PAT token for Issue and PR operations.                                                                                                                                                          | Yes      |                                                 |
-| `base_branch`                | Base branch for PRs.                                                                                                                                                                                   | No       | `${{ github.event.repository.default_branch }}` |
-| `contrast_host`              | Contrast Security API host.                                                                                                                                                                            | Yes      |                                                 |
-| `contrast_org_id`            | Contrast Organization ID.                                                                                                                                                                              | Yes      |                                                 |
-| `contrast_app_id`            | Contrast Application ID for the repository. Omit for NorthStar-only organizations with only static findings from Contrast Code.                                                                        | No       |                                                 |
-| `contrast_authorization_key` | Contrast Authorization Key.                                                                                                                                                                            | Yes      |                                                 |
-| `contrast_api_key`           | Contrast API Key.                                                                                                                                                                                      | Yes      |                                                 |
-| `coding_agent`               | Specify that SmartFix should use Claude Code as the coding agent.                                                                                                                                      | Yes      | `CLAUDE_CODE`                                   |
-| `max_open_prs`               | Maximum number of open PRs SmartFix can create.                                                                                                                                                        | No       | `5`                                             |
-| `debug_mode`                 | Enable verbose logging.                                                                                                                                                                                | No       | `false`                                         |
-| `enable_full_telemetry`      | Control how much telemetry data is sent back to Contrast. When set to 'true' (default), sends complete log files and build commands. When 'false', sensitive build commands and full logs are omitted. | No       | `true`                                          |
+| Input | Description | Required | Default |
+| :---- | :---- | :---- | :---- |
+| `github_token` | GitHub PAT token for Issue and PR operations. | Yes |  |
+| `base_branch` | Base branch for PRs. | No | `${{ github.event.repository.default_branch }}` |
+| `contrast_host` | Contrast Security API host. | Yes |  |
+| `contrast_org_id` | Contrast Organization ID. | Yes |  |
+| `contrast_app_id` | Contrast Application ID for the repository. Omit for NorthStar-only (SAST-only) organizations. | No |  |
+| `contrast_authorization_key` | Contrast Authorization Key. | Yes |  |
+| `contrast_api_key` | Contrast API Key. | Yes |  |
+| `coding_agent` | Specify that SmartFix should use Claude Code as the coding agent. | Yes | `CLAUDE_CODE` |
+| `max_open_prs` | Maximum number of open PRs SmartFix can create. | No | `5` |
+| `debug_mode` | Enable verbose logging. | No | `false` |
+| `enable_full_telemetry` | Control how much telemetry data is sent back to Contrast. When set to 'true' (default), sends complete log files and build commands. When 'false', sensitive build commands and full logs are omitted. | No | `true` |
 
 ## Telemetry
 

--- a/docs/claude_code.md
+++ b/docs/claude_code.md
@@ -20,7 +20,7 @@ When the `@claude` handle is mentioned in the title of a SmartFix-created GitHub
 
 ### Prerequisites
 
-* **Contrast Security:** You need an active Contrast deployment identifying vulnerabilities in your application — either Contrast Assess (IAST) for runtime findings, or NorthStar (SAST) for static-only organizations.
+* **Contrast Security:** You need an active Contrast deployment identifying vulnerabilities in your application — either Contrast Assess (IAST) for runtime findings for Contrast Classic, or static findings from Contrast Code for NorthStar-only organizations.
 * **GitHub:** Your project must be hosted on GitHub and use GitHub Actions.  In the GitHub repository's Settings, enable the Actions > General > Workflow Permissions checkbox for "Allow GitHub Actions to create and approve pull requests".
 * **Claude Code Requirements:**
     * Follow the Claude setup docs: [Claude Code GitHub Actions](https://docs.claude.com/en/docs/claude-code/github-actions#setup)
@@ -34,7 +34,7 @@ When the `@claude` handle is mentioned in the title of a SmartFix-created GitHub
     * **Actions**: Read (optional, for monitoring workflow status)
     * **Metadata**: Read (automatically included with all fine-grained PATs)
   * **Suggestion:** Set up a GitHub service account and use that to make the PAT for more explicit tracking of SmartFix's work in GitHub.
-* **Contrast API Credentials:** You will need your Contrast Host, Organization ID, Authorization Key, and API Key. Also provide your Application ID if your organization uses Contrast Assess (IAST); omit it for NorthStar-only (SAST-only) organizations.
+* **Contrast API Credentials:** You will need your Contrast Host, Organization ID, Authorization Key, and API Key. Also provide your Application ID if your organization uses Contrast Assess (IAST); omit it for NorthStar-only (Contrast Code static SAST) organizations.
 * **LLM Access:** Ensure that you have access to one of our recommended LLMs for use with SmartFix.  If using an AWS Bedrock model, please see Amazon's User Guide on [model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 
 Set the gathered values as secrets and variables for the GitHub repository at Settings tab > Secrets and Variables in the sidebar > Actions.
@@ -111,7 +111,7 @@ jobs:
 
 **Important:**
 
-* Store all sensitive values (API keys, tokens) as GitHub Secrets in your repository or Github organization settings.
+* Store all sensitive values (API keys, tokens) as GitHub Secrets in your repository or GitHub organization settings.
 * Replace `v1` with the specific version of the SmartFix GitHub Action you intend to use.
 * The `contrast_app_id` must correspond to the Contrast Application ID for the code in the repository where this action runs.  To find the app ID, visit the application page in the Contrast web UI, then use the last UUID in the URL (immediately after `/applications/`) as the app ID value.  Omit `contrast_app_id` (and `contrast_app_ids`) for NorthStar-only organizations — SmartFix will run in SAST-only mode and address static findings without an app ID.
 * Set the `coding_agent` value to `CLAUDE_CODE` to force the SmartFix GitHub Action to use the Claude Code coding agent.
@@ -131,7 +131,7 @@ Note: the SmartFix action's setup steps rely on the bash shell.  Please ensure t
 
 SmartFix focuses on remediating:
 
-* **CRITICAL** and **HIGH** severity vulnerabilities identified by Contrast, including IAST findings from Contrast Assess and static SAST findings from NorthStar.
+* **CRITICAL** and **HIGH** severity vulnerabilities identified by Contrast, including IAST findings from Contrast Assess and static SAST findings from Contrast Code for NorthStar.
 * **Exclusions:**
   * Cross-Site Request Forgery (CSRF) is currently excluded due to the complexity of fixes often requiring API changes.
   * Other specific vulnerability types may be excluded based on ongoing testing by Contrast Labs.
@@ -152,7 +152,7 @@ SmartFix focuses on remediating:
    * If SmartFix sees that it has reached the configured `max_open_prs` number of concurrently open SmartFix PRs, it will end its workflow run.
    * If SmartFix has reached its internal time limit of 3 hours of processing time for some reason, it will stop the workflow run instead of requesting a new vulnerability to resolve.
    * If SmartFix encounters an exception of some kind, it will stop the workflow run.
-11. **Exceptions:** Sometimes things go wrong.  When SmartFix cannot generate a fix for the vulnerability, it will log the reason why, try to clean up the Github feature branches that have been made for that vulnerability, and exit the workflow early.
+11. **Exceptions:** Sometimes things go wrong.  When SmartFix cannot generate a fix for the vulnerability, it will log the reason why, try to clean up the GitHub feature branches that have been made for that vulnerability, and exit the workflow early.
 12. **Guardrails:** SmartFix has several configurable and internal guardrails:
    * *Time limit* - SmartFix has an internal time limit of 3 hours.  If it goes over 3 hours of processing time, it will not request another vulnerability to resolve.
    * `max_open_prs` - SmartFix offers this configurable value to control the maximum number concurrently open SmartFix PRs.
@@ -161,19 +161,19 @@ SmartFix focuses on remediating:
 
 The following are key inputs for the SmartFix GitHub Action using the GitHub Claude code coding agent. Refer to the `action.yml` in the SmartFix GitHub Action repository for a complete list and default values.
 
-| Input | Description | Required | Default |
-| :---- | :---- | :---- | :---- |
-| `github_token` | GitHub PAT token for Issue and PR operations. | Yes |  |
-| `base_branch` | Base branch for PRs. | No | `${{ github.event.repository.default_branch }}` |
-| `contrast_host` | Contrast Security API host. | Yes |  |
-| `contrast_org_id` | Contrast Organization ID. | Yes |  |
-| `contrast_app_id` | Contrast Application ID for the repository. Omit for NorthStar-only (SAST-only) organizations. | No |  |
-| `contrast_authorization_key` | Contrast Authorization Key. | Yes |  |
-| `contrast_api_key` | Contrast API Key. | Yes |  |
-| `coding_agent` | Specify that SmartFix should use Claude Code as the coding agent. | Yes | `CLAUDE_CODE` |
-| `max_open_prs` | Maximum number of open PRs SmartFix can create. | No | `5` |
-| `debug_mode` | Enable verbose logging. | No | `false` |
-| `enable_full_telemetry` | Control how much telemetry data is sent back to Contrast. When set to 'true' (default), sends complete log files and build commands. When 'false', sensitive build commands and full logs are omitted. | No | `true` |
+| Input                        | Description                                                                                                                                                                                            | Required | Default                                         |
+| :--------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :---------------------------------------------- |
+| `github_token`               | GitHub PAT token for Issue and PR operations.                                                                                                                                                          | Yes      |                                                 |
+| `base_branch`                | Base branch for PRs.                                                                                                                                                                                   | No       | `${{ github.event.repository.default_branch }}` |
+| `contrast_host`              | Contrast Security API host.                                                                                                                                                                            | Yes      |                                                 |
+| `contrast_org_id`            | Contrast Organization ID.                                                                                                                                                                              | Yes      |                                                 |
+| `contrast_app_id`            | Contrast Application ID for the repository. Omit for NorthStar-only organizations with only static findings from Contrast Code.                                                                        | No       |                                                 |
+| `contrast_authorization_key` | Contrast Authorization Key.                                                                                                                                                                            | Yes      |                                                 |
+| `contrast_api_key`           | Contrast API Key.                                                                                                                                                                                      | Yes      |                                                 |
+| `coding_agent`               | Specify that SmartFix should use Claude Code as the coding agent.                                                                                                                                      | Yes      | `CLAUDE_CODE`                                   |
+| `max_open_prs`               | Maximum number of open PRs SmartFix can create.                                                                                                                                                        | No       | `5`                                             |
+| `debug_mode`                 | Enable verbose logging.                                                                                                                                                                                | No       | `false`                                         |
+| `enable_full_telemetry`      | Control how much telemetry data is sent back to Contrast. When set to 'true' (default), sends complete log files and build commands. When 'false', sensitive build commands and full logs are omitted. | No       | `true`                                          |
 
 ## Telemetry
 

--- a/docs/contrast_llm_early_access.md
+++ b/docs/contrast_llm_early_access.md
@@ -55,7 +55,7 @@ To use Contrast LLM with the SmartFix Coding Agent, simply set one configuration
     # Standard Contrast configuration (unchanged)
     contrast_host: ${{ vars.CONTRAST_HOST }}
     contrast_org_id: ${{ vars.CONTRAST_ORG_ID }}
-    contrast_app_id: ${{ vars.CONTRAST_APP_ID }}
+    contrast_app_id: ${{ vars.CONTRAST_APP_ID }}  # Optional: omit for NorthStar-only (SAST-only) organizations
     contrast_authorization_key: ${{ secrets.CONTRAST_AUTHORIZATION_KEY }}
     contrast_api_key: ${{ secrets.CONTRAST_API_KEY }}
 
@@ -102,7 +102,7 @@ This flexibility allows customers to gradually migrate or use different configur
 All existing Contrast API parameters remain the same:
 - `contrast_host`
 - `contrast_org_id`
-- `contrast_app_id`
+- `contrast_app_id` _(optional — omit for NorthStar-only/SAST-only organizations)_
 - `contrast_authorization_key`
 - `contrast_api_key`
 
@@ -164,7 +164,7 @@ jobs:
           # --- Contrast API Credentials ---
           contrast_host: ${{ vars.CONTRAST_HOST }}
           contrast_org_id: ${{ vars.CONTRAST_ORG_ID }}
-          contrast_app_id: ${{ vars.CONTRAST_APP_ID }}
+          contrast_app_id: ${{ vars.CONTRAST_APP_ID }}  # Optional: omit for NorthStar-only (SAST-only) organizations
           contrast_authorization_key: ${{ secrets.CONTRAST_AUTHORIZATION_KEY }}
           contrast_api_key: ${{ secrets.CONTRAST_API_KEY }}
 

--- a/docs/github_copilot.md
+++ b/docs/github_copilot.md
@@ -14,13 +14,13 @@ When assigned to a SmartFix-created GitHub Issue describing a Contrast-discovere
 
 * **Automated Remediation:** Reduces the manual effort and time required to fix vulnerabilities.
 * **Developer-Focused:** Delivers fixes as PRs directly in your GitHub repository, fitting naturally into existing workflows.
-* **Runtime Context:** Leverages Contrast Assess's runtime analysis (IAST) to provide more accurate and relevant fixes.
+* **Vulnerability Context:** Leverages Contrast's vulnerability data — including IAST runtime findings from Contrast Assess and static findings from NorthStar — to provide accurate and relevant fixes.
 
 ## Getting Started
 
 ### Prerequisites
 
-* **Contrast Assess:** You need an active Contrast Assess deployment identifying vulnerabilities in your application.
+* **Contrast Security:** You need an active Contrast deployment identifying vulnerabilities in your application — either Contrast Assess (IAST) for runtime findings, or NorthStar (SAST) for static-only organizations.
 * **GitHub:** Your project must be hosted on GitHub and use GitHub Actions.  In the GitHub repository's Settings, enable the Actions > General > Workflow Permissions checkbox for "Allow GitHub Actions to create and approve pull requests".
 * **GitHub Copilot Requirements:**
   * GitHub repository with **Issues** and **GitHub Copilot** enabled
@@ -32,7 +32,7 @@ When assigned to a SmartFix-created GitHub Issue describing a Contrast-discovere
     * **Pull requests**: Read and write (required to create PRs and add labels)
     * **Workflows**: Read and write (required to trigger and monitor GitHub Copilot's workflow execution)
   * **Suggestion:** Set up a GitHub service account and use that to make the PAT for more explicit tracking of SmartFix's work in GitHub.
-* **Contrast API Credentials:** You will need your Contrast Host, Organization ID, Application ID, Authorization Key, and API Key.
+* **Contrast API Credentials:** You will need your Contrast Host, Organization ID, Authorization Key, and API Key. Also provide your Application ID if your organization uses Contrast Assess (IAST); omit it for NorthStar-only (SAST-only) organizations.
 
 Set the gathered values as secrets and variables for the GitHub repository at Settings tab > Secrets and Variables in the sidebar > Actions.
 
@@ -44,7 +44,7 @@ Secrets:
 Variables:
 * CONTRAST_HOST (The host name of your Contrast SaaS instance, e.g. 'app.contrastsecurity.com')
 * CONTRAST_ORG_ID (The UUID of your Contrast organization)
-* CONTRAST_APP_ID (The UUID that is specific to the application in this repository.)
+* CONTRAST_APP_ID (The UUID that is specific to the application in this repository. Omit for NorthStar-only/SAST-only organizations.)
 * Any other non-secret values, such as the AWS region for a Bedrock-provided LLM
 
 ### Installation and Configuration for GitHub Copilot Coding Agent
@@ -91,7 +91,7 @@ jobs:
           # Contrast Configuration
           contrast_host: ${{ vars.CONTRAST_HOST }} # The host name of your Contrast SaaS instance, e.g. 'app.contrastsecurity.com'
           contrast_org_id: ${{ vars.CONTRAST_ORG_ID }} # The UUID of your Contrast organization
-          contrast_app_id: ${{ vars.CONTRAST_APP_ID }} # The UUID that is specific to the application in this repository.
+          contrast_app_id: ${{ vars.CONTRAST_APP_ID }} # Optional: omit for NorthStar-only (SAST-only) organizations
           contrast_authorization_key: ${{ secrets.CONTRAST_AUTHORIZATION_KEY }}
           contrast_api_key: ${{ secrets.CONTRAST_API_KEY }}
 
@@ -109,7 +109,7 @@ jobs:
 
 * Store all sensitive values (API keys, tokens) as GitHub Secrets in your repository or Github organization settings.
 * Replace `v1` with the specific version of the SmartFix GitHub Action you intend to use.
-* The `contrast_app_id` must correspond to the Contrast Application ID for the code in the repository where this action runs.  To find the app ID, visit the application page in the Contrast web UI, then use the last UUID in the URL (immediately after `/applications/`) as the app ID value.
+* The `contrast_app_id` must correspond to the Contrast Application ID for the code in the repository where this action runs.  To find the app ID, visit the application page in the Contrast web UI, then use the last UUID in the URL (immediately after `/applications/`) as the app ID value.  Omit `contrast_app_id` (and `contrast_app_ids`) for NorthStar-only organizations — SmartFix will run in SAST-only mode and address static findings without an app ID.
 * Set the `coding_agent` value to `GITHUB_COPILOT` to force the SmartFix GitHub Action to use the GitHub Copilot coding agent.
 
 ### Supported Languages
@@ -127,7 +127,7 @@ Note: the SmartFix action's setup steps rely on the bash shell.  Please ensure t
 
 SmartFix focuses on remediating:
 
-* **CRITICAL** and **HIGH** severity vulnerabilities identified by Contrast Assess.
+* **CRITICAL** and **HIGH** severity vulnerabilities identified by Contrast, including IAST findings from Contrast Assess and static SAST findings from NorthStar.
 * **Exclusions:**
   * Cross-Site Request Forgery (CSRF) is currently excluded due to the complexity of fixes often requiring API changes.
   * Other specific vulnerability types may be excluded based on ongoing testing by Contrast Labs.
@@ -163,7 +163,7 @@ The following are key inputs for the SmartFix GitHub Action using the GitHub Cop
 | `base_branch` | Base branch for PRs. | No | `${{ github.event.repository.default_branch }}` |
 | `contrast_host` | Contrast Security API host. | Yes |  |
 | `contrast_org_id` | Contrast Organization ID. | Yes |  |
-| `contrast_app_id` | Contrast Application ID for the repository. | Yes |  |
+| `contrast_app_id` | Contrast Application ID for the repository. Omit for NorthStar-only (SAST-only) organizations. | No |  |
 | `contrast_authorization_key` | Contrast Authorization Key. | Yes |  |
 | `contrast_api_key` | Contrast API Key. | Yes |  |
 | `coding_agent` | Specify that SmartFix should use Github Copilot as the coding agent. | Yes | `GITHUB_COPILOT` |
@@ -201,7 +201,7 @@ SmartFix collects telemetry data to help improve the service and diagnose issues
   * Ensure the `PAT_token` has the necessary permissions (Actions: read, Contents: read-write, Issues: read-write, Metadata: read, Pull requests: read-write, Workflows: read-write).
   * Check for branch protection rules that might prevent PR creation.
 * **No Fixes Generated:**
-  * Confirm there are eligible CRITICAL or HIGH severity vulnerabilities in Contrast Assess for the configured `contrast_app_id`. SmartFix only attempts to fix vulnerabilities that are in the REPORTED state.
+  * Confirm there are eligible CRITICAL or HIGH severity vulnerabilities in Contrast. For Contrast Assess (IAST) deployments, check under the configured `contrast_app_id`. For NorthStar-only (SAST-only) deployments — where `contrast_app_id` is intentionally omitted — confirm there are eligible SAST findings in your Contrast organization. SmartFix only attempts to fix vulnerabilities that are in the REPORTED state.
   * Check the `max_open_prs` limit; if the number of PRs SmartFix has created that are still open matches this limit, no new PRs will be created.
   * Review the GitHub Action logs for messages indicating why vulnerabilities might have been skipped.
 * **Incorrect Fixes:** The AI-generated fixes should **always** be reviewed carefully. If a fix is incorrect or incomplete:
@@ -215,7 +215,7 @@ SmartFix collects telemetry data to help improve the service and diagnose issues
 ## FAQ
 
 * **Q: Can I use SmartFix if I don't use Contrast Assess?**
-  * A: No, SmartFix relies on vulnerability data from Contrast Assess. In the future we plan to expand to include more.
+  * A: Yes, if your organization uses static analysis (NorthStar/SAST), SmartFix can operate in SAST-only mode. Simply omit `contrast_app_id` and `contrast_app_ids` from your workflow configuration. SmartFix still requires a Contrast account and organization.
 * **Q: How often does SmartFix run?**
   * A: This is determined by the `schedule` trigger in your GitHub Actions workflow file. You can customize it.
 * **Q: What happens if the AI cannot generate a fix?**

--- a/docs/github_copilot.md
+++ b/docs/github_copilot.md
@@ -107,7 +107,7 @@ jobs:
 
 **Important:**
 
-* Store all sensitive values (API keys, tokens) as GitHub Secrets in your repository or Github organization settings.
+* Store all sensitive values (API keys, tokens) as GitHub Secrets in your repository or GitHub organization settings.
 * Replace `v1` with the specific version of the SmartFix GitHub Action you intend to use.
 * The `contrast_app_id` must correspond to the Contrast Application ID for the code in the repository where this action runs.  To find the app ID, visit the application page in the Contrast web UI, then use the last UUID in the URL (immediately after `/applications/`) as the app ID value.  Omit `contrast_app_id` (and `contrast_app_ids`) for NorthStar-only organizations — SmartFix will run in SAST-only mode and address static findings without an app ID.
 * Set the `coding_agent` value to `GITHUB_COPILOT` to force the SmartFix GitHub Action to use the GitHub Copilot coding agent.
@@ -148,7 +148,7 @@ SmartFix focuses on remediating:
    * If SmartFix sees that it has reached the configured `max_open_prs` number of concurrently open SmartFix PRs, it will end its workflow run.
    * If SmartFix has reached its internal time limit of 3 hours of processing time for some reason, it will stop the workflow run instead of requesting a new vulnerability to resolve.
    * If SmartFix encounters an exception of some kind, it will stop the workflow run.
-11. **Exceptions:** Sometimes things go wrong.  When SmartFix cannot generate a fix for the vulnerability, it will log the reason why, try to clean up the Github feature branches that have been made for that vulnerability, and exit the workflow early.
+11. **Exceptions:** Sometimes things go wrong.  When SmartFix cannot generate a fix for the vulnerability, it will log the reason why, try to clean up the GitHub feature branches that have been made for that vulnerability, and exit the workflow early.
 12. **Guardrails:** SmartFix has several configurable and internal guardrails:
    * *Time limit* - SmartFix has an internal time limit of 3 hours.  If it goes over 3 hours of processing time, it will not request another vulnerability to resolve.
    * `max_open_prs` - SmartFix offers this configurable value to control the maximum number concurrently open SmartFix PRs.
@@ -166,7 +166,7 @@ The following are key inputs for the SmartFix GitHub Action using the GitHub Cop
 | `contrast_app_id` | Contrast Application ID for the repository. Omit for NorthStar-only (SAST-only) organizations. | No |  |
 | `contrast_authorization_key` | Contrast Authorization Key. | Yes |  |
 | `contrast_api_key` | Contrast API Key. | Yes |  |
-| `coding_agent` | Specify that SmartFix should use Github Copilot as the coding agent. | Yes | `GITHUB_COPILOT` |
+| `coding_agent` | Specify that SmartFix should use GitHub Copilot as the coding agent. | Yes | `GITHUB_COPILOT` |
 | `max_open_prs` | Maximum number of open PRs SmartFix can create. | No | `5` |
 | `debug_mode` | Enable verbose logging. | No | `false` |
 | `enable_full_telemetry` | Control how much telemetry data is sent back to Contrast. When set to 'true' (default), sends complete log files and build commands. When 'false', sensitive build commands and full logs are omitted. | No | `true` |

--- a/docs/smartfix-setup-agent-prompt.md
+++ b/docs/smartfix-setup-agent-prompt.md
@@ -338,7 +338,7 @@ If you haven't added a Contrast Agent to your application, you're likely SAST-on
 2. SAST-only / NorthStar
 ```
 
-Store: `DEPLOYMENT_TYPE = "iast"` or `"sast_only"`
+Store: `DEPLOYMENT_TYPE = "iast"` or `DEPLOYMENT_TYPE = "sast_only"`
 
 ---
 

--- a/docs/smartfix-setup-agent-prompt.md
+++ b/docs/smartfix-setup-agent-prompt.md
@@ -311,13 +311,44 @@ Let's continue with the setup - you can always adjust the build command later.
 
 ## PHASE 3: Gather Contrast Information
 
-### Get Application URL
+### Determine Deployment Type (IAST or SAST-only)
 
-This is the key simplification - get host, org ID, and app ID from ONE URL.
+Before requesting a URL, ask whether the organization uses IAST or SAST-only:
 
 ```
-Now I need to connect SmartFix to your Contrast Security account.
+Before I connect SmartFix to your Contrast account, one quick question:
 
+Does your Contrast organization use **IAST** (Contrast Assess — runtime vulnerability detection via the Contrast Agent) or **SAST-only** (NorthStar — static analysis only, no agent instrumentation)?
+
+1. IAST / Contrast Assess — our apps are instrumented with the Contrast Agent
+2. SAST-only / NorthStar — we use Contrast's static analysis only (no agent instrumentation)
+3. I'm not sure
+```
+
+**If option 3 (not sure):** Explain briefly:
+```
+No problem! Here's the difference:
+
+- **IAST (Contrast Assess)**: The Contrast Agent runs inside your application and detects vulnerabilities at runtime. You'd have installed an agent library in your app.
+- **SAST-only (NorthStar)**: Contrast scans your source code statically without any agent.
+
+If you haven't added a Contrast Agent to your application, you're likely SAST-only. Which best describes your setup?
+
+1. IAST / Contrast Assess
+2. SAST-only / NorthStar
+```
+
+Store: `DEPLOYMENT_TYPE = "iast"` or `"sast_only"`
+
+---
+
+### Get Application URL (IAST only — skip for SAST-only)
+
+**If DEPLOYMENT_TYPE == "sast_only"**: skip to "Get Host and Org ID" below.
+
+**If DEPLOYMENT_TYPE == "iast"**: use the URL approach — get host, org ID, and app ID from ONE URL.
+
+```
 Please open Contrast Security in your browser and navigate to the application you want SmartFix to fix vulnerabilities for. Then paste the URL here.
 
 It will look something like:
@@ -346,7 +377,7 @@ Extracts to:
 - org_id: `12345678-1234-1234-1234-123456789abc`
 - app_id: `87654321-4321-4321-4321-cba987654321`
 
-### Confirm Extracted Values
+### Confirm Extracted Values (IAST)
 
 ```
 I found these details from your URL:
@@ -366,6 +397,42 @@ If the URL doesn't match the expected pattern, ask the user to:
 1. Make sure they're on the application page in Contrast
 2. Try copying the URL from the browser address bar
 3. Or select option 3 to manually provide the three values
+
+---
+
+### Get Host and Org ID (SAST-only)
+
+**If DEPLOYMENT_TYPE == "sast_only"**: ask for just the host and org ID.
+
+```
+Please open Contrast Security in your browser and navigate to your organization's overview or dashboard page, then paste the URL here.
+
+It will look something like:
+https://app.contrastsecurity.com/Contrast/static/ng/index.html#/xxxxx/...
+
+(No application page needed — SmartFix will operate in SAST-only mode without an Application ID.)
+```
+
+Extract from the URL:
+- **host**: Everything between `https://` and `/Contrast`
+- **org_id**: The UUID immediately after `#/`
+
+Store: `APP_ID = null` (no application ID for SAST-only)
+
+```
+I found these details from your URL:
+
+🌐 **Contrast Host:** app.contrastsecurity.com
+🏢 **Organization ID:** 12345678-1234-1234-1234-123456789abc
+
+SmartFix will run in **SAST-only mode** — it will fix static findings from NorthStar without requiring an Application ID.
+
+Does this look correct?
+
+1. Yes, that's correct
+2. No, let me paste the URL again
+3. I'd rather enter these values manually
+```
 
 ---
 
@@ -706,7 +773,9 @@ permissions:
 
 env:
   # Contrast Application ID - extracted from your Contrast URL
-  CONTRAST_APP_ID: '{EXTRACTED_APP_ID}'
+  # IAST organizations: set this to the app UUID extracted from the Contrast URL
+  # SAST-only (NorthStar) organizations: omit this variable entirely
+  {IF_IAST}CONTRAST_APP_ID: '{EXTRACTED_APP_ID}'
 
   # Build configuration - detected from your project
   BUILD_COMMAND: '{DETECTED_BUILD_COMMAND}'
@@ -732,7 +801,7 @@ jobs:
           # Contrast connection (uses secrets/variables you'll configure next)
           contrast_host: ${{ vars.CONTRAST_HOST }}
           contrast_org_id: ${{ vars.CONTRAST_ORG_ID }}
-          contrast_app_id: ${{ env.CONTRAST_APP_ID }}
+          {IF_IAST}contrast_app_id: ${{ env.CONTRAST_APP_ID }}  # Omit this line for SAST-only organizations
           contrast_authorization_key: ${{ secrets.CONTRAST_AUTHORIZATION_KEY }}
           contrast_api_key: ${{ secrets.CONTRAST_API_KEY }}
 
@@ -763,7 +832,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           contrast_host: ${{ vars.CONTRAST_HOST }}
           contrast_org_id: ${{ vars.CONTRAST_ORG_ID }}
-          contrast_app_id: ${{ env.CONTRAST_APP_ID }}
+          {IF_IAST}contrast_app_id: ${{ env.CONTRAST_APP_ID }}  # Omit this line for SAST-only organizations
           contrast_authorization_key: ${{ secrets.CONTRAST_AUTHORIZATION_KEY }}
           contrast_api_key: ${{ secrets.CONTRAST_API_KEY }}
         env:
@@ -785,7 +854,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           contrast_host: ${{ vars.CONTRAST_HOST }}
           contrast_org_id: ${{ vars.CONTRAST_ORG_ID }}
-          contrast_app_id: ${{ env.CONTRAST_APP_ID }}
+          {IF_IAST}contrast_app_id: ${{ env.CONTRAST_APP_ID }}  # Omit this line for SAST-only organizations
           contrast_authorization_key: ${{ secrets.CONTRAST_AUTHORIZATION_KEY }}
           contrast_api_key: ${{ secrets.CONTRAST_API_KEY }}
         env:
@@ -1334,7 +1403,7 @@ Try running the workflow again after re-adding the secrets.
 This means SmartFix can't find the application. Let's verify:
 
 1. Open the workflow file: .github/workflows/smartfix.yml
-2. Check the CONTRAST_APP_ID value
+2. Check the CONTRAST_APP_ID value (IAST organizations only — SAST-only orgs don't use this)
 3. Compare it to the URL in Contrast for your application
 
 The app ID should be the UUID that appears after "/applications/" in your Contrast URL.
@@ -1403,7 +1472,8 @@ Here's a summary of what we configured:
 📁 **Workflow file:** .github/workflows/smartfix.yml
 🔗 **Contrast Host:** {HOST}
 🏢 **Organization:** {ORG_ID}
-📱 **Application:** {APP_ID}
+{IF_IAST}📱 **Application:** {APP_ID}
+{IF_SAST_ONLY}🔍 **Mode:** SAST-only (NorthStar) — no Application ID required
 🏗️ **Build Command:** {BUILD_COMMAND}
 {IF_FORMAT}✨ **Formatting:** {FORMAT_COMMAND}
 
@@ -1416,7 +1486,7 @@ Here's a summary of what we configured:
 **Need to make changes later?**
 - Build command: Edit BUILD_COMMAND in .github/workflows/smartfix.yml
 - Schedule: Edit the cron value in the same file
-- Different application: Update CONTRAST_APP_ID value
+- Different application: Update CONTRAST_APP_ID value (IAST only; remove it entirely for SAST-only mode)
 
 **Documentation:** https://github.com/Contrast-Security-OSS/contrast-ai-smartfix-action
 

--- a/docs/smartfix_coding_agent.md
+++ b/docs/smartfix_coding_agent.md
@@ -132,9 +132,9 @@ jobs:
 
 **Important:**
 
-* Store all sensitive values (API keys, tokens) as GitHub Secrets in your repository or Github organization settings.
+* Store all sensitive values (API keys, tokens) as GitHub Secrets in your repository or GitHub organization settings.
 * Replace `v1` with the specific version of the SmartFix GitHub Action you intend to use.
-* The `build_command` configured for the `generate_fixes` job must be an appropriate build command for your project and is required for the proper functioning of SmartFix.  A `build_command` that runs your project's unit tests would be doubly useful as it would enable SmartFix to attempt to correct any changes that break your project's tests.  Please remember to do any additional setup for your `build_command` (such as library installation) in the `generate_fixes` job as a new step preceeding the `Run Contrast AI SmartFix - Generate Fixes Action` step.  For details about the libraries that come pre-installed with Github's Ubuntu runner, please visit https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md.  For details about GitHub's Windows runner, please visit https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md.
+* The `build_command` configured for the `generate_fixes` job must be an appropriate build command for your project and is required for the proper functioning of SmartFix.  A `build_command` that runs your project's unit tests would be doubly useful as it would enable SmartFix to attempt to correct any changes that break your project's tests.  Please remember to do any additional setup for your `build_command` (such as library installation) in the `generate_fixes` job as a new step preceeding the `Run Contrast AI SmartFix - Generate Fixes Action` step.  For details about the libraries that come pre-installed with GitHub's Ubuntu runner, please visit https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md.  For details about GitHub's Windows runner, please visit https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md.
 * The optional `formatting_command` will be run after SmartFix makes code changes to resolve the vulnerability and prior to any subsequent `build_command` invocations.  We recommend supplying a `formatting_command` to fix code style issues in your project as it is an easy way to correct a common class of build-breaking problems.
 
 ### LLM Configuration for the SmartFix Coding Agent
@@ -241,7 +241,7 @@ SmartFix focuses on remediating:
    * If SmartFix sees that it has reached the configured `max_open_prs` number of concurrently open SmartFix PRs, it will end its workflow run.
    * If SmartFix has reached its internal time limit of 3 hours of processing time for some reason, it will stop the workflow run instead of requesting a new vulnerability to resolve.
    * If SmartFix encounters an exception of some kind, it will stop the workflow run.
-11. **Exceptions:** Sometimes things go wrong.  When SmartFix cannot generate a fix for the vulnerability, it will log the reason why, try to clean up the Github feature branches that have been made for that vulnerability, and exit the workflow early.
+11. **Exceptions:** Sometimes things go wrong.  When SmartFix cannot generate a fix for the vulnerability, it will log the reason why, try to clean up the GitHub feature branches that have been made for that vulnerability, and exit the workflow early.
 12. **Guardrails:** SmartFix has several configurable and internal guardrails:
    * *Time limit* - SmartFix has an internal time limit of 3 hours.  If it goes over 3 hours of processing time, it will not request another vulnerability to resolve.
    * `max_open_prs` - SmartFix offers this configurable value to control the maximum number concurrently open SmartFix PRs

--- a/docs/smartfix_coding_agent.md
+++ b/docs/smartfix_coding_agent.md
@@ -14,9 +14,9 @@ The SmartFix Coding Agent uses Contrast vulnerability data with a team of agenti
 
 ### Prerequisites
 
-* **Contrast Assess:** You need an active Contrast Assess deployment identifying vulnerabilities in your application.
+* **Contrast Security:** You need an active Contrast deployment identifying vulnerabilities in your application — either Contrast Assess (IAST) for runtime findings, or NorthStar (SAST) for static-only organizations.
 * **GitHub:** Your project must be hosted on GitHub and use GitHub Actions.  In the GitHub repository's Settings, enable the Actions > General > Workflow Permissions checkbox for "Allow GitHub Actions to create and approve pull requests".
-* **Contrast API Credentials:** You will need your Contrast Host, Organization ID, Application ID, Authorization Key, and API Key values.  To find the app ID, visit the application page in the Contrast web UI, then use the last UUID in the URL (immediately after `/applications/`) as the app ID value.  **Suggestion:** Setup an API-only service user named “Contrast AI SmartFix” in your Organization Settings in your Contrast SaaS instance.  At a minimum, it should have the “View Organization” permission and “Edit Application” permission for this application.  This service user’s `contrast_authorization_key` value and the Organization’s `contrast_api_key` value should be used in the workflow.
+* **Contrast API Credentials:** You will need your Contrast Host, Organization ID, Authorization Key, and API Key values.  For repositories with IAST findings, also provide your Application ID — visit the application page in the Contrast web UI and use the last UUID in the URL (immediately after `/applications/`).  Omit the Application ID for NorthStar-only (SAST-only) organizations; SmartFix will run in SAST-only mode.  **Suggestion:** Setup an API-only service user named “Contrast AI SmartFix” in your Organization Settings in your Contrast SaaS instance.  At a minimum, it should have the “View Organization” permission and “Edit Application” permission for this application.  This service user’s `contrast_authorization_key` value and the Organization’s `contrast_api_key` value should be used in the workflow.
 * **GitHub Token Permissions:** The GitHub token must have `contents: write` and `pull-requests: write` permissions. These permissions must be explicitly set in your workflow file, as they are in the example config file, below.  Note, the SmartFix Coding Agent uses the internal GitHub token for Actions; you do not need to create a Personal Access Token (PAT).
 * **LLM Access (Optional):** SmartFix uses Contrast's LLM service for seamless setup. If you prefer to use your own LLM provider (BYOLLM), ensure that you have API access to one of our recommended LLMs. If using an AWS Bedrock model, please see Amazon's User Guide on [model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 
@@ -30,7 +30,7 @@ Secrets:
 Variables:
 * CONTRAST_HOST (The host name of your Contrast SaaS instance, e.g. 'app.contrastsecurity.com')
 * CONTRAST_ORG_ID (The UUID of your Contrast organization)
-* CONTRAST_APP_ID (The UUID that is specific to the application in this repository.)
+* CONTRAST_APP_ID (The UUID that is specific to the application in this repository. Omit for NorthStar-only/SAST-only organizations.)
 * Any other non-secret values, such as the AWS region for a Bedrock-provided LLM - only needed if using BYOLLM
 
 ### Installation and Configuration
@@ -97,7 +97,7 @@ jobs:
           # Contrast Configuration
           contrast_host: ${{ vars.CONTRAST_HOST }} # The host name of your Contrast SaaS instance, e.g. 'app.contrastsecurity.com'
           contrast_org_id: ${{ vars.CONTRAST_ORG_ID }} # The UUID of your Contrast organization
-          contrast_app_id: ${{ vars.CONTRAST_APP_ID }} # The UUID that is specific to the application in this repository.
+          contrast_app_id: ${{ vars.CONTRAST_APP_ID }} # Optional: omit for NorthStar-only (SAST-only) organizations
           contrast_authorization_key: ${{ secrets.CONTRAST_AUTHORIZATION_KEY }}
           contrast_api_key: ${{ secrets.CONTRAST_API_KEY }}
 
@@ -215,7 +215,7 @@ Note: the SmartFix action's setup steps rely on the bash shell.  Please ensure t
 
 SmartFix focuses on remediating:
 
-* **CRITICAL** and **HIGH** severity vulnerabilities identified by Contrast Assess.
+* **CRITICAL** and **HIGH** severity vulnerabilities identified by Contrast, including IAST findings from Contrast Assess and static SAST findings from NorthStar.
 * **Exclusions:**
   * Cross-Site Request Forgery (CSRF) is currently excluded due to the complexity of fixes often requiring API changes.
   * Other specific vulnerability types may be excluded based on ongoing testing by Contrast Labs.
@@ -258,7 +258,7 @@ The following are key inputs for the SmartFix GitHub Action using SmartFix Codin
 | `base_branch` | Base branch for PRs. | No | `${{ github.event.repository.default_branch }}` |
 | `contrast_host` | Contrast Security API host. | Yes |  |
 | `contrast_org_id` | Contrast Organization ID. | Yes |  |
-| `contrast_app_id` | Contrast Application ID for the repository. | Yes |  |
+| `contrast_app_id` | Contrast Application ID for the repository. Omit for NorthStar-only (SAST-only) organizations. | No |  |
 | `contrast_authorization_key` | Contrast Authorization Key. | Yes |  |
 | `contrast_api_key` | Contrast API Key. | Yes |  |
 | `use_contrast_llm` | Use Contrast LLM service. Set to 'false' to use your own LLM provider. | No | `true` |
@@ -365,7 +365,7 @@ SmartFix collects telemetry data to help improve the service and diagnose issues
   * Ensure the `github_token` has the necessary permissions to create PRs in the repository.
   * Check for branch protection rules that might prevent PR creation.
 * **No Fixes Generated:**
-  * Confirm there are eligible CRITICAL or HIGH severity vulnerabilities in Contrast Assess for the configured `contrast_app_id`. SmartFix only attempts to fix vulnerabilities that are in the REPORTED state.
+  * Confirm there are eligible CRITICAL or HIGH severity vulnerabilities in Contrast. For Contrast Assess (IAST) deployments, check under the configured `contrast_app_id`. For NorthStar-only (SAST-only) deployments — where `contrast_app_id` is intentionally omitted — confirm there are eligible SAST findings in your Contrast organization. SmartFix only attempts to fix vulnerabilities that are in the REPORTED state.
   * Check the `max_open_prs` limit; if the number of PRs SmartFix has created that are still open matches this limit, no new PRs will be created.
   * Review the GitHub Action logs for messages indicating why vulnerabilities might have been skipped.
 * **Incorrect Fixes:** The AI-generated fixes should **always** be reviewed carefully. If a fix is incorrect or incomplete:
@@ -382,7 +382,7 @@ SmartFix collects telemetry data to help improve the service and diagnose issues
 ## FAQ
 
 * **Q: Can I use SmartFix if I don't use Contrast Assess?**
-  * A: No, SmartFix relies on vulnerability data from Contrast Assess. In the future we plan to expand to include more.
+  * A: Yes, if your organization uses static analysis (NorthStar/SAST), SmartFix can operate in SAST-only mode. Simply omit `contrast_app_id` and `contrast_app_ids` from your workflow configuration. SmartFix still requires a Contrast account and organization.
 * **Q: Do I need to specify `build_command`?**
   * A: Usually no! SmartFix automatically detects build commands for common build systems (Maven, Gradle, npm, pytest, .NET, PHP, etc.). If auto-detection doesn't work for your project, you can manually specify `build_command`.
 * **Q: How often does SmartFix run?**


### PR DESCRIPTION
## Summary

- Updates all SmartFix user-facing docs to make clear that `contrast_app_id` is optional and that SmartFix supports NorthStar-only (SAST-only) organizations out of the box
- Fixes the false FAQ answer ("No, SmartFix requires Contrast Assess") across README and all three agent docs
- Updates the setup wizard prompt to ask IAST vs SAST-only up front and skip app ID collection for SAST-only organizations

## Files changed

- **`README.md`** — broadened "Contrast Assess" references to "Contrast Security"; replaced IAST-only "Runtime Context" bullet with "Vulnerability Context"; fixed FAQ
- **`docs/claude_code.md`**, **`docs/github_copilot.md`**, **`docs/smartfix_coding_agent.md`** — parallel changes to all three: prerequisites, credentials note, CONTRAST_APP_ID variable description, workflow YAML comment, Important bullet, Supported Vulnerabilities, input table Required column, Troubleshooting "No Fixes Generated", FAQ
- **`docs/contrast_llm_early_access.md`** — added SAST-only comment to `contrast_app_id` lines in both YAML examples; marked `contrast_app_id` optional in the parameters list
- **`docs/smartfix-setup-agent-prompt.md`** — Phase 3 now asks IAST vs SAST-only before requesting any URL; SAST-only path skips app ID entirely; Phase 5 template gates `CONTRAST_APP_ID` and `contrast_app_id` on `{IF_IAST}`; Phase 7 troubleshooting notes CONTRAST_APP_ID is IAST-only; Phase 8 wrap-up conditionally shows Application vs SAST-only mode line

## Test plan

- [ ] Review README intro and FAQ — should no longer say IAST is required
- [ ] Review each agent doc's prerequisites, input table, Important bullet, and FAQ for consistency
- [ ] Review `contrast_llm_early_access.md` YAML snippets — `contrast_app_id` should have the "Optional" comment
- [ ] Review `smartfix-setup-agent-prompt.md` Phase 3 dialog scripts for IAST vs SAST-only branching logic
- [ ] Verify no remaining bare "Contrast Assess is required" language anywhere in docs/

Jira: https://contrast.atlassian.net/browse/AIML-1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)