### PR TITLE
AIML-999: send repoUrl on /open reconciliation

### DIFF
--- a/src/contrast_api.py
+++ b/src/contrast_api.py
@@ -60,7 +60,8 @@ def get_sanitized_409_message(response_text: str) -> tuple[str, bool]:
 
 
 def get_org_open_remediations(contrast_host: str, contrast_org_id: str, app_ids: list,
-                              contrast_auth_key: str, contrast_api_key: str) -> list:
+                              contrast_auth_key: str, contrast_api_key: str,
+                              github_repo_url: str) -> list:
     """Returns open remediations across multiple apps from the org-level endpoint.
 
     Best-effort: returns [] on any error. Must not block main flow.
@@ -71,6 +72,9 @@ def get_org_open_remediations(contrast_host: str, contrast_org_id: str, app_ids:
         app_ids: List of application IDs to query
         contrast_auth_key: The Contrast authorization key
         contrast_api_key: The Contrast API key
+        github_repo_url: The GitHub repository URL. Scopes reconciliation to this
+            repository for SAST-only (no app IDs) runs so the caller only receives
+            its own repo's open remediations, avoiding cross-repo PR-number collisions.
 
     Returns:
         list: List of open remediation dicts, or empty list on error
@@ -86,7 +90,7 @@ def get_org_open_remediations(contrast_host: str, contrast_org_id: str, app_ids:
         "User-Agent": config.USER_AGENT
     }
 
-    payload = {"appIds": app_ids or None}
+    payload = {"appIds": app_ids or None, "repoUrl": github_repo_url}
 
     try:
         debug_log(f"Fetching org-level open remediations from: {api_url}")

--- a/src/smartfix/domains/workflow/pr_reconciliation.py
+++ b/src/smartfix/domains/workflow/pr_reconciliation.py
@@ -17,6 +17,8 @@
 # #L%
 #
 
+from urllib.parse import urlparse
+
 from src import contrast_api
 from src.utils import debug_log, log
 
@@ -27,6 +29,12 @@ def reconcile_open_remediations(config, github_ops):
     Calls the appropriate backend transition for any that have drifted.
     Best-effort: logs warnings on failure, never raises, never exits.
     """
+    # Same repo URL the remediation-details/prompt-details calls send, so the backend scopes
+    # reconciliation to this repository. Without it, SAST-only (no app IDs) runs would receive
+    # the org-wide open-remediation list and could reconcile another repo's same-numbered PR.
+    github_host = urlparse(config.GITHUB_SERVER_URL).netloc
+    github_repo_url = f"{github_host}/{config.GITHUB_REPOSITORY}"
+
     try:
         open_remediations = contrast_api.get_org_open_remediations(
             contrast_host=config.CONTRAST_HOST,
@@ -34,6 +42,7 @@ def reconcile_open_remediations(config, github_ops):
             app_ids=config.CONTRAST_APP_IDS,
             contrast_auth_key=config.CONTRAST_AUTHORIZATION_KEY,
             contrast_api_key=config.CONTRAST_API_KEY,
+            github_repo_url=github_repo_url,
         )
     except Exception as e:
         log(f"Error fetching open remediations: {e}", is_warning=True)

--- a/test/contrast_api/test_contrast_api_org_endpoints.py
+++ b/test/contrast_api/test_contrast_api_org_endpoints.py
@@ -62,6 +62,7 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
             app_ids=APP_IDS,
             contrast_auth_key=AUTH_KEY,
             contrast_api_key=API_KEY,
+            github_repo_url='https://github.com/org/repo',
         )
         return contrast_api.get_org_open_remediations(**{**defaults, **overrides})
 
@@ -88,6 +89,22 @@ class TestGetOrgOpenRemediations(unittest.TestCase):
         self._call()
         payload = mock_post.call_args[1]['json']
         self.assertEqual(payload['appIds'], APP_IDS)
+
+    @patch('src.contrast_api.requests.post')
+    def test_sends_repo_url_in_body(self, mock_post):
+        mock_post.return_value = make_sample_response(200, body=[])
+        self._call(github_repo_url='github.com/org/repo')
+        payload = mock_post.call_args[1]['json']
+        self.assertEqual(payload['repoUrl'], 'github.com/org/repo')
+
+    @patch('src.contrast_api.requests.post')
+    def test_sast_only_sends_null_app_ids_with_repo_url(self, mock_post):
+        """SAST-only runs send no app IDs but still scope by repo URL."""
+        mock_post.return_value = make_sample_response(200, body=[])
+        self._call(app_ids=[], github_repo_url='github.com/org/repo')
+        payload = mock_post.call_args[1]['json']
+        self.assertIsNone(payload['appIds'])
+        self.assertEqual(payload['repoUrl'], 'github.com/org/repo')
 
     @patch('src.contrast_api.requests.post')
     def test_returns_empty_list_on_non_200(self, mock_post):

--- a/test/test_reconcile_open_remediations.py
+++ b/test/test_reconcile_open_remediations.py
@@ -18,6 +18,8 @@ class TestReconcileOpenRemediations(unittest.TestCase):
             CONTRAST_APP_IDS=['test-app-id'],
             CONTRAST_AUTHORIZATION_KEY='test-auth-key',
             CONTRAST_API_KEY='test-api-key',
+            GITHUB_SERVER_URL='https://github.com',
+            GITHUB_REPOSITORY='test-org/test-repo',
         )
         self.mock_github_ops = Mock(spec=GitHubOperations)
 
@@ -151,8 +153,8 @@ class TestReconcileOpenRemediations(unittest.TestCase):
         mock_contrast_api.notify_remediation_pr_closed_org.assert_called_once()
 
     @patch('src.smartfix.domains.workflow.pr_reconciliation.contrast_api')
-    def test_get_org_open_remediations_called_with_app_ids(self, mock_contrast_api):
-        """Test that get_org_open_remediations is called with app_ids from config."""
+    def test_get_org_open_remediations_called_with_app_ids_and_repo_url(self, mock_contrast_api):
+        """Test that get_org_open_remediations is called with app_ids and the repo URL."""
         mock_contrast_api.get_org_open_remediations.return_value = []
 
         reconcile_open_remediations(self.mock_config, self.mock_github_ops)
@@ -163,6 +165,7 @@ class TestReconcileOpenRemediations(unittest.TestCase):
             app_ids=['test-app-id'],
             contrast_auth_key='test-auth-key',
             contrast_api_key='test-api-key',
+            github_repo_url='github.com/test-org/test-repo',
         )
 
 


### PR DESCRIPTION
## Summary

Reconciliation of open remediations fetched the org-level `/open` list without a `repoUrl`. For SAST-only runs (no app IDs configured) the backend returned the org-wide list, and because GitHub PR numbers are per-repo and collide across repos, `reconcile_open_remediations` could look up an unrelated same-numbered PR in the current repo and falsely mark another repo's remediation **merged** or **closed**. The merged case is the worst — a NORTHSTAR_ONLY remediation going to merged triggers NorthStar writeback (closes the finding and comments it as remediated), so a genuinely open vulnerability could be marked fixed.

This sends `repoUrl` on the `/open` call so the backend can scope the returned remediations to the current repository.

## Changes

- `get_org_open_remediations` now takes and sends `repoUrl`, built the same way as the existing `remediation-details` / `prompt-details` calls (`GITHUB_SERVER_URL` netloc + `GITHUB_REPOSITORY`).
- `reconcile_open_remediations` computes that URL and passes it through.
- Tests updated: reconcile call assertion includes the repo URL, and new `/open` payload tests cover `repoUrl` and the SAST-only (null appIds + repoUrl) case.

## Backend dependency

Pairs with aiml-services PR #282, which adds `repoUrl` to the `/open` request, resolves it to a repositoryId, and scopes the query per repository. Both sides are independently backward compatible — until the backend honors `repoUrl` it is ignored, and until the action sends it the backend falls back — so the cross-repo hole is only fully closed once both land.

## Testing

- `make test` — 1010 passed
- `flake8` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)